### PR TITLE
Fixed: Validation Rule marked __typename as invalid field for interfaces and unions

### DIFF
--- a/src/Core.Tests/Integration/StarWarsCodeFirst/StarWarsCodeFirstTests.cs
+++ b/src/Core.Tests/Integration/StarWarsCodeFirst/StarWarsCodeFirstTests.cs
@@ -523,6 +523,46 @@ namespace HotChocolate.Integration.StarWarsCodeFirst
             Assert.Equal(Snapshot.Current(), Snapshot.New(result));
         }
 
+        [Fact]
+        public void IntrospectionPropertiesAreExecuted()
+        {
+            // arrange
+            Schema schema = CreateSchema();
+            string query = @"
+            query foo {
+                hero(episode: NEWHOPE) {
+                    __typename
+                    id
+                    name
+                    ... on Human {
+                        __typename
+                        homePlanet
+                    }
+                    ... on Droid {
+                        __typename
+                        primaryFunction
+                    }
+                    friends {
+                        __typename
+                        ... on Human {
+                            __typename
+                            homePlanet
+                        }
+                        ... on Droid {
+                            __typename
+                            primaryFunction
+                        }
+                    }
+                }
+            }";
+
+            // act
+            IExecutionResult result = schema.Execute(query);
+
+            // assert
+            Assert.Equal(Snapshot.Current(), Snapshot.New(result));
+        }
+
         private static Schema CreateSchema()
         {
             CharacterRepository repository = new CharacterRepository();

--- a/src/Core.Tests/Integration/StarWarsCodeFirst/StarWarsCodeFirstTests.cs
+++ b/src/Core.Tests/Integration/StarWarsCodeFirst/StarWarsCodeFirstTests.cs
@@ -524,7 +524,7 @@ namespace HotChocolate.Integration.StarWarsCodeFirst
         }
 
         [Fact]
