### PR TITLE
Add Field<TResolver> to the generic IObjectTypeDescriptor

### DIFF
--- a/src/Types/Types/Descriptors/IObjectTypeDescriptor.cs
+++ b/src/Types/Types/Descriptors/IObjectTypeDescriptor.cs
@@ -70,6 +70,17 @@ namespace HotChocolate.Types
         /// </param>
         IObjectFieldDescriptor Field(NameString name);
 
+        /// <summary>
+        /// Specifies an object type field which is bound to a resolver type.
+        /// </summary>
+        /// <param name="propertyOrMethod">
+        /// An expression selecting a property or method of
+        /// <typeparamref name="TResolver"/>.
+        /// The resolver type containing the property or method.
+        /// </param>
+        IObjectFieldDescriptor Field<TResolver>(
+            Expression<Func<TResolver, object>> propertyOrMethod);
+
         IObjectTypeDescriptor Directive<T>(T directive)
             where T : class;
 
@@ -155,17 +166,6 @@ namespace HotChocolate.Types
         /// </param>
         IObjectFieldDescriptor Field(
             Expression<Func<T, object>> propertyOrMethod);
-
-        /// <summary>
-        /// Specifies an object type field which is bound to a resolver type.
-        /// </summary>
-        /// <param name="propertyOrMethod">
-        /// An expression selecting a property or method of
-        /// <typeparamref name="TResolver"/>.
-        /// The resolver type containing the property or method.
-        /// </param>
-        IObjectFieldDescriptor Field<TResolver>(
-            Expression<Func<TResolver, object>> propertyOrMethod);
 
         new IObjectTypeDescriptor<T> Directive<TDirective>(TDirective directive)
             where TDirective : class;

--- a/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -138,6 +138,30 @@ namespace HotChocolate.Types
             return fieldDescriptor;
         }
 
+        protected ObjectFieldDescriptor Field<TResolver>(
+            Expression<Func<TResolver, object>> propertyOrMethod)
+        {
+            if (propertyOrMethod == null)
+            {
+                throw new ArgumentNullException(nameof(propertyOrMethod));
+            }
+
+            MemberInfo member = propertyOrMethod.ExtractMember();
+            if (member is PropertyInfo || member is MethodInfo)
+            {
+                ObjectFieldDescriptor fieldDescriptor =
+                    CreateResolverDescriptor(
+                        ObjectDescription.ClrType,
+                        typeof(TResolver), member);
+                Fields.Add(fieldDescriptor);
+                return fieldDescriptor;
+            }
+
+            throw new ArgumentException(
+                "A field of an entity can only be a property or a method.",
+                nameof(member));
+        }
+
         protected void AddResolverTypes(
             IDictionary<string, ObjectFieldDescription> fields)
         {
@@ -295,6 +319,12 @@ namespace HotChocolate.Types
             return Field(name);
         }
 
+        IObjectFieldDescriptor IObjectTypeDescriptor.Field<TResolver>(
+            Expression<Func<TResolver, object>> propertyOrMethod)
+        {
+            return Field(propertyOrMethod);
+        }
+
         IObjectTypeDescriptor IObjectTypeDescriptor.Directive<T>(T directive)
         {
             ObjectDescription.Directives.AddDirective(directive);
@@ -339,30 +369,6 @@ namespace HotChocolate.Types
         protected void BindFields(BindingBehavior bindingBehavior)
         {
             ObjectDescription.FieldBindingBehavior = bindingBehavior;
-        }
-
-        protected ObjectFieldDescriptor Field<TResolver>(
-           Expression<Func<TResolver, object>> propertyOrMethod)
-        {
-            if (propertyOrMethod == null)
-            {
-                throw new ArgumentNullException(nameof(propertyOrMethod));
-            }
-
-            MemberInfo member = propertyOrMethod.ExtractMember();
-            if (member is PropertyInfo || member is MethodInfo)
-            {
-                ObjectFieldDescriptor fieldDescriptor =
-                    CreateResolverDescriptor(
-                        ObjectDescription.ClrType,
-                        typeof(TResolver), member);
-                Fields.Add(fieldDescriptor);
-                return fieldDescriptor;
-            }
-
-            throw new ArgumentException(
-                "A field of an entity can only be a property or a method.",
-                nameof(member));
         }
 
         protected override void OnCompleteFields(
@@ -457,12 +463,6 @@ namespace HotChocolate.Types
 
         IObjectFieldDescriptor IObjectTypeDescriptor<T>.Field(
             Expression<Func<T, object>> propertyOrMethod)
-        {
-            return Field(propertyOrMethod);
-        }
-
-        IObjectFieldDescriptor IObjectTypeDescriptor<T>.Field<TResolver>(
-            Expression<Func<TResolver, object>> propertyOrMethod)
         {
             return Field(propertyOrMethod);
         }


### PR DESCRIPTION
Moved the Field declaration function that can be parameterized with a… ResolverType to the untyped version of IObjectTypeDescriptor. There is nothing in that function that referes to T, therefore it can be safely used outside of the typed ObjectTypeDescriptor class. This way, a user can have an untyped ObjectType and refer to other resolver classes in their field declarations.