### PR TITLE
Preregister extended scalar types

### DIFF
--- a/src/Core/Schema.Factory.cs
+++ b/src/Core/Schema.Factory.cs
@@ -138,19 +138,31 @@ namespace HotChocolate
         {
             SchemaContext context = new SchemaContext(new ServiceManager());
 
-            // register speced scalar types
+            RegisterSpecScalarTypes(context);
+            RegisterExtendedScalarTypes(context);
+            RegisterIntrospectionTypes(context);
+
+            return context;
+        }
+
+        private static void RegisterSpecScalarTypes(SchemaContext context)
+        {
             context.Types.RegisterType(new TypeReference(typeof(StringType)));
             context.Types.RegisterType(new TypeReference(typeof(IdType)));
             context.Types.RegisterType(new TypeReference(typeof(BooleanType)));
             context.Types.RegisterType(new TypeReference(typeof(IntType)));
             context.Types.RegisterType(new TypeReference(typeof(FloatType)));
+        }
 
-            // register extended scalar types
+        private static void RegisterExtendedScalarTypes(SchemaContext context)
+        {
             context.Types.RegisterType(new TypeReference(typeof(DecimalType)));
             context.Types.RegisterType(new TypeReference(typeof(DateTimeType)));
             context.Types.RegisterType(new TypeReference(typeof(DateType)));
+        }
 
-            // register introspection types
+        private static void RegisterIntrospectionTypes(SchemaContext context)
+        {
             context.Types.RegisterType(new TypeReference(typeof(__Directive)));
             context.Types.RegisterType(new TypeReference(typeof(__DirectiveLocation)));
             context.Types.RegisterType(new TypeReference(typeof(__EnumValue)));
@@ -159,8 +171,6 @@ namespace HotChocolate
             context.Types.RegisterType(new TypeReference(typeof(__Schema)));
             context.Types.RegisterType(new TypeReference(typeof(__Type)));
             context.Types.RegisterType(new TypeReference(typeof(__TypeKind)));
-
-            return context;
         }
     }
 }

--- a/src/Core/Schema.Factory.cs
+++ b/src/Core/Schema.Factory.cs
@@ -138,11 +138,17 @@ namespace HotChocolate
         {
             SchemaContext context = new SchemaContext(new ServiceManager());
 
-            // create context with system types
+            // register speced scalar types
             context.Types.RegisterType(new TypeReference(typeof(StringType)));
+            context.Types.RegisterType(new TypeReference(typeof(IdType)));
             context.Types.RegisterType(new TypeReference(typeof(BooleanType)));
             context.Types.RegisterType(new TypeReference(typeof(IntType)));
             context.Types.RegisterType(new TypeReference(typeof(FloatType)));
+
+            // register extended scalar types
+            context.Types.RegisterType(new TypeReference(typeof(DecimalType)));
+            context.Types.RegisterType(new TypeReference(typeof(DateTimeType)));
+            context.Types.RegisterType(new TypeReference(typeof(DateType)));
 
             // register introspection types
             context.Types.RegisterType(new TypeReference(typeof(__Directive)));


### PR DESCRIPTION
The extended scalar types like decimal or date-time are now preregistered and do not have to be registered by a schema developer. We found that this is more convenient that to always having to register those when they are needed. We will introduce an UnRegisterType<DateTimeType>() functionality on the schema configuration with some later releases so that a schema dev is able to get rid of those extended scalar types and register his or her own take on a date-time scalar.