### PR TITLE
Fixed: Enums do not deserialise correctly

### DIFF
--- a/src/AspNetCore.Tests/Schema/Foo.cs
+++ b/src/AspNetCore.Tests/Schema/Foo.cs
@@ -6,4 +6,9 @@ namespace HotChocolate.AspNetCore
         public string B { get; set; }
         public int C { get; set; }
     }
+
+    public class Bar
+    {
+        public TestEnum A { get; set; }
+    }
 }

--- a/src/AspNetCore.Tests/Schema/Query.cs
+++ b/src/AspNetCore.Tests/Schema/Query.cs
@@ -71,5 +71,10 @@ namespace HotChocolate.AspNetCore
         {
             return true;
         }
+
+        public TestEnum GetWithNestedEnum(Bar bar)
+        {
+            return bar.A;
+        }
     }
 }

--- a/src/AspNetCore.Tests/__snapshots__/HttpPost_NestedEnumArgument.json
+++ b/src/AspNetCore.Tests/__snapshots__/HttpPost_NestedEnumArgument.json
@@ -1,0 +1,6 @@
+{
+  "Data": {
+    "withNestedEnum": "B"
+  },
+  "Errors": null
+}

--- a/src/Types/Types/EnumType.cs
+++ b/src/Types/Types/EnumType.cs
@@ -87,6 +87,13 @@ namespace HotChocolate.Types
                 return ev.Value;
             }
 
+            // TODO : This fixes a deserialisation issue when an input object is deserialized from a json string. We should however fix this in the aspnet middleware.
+            if (literal is StringValueNode svn
+                && _nameToValues.TryGetValue(svn.Value, out ev))
+            {
+                return ev.Value;
+            }
+
             if (literal is NullValueNode)
             {
                 return null;


### PR DESCRIPTION
When we deserialise an input object from a json string we do not currently have a schema context. This causes an issue with enum values which are handled as string values.
This pr introduces a hot fix for the issue but we have to fix this issue in another pr in the middleware.