-        public void IntrospectionPropertiesAreExecuted()
+        public void TypeNameFieldIsCorrectlyExecutedOnInterfaces()
         {
             // arrange
             Schema schema = CreateSchema();

--- a/src/Core.Tests/__snapshots__/TypeNameFieldIsCorrectlyExecutedOnInterfaces.json
+++ b/src/Core.Tests/__snapshots__/TypeNameFieldIsCorrectlyExecutedOnInterfaces.json
@@ -1,0 +1,25 @@
+{
+  "Data": {
+    "hero": {
+      "__typename": "Droid",
+      "id": "2001",
+      "name": "R2-D2",
+      "primaryFunction": "Astromech",
+      "friends": [
+        {
+          "__typename": "Human",
+          "homePlanet": "Tatooine"
+        },
+        {
+          "__typename": "Human",
+          "homePlanet": null
+        },
+        {
+          "__typename": "Human",
+          "homePlanet": "Alderaan"
+        }
+      ]
+    }
+  },
+  "Errors": null
+}

--- a/src/Core/Validation/FieldMustBeDefinedVisitor.cs
+++ b/src/Core/Validation/FieldMustBeDefinedVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using HotChocolate.Utilities;
 using HotChocolate.Language;
 using HotChocolate.Types;
+using HotChocolate.Types.Introspection;
 
 namespace HotChocolate.Validation
 {
@@ -41,7 +42,7 @@ namespace HotChocolate.Validation
             ImmutableStack<ISyntaxNode> path)
         {
             if (type is IComplexOutputType ct
-                && !ct.Fields.ContainsField(field.Name.Value))
+                && !FieldExists(ct, field.Name.Value))
             {
                 Errors.Add(new ValidationError(
                     $"The field `{field.Name.Value}` does not exist " +
@@ -55,7 +56,21 @@ namespace HotChocolate.Validation
         {
             return selectionSet.Selections
                 .OfType<FieldNode>()
-                .All(t => t.Name.Value.EqualsOrdinal("__typename"));
+                .All(t => IsTypeNameField(t.Name.Value));
+        }
+
+        private bool FieldExists(IComplexOutputType type, string fieldName)
+        {
+            if (IsTypeNameField(fieldName))
+            {
+                return true;
+            }
+            return type.Fields.ContainsField(fieldName);
+        }
+
+        private static bool IsTypeNameField(string fieldName)
+        {
+            return fieldName.EqualsOrdinal(IntrospectionFields.TypeName);
         }
     }
 }

--- a/src/Core/Validation/FieldSelectionMergingVisitor.cs
+++ b/src/Core/Validation/FieldSelectionMergingVisitor.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using HotChocolate.Utilities;
 using HotChocolate.Language;
 using HotChocolate.Types;
+using HotChocolate.Types.Introspection;
 
 namespace HotChocolate.Validation
 {
@@ -49,14 +50,17 @@ namespace HotChocolate.Validation
             IType type,
             ImmutableStack<ISyntaxNode> path)
         {
-            if (TryGetSelectionSet(path, out SelectionSetNode selectionSet)
-                && _fieldSelectionSets.TryGetValue(selectionSet,
-                    out List<FieldInfo> fields))
+            if (!field.Name.Value.EqualsOrdinal(IntrospectionFields.TypeName))
             {
-                fields.Add(new FieldInfo(type, field));
-            }
+                if (TryGetSelectionSet(path, out SelectionSetNode selectionSet)
+                    && _fieldSelectionSets.TryGetValue(selectionSet,
+                        out List<FieldInfo> fields))
+                {
+                    fields.Add(new FieldInfo(type, field));
+                }
 
-            base.VisitField(field, type, path);
+                base.VisitField(field, type, path);
+            }
         }
 
         protected override void VisitSelectionSet(

--- a/src/Types/Types/Introspection/IntrospectionFields.cs
+++ b/src/Types/Types/Introspection/IntrospectionFields.cs
@@ -1,0 +1,9 @@
+namespace HotChocolate.Types.Introspection
+{
+    internal static class IntrospectionFields
+    {
+        public static string TypeName { get; } = "__typename";
+        public static string Schema { get; } = "__schema";
+        public static string Type { get; } = "__type";
+    }
+}

--- a/src/Types/Types/Introspection/__SchemaField.cs
+++ b/src/Types/Types/Introspection/__SchemaField.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Types.Introspection
         : ObjectField
     {
         internal __SchemaField()
-            : base("__schema", d =>
+            : base(IntrospectionFields.Schema, d =>
             {
                 d.Description("Access the current type schema of this server.")
                     .Type<NonNullType<__Schema>>()

--- a/src/Types/Types/Introspection/__TypeField.cs
+++ b/src/Types/Types/Introspection/__TypeField.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Types.Introspection
         : ObjectField
     {
         internal __TypeField()
-            : base("__type", d =>
+            : base(IntrospectionFields.Type, d =>
             {
                 d.Description("Request the type information of a single type.")
                     .Argument("type", a => a.Type<NonNullType<StringType>>())

--- a/src/Types/Types/Introspection/__TypeNameField.cs
+++ b/src/Types/Types/Introspection/__TypeNameField.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Types.Introspection
         : ObjectField
     {
         internal __TypeNameField()
-           : base("__typename", d =>
+           : base(IntrospectionFields.TypeName, d =>
            {
                d.Description("The name of the current Object type at runtime.")
                    .Type<NonNullType<StringType>>()

--- a/src/Validation.Tests/FieldMustBeDefinedRuleTests.cs
+++ b/src/Validation.Tests/FieldMustBeDefinedRuleTests.cs
@@ -127,5 +127,60 @@ namespace HotChocolate.Validation
                     "A union type cannot declare a field directly. " +
                     "Use inline fragments or fragments instead", t.Message));
         }
+
+
+        [Fact]
+        public void IntrospectionFieldsOnInterface()
+        {
+            // arrange
+            Schema schema = ValidationUtils.CreateSchema();
+            DocumentNode query = Parser.Default.Parse(@"
+                fragment interfaceFieldSelection on Pet {
+                    __typename
+                }
+            ");
+
+            // act
+            QueryValidationResult result = Rule.Validate(schema, query);
+
+            // assert
+            Assert.False(result.HasErrors);
+        }
+
+        [Fact]
+        public void IntrospectionFieldsOnUnion()
+        {
+            // arrange
+            Schema schema = ValidationUtils.CreateSchema();
+            DocumentNode query = Parser.Default.Parse(@"
+                fragment interfaceFieldSelection on CatOrDog {
+                    __typename
+                }
+            ");
+
+            // act
+            QueryValidationResult result = Rule.Validate(schema, query);
+
+            // assert
+            Assert.False(result.HasErrors);
+        }
+
+        [Fact]
+        public void IntrospectionFieldsOnObject()
+        {
+            // arrange
+            Schema schema = ValidationUtils.CreateSchema();
+            DocumentNode query = Parser.Default.Parse(@"
+                fragment interfaceFieldSelection on Cat {
+                    __typename
+                }
+            ");
+
+            // act
+            QueryValidationResult result = Rule.Validate(schema, query);
+
+            // assert
+            Assert.False(result.HasErrors);
+        }
     }
 }

--- a/src/Validation.Tests/FieldSelectionMergingRuleTests.cs
+++ b/src/Validation.Tests/FieldSelectionMergingRuleTests.cs
@@ -348,5 +348,62 @@ namespace HotChocolate.Validation
             // assert
             Assert.False(result.HasErrors);
         }
+
+        [Fact]
+        public void TypeNameFieldOnInterfaceIsMergable()
+        {
+            // arrange
+            Schema schema = ValidationUtils.CreateSchema();
+            DocumentNode query = Parser.Default.Parse(@"
+                fragment interfaceFieldSelection on Pet {
+                    __typename
+                    __typename
+                }
+            ");
+
+            // act
+            QueryValidationResult result = Rule.Validate(schema, query);
+
+            // assert
+            Assert.False(result.HasErrors);
+        }
+
+        [Fact]
+        public void TypeNameFieldOnUnionIsMergable()
+        {
+            // arrange
+            Schema schema = ValidationUtils.CreateSchema();
+            DocumentNode query = Parser.Default.Parse(@"
+                fragment interfaceFieldSelection on CatOrDog {
+                    __typename
+                    __typename
+                }
+            ");
+
+            // act
+            QueryValidationResult result = Rule.Validate(schema, query);
+
+            // assert
+            Assert.False(result.HasErrors);
+        }
+
+        [Fact]
+        public void TypeNameFieldOnObjectIsMergable()
+        {
+            // arrange
+            Schema schema = ValidationUtils.CreateSchema();
+            DocumentNode query = Parser.Default.Parse(@"
+                fragment interfaceFieldSelection on Cat {
+                    __typename
+                    __typename
+                }
+            ");
+
+            // act
+            QueryValidationResult result = Rule.Validate(schema, query);
+
+            // assert
+            Assert.False(result.HasErrors);
+        }
     }
 }


### PR DESCRIPTION
When __typename was defined on interfaces the validation rules would mark __typename as an invalid field and reject the query. We have now fixed the validation rules and added validation rule tests and an integration test on the Star Wars schema.