### PR TITLE
Limit directive uniqueness to explicitly marked directives.

### DIFF
--- a/src/Core/Core.Tests/Execution/IntrospectionTests.cs
+++ b/src/Core/Core.Tests/Execution/IntrospectionTests.cs
@@ -11,11 +11,11 @@ namespace HotChocolate.Execution
         public async Task TypeNameIntrospectionOnQuery()
         {
             // arrange
-            Schema schema = CreateSchema();
             string query = "{ __typename }";
+            IQueryExecuter executer = CreateSchema().MakeExecutable();
 
             // act
-            IExecutionResult result = await schema.ExecuteAsync(query);
+            IExecutionResult result = await executer.ExecuteAsync(query);
 
             // assert
             Assert.Null(result.Errors);
@@ -26,11 +26,11 @@ namespace HotChocolate.Execution
         public async Task TypeNameIntrospectionNotOnQuery()
         {
             // arrange
-            Schema schema = CreateSchema();
             string query = "{ b { __typename } }";
+            IQueryExecuter executer = CreateSchema().MakeExecutable();
 
             // act
-            IExecutionResult result = await schema.ExecuteAsync(query);
+            IExecutionResult result = await executer.ExecuteAsync(query);
 
             // assert
             Assert.Null(result.Errors);
@@ -41,11 +41,11 @@ namespace HotChocolate.Execution
         public async Task TypeIntrospectionOnQuery()
         {
             // arrange
-            Schema schema = CreateSchema();
             string query = "{ __type (type: \"Foo\") { name } }";
+            IQueryExecuter executer = CreateSchema().MakeExecutable();
 
             // act
-            IExecutionResult result = await schema.ExecuteAsync(query);
+            IExecutionResult result = await executer.ExecuteAsync(query);
 
             // assert
             Assert.Null(result.Errors);
@@ -56,13 +56,13 @@ namespace HotChocolate.Execution
         public async Task TypeIntrospectionOnQueryWithFields()
         {
             // arrange
-            Schema schema = CreateSchema();
             string query =
                 "{ __type (type: \"Foo\") " +
                 "{ name fields { name type { name } } } }";
+            IQueryExecuter executer = CreateSchema().MakeExecutable();
 
             // act
-            IExecutionResult result = await schema.ExecuteAsync(query);
+            IExecutionResult result = await executer.ExecuteAsync(query);
 
             // assert
             Assert.Null(result.Errors);
@@ -73,12 +73,12 @@ namespace HotChocolate.Execution
         public async Task ExecuteGraphiQLIntrospectionQuery()
         {
             // arrange
-            Schema schema = CreateSchema();
             string query =
                 FileResource.Open("IntrospectionQuery.graphql");
+            IQueryExecuter executer = CreateSchema().MakeExecutable();
 
             // act
-            IExecutionResult result = await schema.ExecuteAsync(query);
+            IExecutionResult result = await executer.ExecuteAsync(query);
 
             // assert
             Assert.Null(result.Errors);

--- a/src/Core/Core.Tests/__snapshots__/ExecuteGraphiQLIntrospectionQuery.json
+++ b/src/Core/Core.Tests/__snapshots__/ExecuteGraphiQLIntrospectionQuery.json
@@ -151,6 +151,18 @@
               "deprecationReason": null
             },
             {
+              "name": "isRepeatable",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "locations",
               "description": null,
               "args": [],

--- a/src/Core/Core/Validation/AllVariableUsagesAreAllowedVisitor.cs
+++ b/src/Core/Core/Validation/AllVariableUsagesAreAllowedVisitor.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.Validation
     internal sealed class AllVariableUsagesAreAllowedVisitor
         : QueryVisitorErrorBase
     {
-        private readonly Dictionary<string, DirectiveType> _directives;
+        private readonly Dictionary<NameString, DirectiveType> _directives;
         private readonly Dictionary<string, VariableDefinitionNode> _variableDefinitions
             = new Dictionary<string, VariableDefinitionNode>();
         private readonly List<VariableUsage> _variablesUsages =

--- a/src/Core/Core/Validation/ArgumentNamesVisitor.cs
+++ b/src/Core/Core/Validation/ArgumentNamesVisitor.cs
@@ -9,7 +9,7 @@ namespace HotChocolate.Validation
     internal sealed class ArgumentNamesVisitor
         : QueryVisitorErrorBase
     {
-        private readonly Dictionary<string, DirectiveType> _directives;
+        private readonly Dictionary<NameString, DirectiveType> _directives;
 
         public ArgumentNamesVisitor(ISchema schema)
             : base(schema)

--- a/src/Core/Core/Validation/DirectivesAreDefinedVisitor.cs
+++ b/src/Core/Core/Validation/DirectivesAreDefinedVisitor.cs
@@ -8,12 +8,12 @@ namespace HotChocolate.Validation
     internal sealed class DirectivesAreDefinedVisitor
         : QueryVisitorErrorBase
     {
-        private readonly HashSet<string> _directives;
+        private readonly HashSet<NameString> _directives;
 
         public DirectivesAreDefinedVisitor(ISchema schema)
             : base(schema)
         {
-            _directives = new HashSet<string>(
+            _directives = new HashSet<NameString>(
                 schema.DirectiveTypes.Select(t => t.Name));
         }
 

--- a/src/Core/Core/Validation/DirectivesAreInValidLocationsVisitor.cs
+++ b/src/Core/Core/Validation/DirectivesAreInValidLocationsVisitor.cs
@@ -9,7 +9,7 @@ namespace HotChocolate.Validation
     internal sealed class DirectivesAreInValidLocationsVisitor
         : QueryVisitorErrorBase
     {
-        private readonly Dictionary<string, DirectiveType> _directives;
+        private readonly Dictionary<NameString, DirectiveType> _directives;
 
         public DirectivesAreInValidLocationsVisitor(ISchema schema)
             : base(schema)

--- a/src/Core/Core/Validation/InputObjectFieldVisitorBase.cs
+++ b/src/Core/Core/Validation/InputObjectFieldVisitorBase.cs
@@ -9,7 +9,7 @@ namespace HotChocolate.Validation
     internal abstract class InputObjectFieldVisitorBase
         : QueryVisitorErrorBase
     {
-        private readonly Dictionary<string, DirectiveType> _directives;
+        private readonly Dictionary<NameString, DirectiveType> _directives;
 
         protected InputObjectFieldVisitorBase(ISchema schema)
             : base(schema)

--- a/src/Core/Core/Validation/RequiredArgumentVisitor.cs
+++ b/src/Core/Core/Validation/RequiredArgumentVisitor.cs
@@ -9,7 +9,7 @@ namespace HotChocolate.Validation
     internal sealed class RequiredArgumentVisitor
         : QueryVisitorErrorBase
     {
-        private readonly Dictionary<string, DirectiveType> _directives;
+        private readonly Dictionary<NameString, DirectiveType> _directives;
 
         public RequiredArgumentVisitor(ISchema schema)
             : base(schema)

--- a/src/Core/Core/Validation/ValuesOfCorrectTypeVisitor.cs
+++ b/src/Core/Core/Validation/ValuesOfCorrectTypeVisitor.cs
@@ -12,7 +12,7 @@ namespace HotChocolate.Validation
     {
         private readonly HashSet<ObjectValueNode> _visited =
             new HashSet<ObjectValueNode>();
-        private readonly Dictionary<string, DirectiveType> _directives;
+        private readonly Dictionary<NameString, DirectiveType> _directives;
 
         public ValuesOfCorrectTypeVisitor(ISchema schema)
             : base(schema)

--- a/src/Core/Language.Tests/AST/DirectiveDefinitionNodeTests.cs
+++ b/src/Core/Language.Tests/AST/DirectiveDefinitionNodeTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace HotChocolate.Language
+{
+    public class DirectiveDefinitionNodeTests
+    {
+        [InlineData(true)]
+        [InlineData(false)]
+        [Theory]
+        public void CreateDirectiveDefinitionWithLocation(bool isRepeatable)
+        {
+            // arrange
+            var source = new Source("foo");
+            var start = new SyntaxToken(
+                TokenKind.StartOfFile, 0, 0, 1, 1, null);
+            var location = new Location(source, start, start);
+            var name = new NameNode("foo");
+            var description = new StringValueNode("bar");
+            var arguments = new List<InputValueDefinitionNode>();
+            var locations = new List<NameNode>();
+
+            // act
+            var directiveDefinition = new DirectiveDefinitionNode(
+                location, name, description, isRepeatable,
+                arguments, locations);
+
+            // assert
+            Assert.Equal(NodeKind.DirectiveDefinition,
+                directiveDefinition.Kind);
+            Assert.Equal(location, directiveDefinition.Location);
+            Assert.Equal(name, directiveDefinition.Name);
+            Assert.Equal(description, directiveDefinition.Description);
+            Assert.Equal(isRepeatable, directiveDefinition.IsRepeatable);
+            Assert.Equal(arguments, directiveDefinition.Arguments);
+            Assert.Equal(locations, directiveDefinition.Locations);
+        }
+
+        [Fact]
+        public void CreateDirectiveDefinition()
+        {
+            // arrange
+            var name = new NameNode("foo");
+            var description = new StringValueNode("bar");
+            var arguments = new List<InputValueDefinitionNode>();
+            var locations = new List<NameNode>();
+
+            // act
+            var directiveDefinition = new DirectiveDefinitionNode(
+                null, name, description, true,
+                arguments, locations);
+
+            // assert
+            Assert.Equal(NodeKind.DirectiveDefinition,
+                directiveDefinition.Kind);
+            Assert.Null(directiveDefinition.Location);
+            Assert.Equal(name, directiveDefinition.Name);
+            Assert.Equal(description, directiveDefinition.Description);
+            Assert.Equal(arguments, directiveDefinition.Arguments);
+            Assert.Equal(locations, directiveDefinition.Locations);
+        }
+    }
+}

--- a/src/Core/Language.Tests/Parser/DirectiveDefinitionTests.cs
+++ b/src/Core/Language.Tests/Parser/DirectiveDefinitionTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using Xunit;
+
+namespace HotChocolate.Language
+{
+    public class DirectiveDefinitionParserTests
+    {
+        [Fact]
+        public void ParseUniqueDirective()
+        {
+            // arrange
+            var text = "directive @skip(if: Boolean!) " +
+                "on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT";
+            var parser = new Parser();
+
+            // assert
+            DocumentNode document = parser.Parse(text);
+
+            // assert
+            DirectiveDefinitionNode directiveDefinition = document.Definitions
+                .OfType<DirectiveDefinitionNode>().FirstOrDefault();
+            Assert.NotNull(directiveDefinition);
+            Assert.False(directiveDefinition.IsRepeatable);
+        }
+
+        [Fact]
+        public void ParseRepeatableDirective()
+        {
+            // arrange
+            var text = "directive @skip(if: Boolean!) repeatable " +
+                "on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT";
+            var parser = new Parser();
+
+            // assert
+            DocumentNode document = parser.Parse(text);
+
+            // assert
+            DirectiveDefinitionNode directiveDefinition = document.Definitions
+                .OfType<DirectiveDefinitionNode>().FirstOrDefault();
+            Assert.NotNull(directiveDefinition);
+            Assert.True(directiveDefinition.IsRepeatable);
+        }
+    }
+}

--- a/src/Core/Language.Tests/__resources__/schema-kitchen-sink.graphql
+++ b/src/Core/Language.Tests/__resources__/schema-kitchen-sink.graphql
@@ -114,6 +114,8 @@ extend input InputType @onInputObject
 
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+directive @skip2(if: Boolean!) repeatable on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 directive @include(if: Boolean!)
   on FIELD
    | FRAGMENT_SPREAD

--- a/src/Core/Language.Tests/__snapshots__/ParseFacebookKitchenSinkSchema.json
+++ b/src/Core/Language.Tests/__snapshots__/ParseFacebookKitchenSinkSchema.json
@@ -1500,6 +1500,62 @@
         "Value": "skip"
       },
       "Description": null,
+      "IsRepeatable": false,
+      "Arguments": [
+        {
+          "Kind": "InputValueDefinition",
+          "Description": null,
+          "Type": {
+            "Kind": "NonNullType",
+            "Location": null,
+            "Type": {
+              "Kind": "NamedType",
+              "Location": null,
+              "Name": {
+                "Kind": "Name",
+                "Location": null,
+                "Value": "Boolean"
+              }
+            }
+          },
+          "DefaultValue": null,
+          "Location": null,
+          "Name": {
+            "Kind": "Name",
+            "Location": null,
+            "Value": "if"
+          },
+          "Directives": []
+        }
+      ],
+      "Locations": [
+        {
+          "Kind": "Name",
+          "Location": null,
+          "Value": "FIELD"
+        },
+        {
+          "Kind": "Name",
+          "Location": null,
+          "Value": "FRAGMENT_SPREAD"
+        },
+        {
+          "Kind": "Name",
+          "Location": null,
+          "Value": "INLINE_FRAGMENT"
+        }
+      ]
+    },
+    {
+      "Kind": "DirectiveDefinition",
+      "Location": null,
+      "Name": {
+        "Kind": "Name",
+        "Location": null,
+        "Value": "skip2"
+      },
+      "Description": null,
+      "IsRepeatable": true,
       "Arguments": [
         {
           "Kind": "InputValueDefinition",
@@ -1554,6 +1610,7 @@
         "Value": "include"
       },
       "Description": null,
+      "IsRepeatable": false,
       "Arguments": [
         {
           "Kind": "InputValueDefinition",
@@ -1608,6 +1665,7 @@
         "Value": "include2"
       },
       "Description": null,
+      "IsRepeatable": false,
       "Arguments": [
         {
           "Kind": "InputValueDefinition",

--- a/src/Core/Language/AST/DirectiveDefinitionNode.cs
+++ b/src/Core/Language/AST/DirectiveDefinitionNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace HotChocolate.Language
 {
@@ -9,17 +10,19 @@ namespace HotChocolate.Language
             Location location,
             NameNode name,
             StringValueNode description,
+            bool isRepeatable,
             IReadOnlyCollection<InputValueDefinitionNode> arguments,
             IReadOnlyCollection<NameNode> locations)
         {
             Location = location;
-            Name = name 
-                ?? throw new System.ArgumentNullException(nameof(name));
+            Name = name
+                ?? throw new ArgumentNullException(nameof(name));
             Description = description;
-            Arguments = arguments 
-                ?? throw new System.ArgumentNullException(nameof(arguments));
-            Locations = locations 
-                ?? throw new System.ArgumentNullException(nameof(locations));
+            IsRepeatable = isRepeatable;
+            Arguments = arguments
+                ?? throw new ArgumentNullException(nameof(arguments));
+            Locations = locations
+                ?? throw new ArgumentNullException(nameof(locations));
         }
 
         public NodeKind Kind { get; } = NodeKind.DirectiveDefinition;
@@ -29,6 +32,8 @@ namespace HotChocolate.Language
         public NameNode Name { get; }
 
         public StringValueNode Description { get; }
+
+        public bool IsRepeatable { get; }
 
         public IReadOnlyCollection<InputValueDefinitionNode> Arguments { get; }
 

--- a/src/Core/Language/Parser/Keywords.cs
+++ b/src/Core/Language/Parser/Keywords.cs
@@ -13,6 +13,7 @@
         public const string Extend = "extend";
         public const string Directive = "directive";
         public const string Implements = "implements";
+        public const string Repeatable = "repeatable";
 
         // query
         public const string Query = "query";

--- a/src/Core/Language/Parser/Parser.Directives.cs
+++ b/src/Core/Language/Parser/Parser.Directives.cs
@@ -14,6 +14,7 @@ namespace HotChocolate.Language
             NameNode name = ParseName(context);
             List<InputValueDefinitionNode> arguments =
                 ParseArgumentDefinitions(context);
+            bool isRepeatable = context.SkipRepeatableKeyword();
             context.ExpectOnKeyword();
             List<NameNode> locations =
                 ParseDirectiveLocations(context);
@@ -24,6 +25,7 @@ namespace HotChocolate.Language
                 location,
                 name,
                 description,
+                isRepeatable,
                 arguments,
                 locations
             );

--- a/src/Core/Language/Parser/ParserContextExtensions.cs
+++ b/src/Core/Language/Parser/ParserContextExtensions.cs
@@ -200,6 +200,11 @@
             return match;
         }
 
+        public static bool SkipRepeatableKeyword(this ParserContext context)
+        {
+            return SkipKeyword(context, Keywords.Repeatable);
+        }
+
         public static bool SkipKeyword(
             this ParserContext context,
             string keyword)

--- a/src/Core/Stitching/AnnotateQueryRewriter.cs
+++ b/src/Core/Stitching/AnnotateQueryRewriter.cs
@@ -8,8 +8,8 @@ namespace HotChocolate.Stitching
     internal sealed class AnnotateQueryRewriter
         : QuerySyntaxRewriter<AnnotationContext>
     {
-        private static readonly HashSet<string> _stitchingDirectives =
-            new HashSet<string>
+        private static readonly HashSet<NameString> _stitchingDirectives =
+            new HashSet<NameString>
             {
                 DirectiveNames.Schema,
                 DirectiveNames.Delegate
@@ -37,7 +37,7 @@ namespace HotChocolate.Stitching
                 && type.Fields.TryGetField(fieldName, out IOutputField field))
             {
 
-                ILookup<string, IDirective> directiveLookup =
+                ILookup<NameString, IDirective> directiveLookup =
                     field.Directives.ToLookup(t => t.Name);
 
                 var directives = new List<DirectiveNode>(node.Directives);

--- a/src/Core/Types.Tests/Types/DirectiveLocationTests.cs
+++ b/src/Core/Types.Tests/Types/DirectiveLocationTests.cs
@@ -6,7 +6,7 @@ namespace HotChocolate.Types
 {
     public class DirectiveLocationTests
     {
-        // flag values must be set correct 
+        // flag values must be set correct
         [Fact]
         public void FlagsCorrect()
         {
@@ -18,6 +18,6 @@ namespace HotChocolate.Types
                     Assert.Equal(v, (int)loc);
                     return v;
                 });
-        } 
+        }
     }
 }

--- a/src/Core/Types/Schema.cs
+++ b/src/Core/Types/Schema.cs
@@ -20,7 +20,7 @@ namespace HotChocolate
     {
         private readonly SchemaTypes _types;
         private bool _disposed;
-        private readonly Dictionary<string, DirectiveType> _directiveTypes;
+        private readonly Dictionary<NameString, DirectiveType> _directiveTypes;
 
         private Schema(
             IServiceProvider services,

--- a/src/Core/Types/Types/Descriptors/DirectiveTypeDescription.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveTypeDescription.cs
@@ -15,6 +15,8 @@ namespace HotChocolate.Types
 
         public string Description { get; set; }
 
+        public bool IsRepeatable { get; set; }
+
         public Type ClrType { get; set; }
 
         public BindingBehavior ArgumentBindingBehavior { get; set; }

--- a/src/Core/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
@@ -213,6 +213,12 @@ namespace HotChocolate.Types
             return this;
         }
 
+        IDirectiveTypeDescriptor IDirectiveTypeDescriptor.Repeatable()
+        {
+            DirectiveDescription.IsRepeatable = true;
+            return this;
+        }
+
         #endregion
     }
 
@@ -379,24 +385,30 @@ namespace HotChocolate.Types
             return this;
         }
 
-        IDirectiveTypeDescriptor IDirectiveTypeDescriptor<T>.Middleware(
+        IDirectiveTypeDescriptor<T> IDirectiveTypeDescriptor<T>.Middleware(
             DirectiveMiddleware middleware)
         {
             Middleware(middleware);
             return this;
         }
 
-        IDirectiveTypeDescriptor IDirectiveTypeDescriptor<T>.Middleware<TM>(
+        IDirectiveTypeDescriptor<T> IDirectiveTypeDescriptor<T>.Middleware<TM>(
             Expression<Func<TM, object>> method)
         {
             Middleware(method);
             return this;
         }
 
-        IDirectiveTypeDescriptor IDirectiveTypeDescriptor<T>.Middleware<TM>(
+        IDirectiveTypeDescriptor<T> IDirectiveTypeDescriptor<T>.Middleware<TM>(
             Expression<Action<T>> method)
         {
             Middleware(method);
+            return this;
+        }
+
+        IDirectiveTypeDescriptor<T> IDirectiveTypeDescriptor<T>.Repeatable()
+        {
+            DirectiveDescription.IsRepeatable = true;
             return this;
         }
 

--- a/src/Core/Types/Types/Descriptors/IDirectiveTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/IDirectiveTypeDescriptor.cs
@@ -58,6 +58,11 @@ namespace HotChocolate.Types
         // TODO : DOCU
         IDirectiveTypeDescriptor Middleware<T>(
             Expression<Action<T>> method);
+
+        /// <summary>
+        /// Allows this directive type to be declared multiple times in a single location.
+        /// </summary>
+        IDirectiveTypeDescriptor Repeatable();
     }
 
     public interface IDirectiveTypeDescriptor<T>
@@ -127,15 +132,20 @@ namespace HotChocolate.Types
         new IDirectiveTypeDescriptor<T> Location(DirectiveLocation location);
 
         // TODO : DOCU
-        new IDirectiveTypeDescriptor Middleware(
+        new IDirectiveTypeDescriptor<T> Middleware(
             DirectiveMiddleware middleware);
 
         // TODO : DOCU
-        new IDirectiveTypeDescriptor Middleware<TMiddleware>(
+        new IDirectiveTypeDescriptor<T> Middleware<TMiddleware>(
             Expression<Func<TMiddleware, object>> method);
 
         // TODO : DOCU
-        IDirectiveTypeDescriptor Middleware<TMiddleware>(
+        IDirectiveTypeDescriptor<T> Middleware<TMiddleware>(
             Expression<Action<T>> method);
+
+        /// <summary>
+        /// Allows this directive type to be declared multiple times in a single location.
+        /// </summary>
+        new IDirectiveTypeDescriptor<T> Repeatable();
     }
 }

--- a/src/Core/Types/Types/Directive.cs
+++ b/src/Core/Types/Types/Directive.cs
@@ -43,13 +43,13 @@ namespace HotChocolate.Types
             Name = directiveType.Name;
         }
 
-        public string Name { get; }
+        public NameString Name { get; }
 
         public DirectiveType Type { get; }
 
         public object Source { get; }
 
-        public DirectiveMiddleware Middleware  => Type.Middleware;
+        public DirectiveMiddleware Middleware => Type.Middleware;
 
         public bool IsExecutable => Type.IsExecutable;
 

--- a/src/Core/Types/Types/DirectiveCollection.cs
+++ b/src/Core/Types/Types/DirectiveCollection.cs
@@ -19,11 +19,12 @@ namespace HotChocolate.Types
             DirectiveLocation location,
             IReadOnlyCollection<DirectiveDescription> directiveDescriptions)
         {
-            _source = source;
+            _source = source
+                ?? throw new ArgumentNullException(nameof(source));
             _location = location;
             _descriptions = directiveDescriptions
                 ?? throw new ArgumentNullException(
-                        nameof(directiveDescriptions));
+                    nameof(directiveDescriptions));
         }
 
         public int Count => _directives.Count;
@@ -33,32 +34,44 @@ namespace HotChocolate.Types
         protected override void OnCompleteType(
             ITypeInitializationContext context)
         {
+            var processed = new HashSet<string>();
+
             foreach (DirectiveDescription description in _descriptions)
             {
-                CompleteDirecive(context, description);
+                CompleteDirecive(context, description, processed);
             }
         }
 
         private void CompleteDirecive(
             ITypeInitializationContext context,
-            DirectiveDescription description)
+            DirectiveDescription description,
+            HashSet<string> processed)
         {
             DirectiveReference reference =
                 DirectiveReference.FromDescription(description);
-            DirectiveType type = context.GetDirectiveType(reference);
+            DirectiveType directiveType = context.GetDirectiveType(reference);
 
-            if (type != null)
+            if (directiveType != null)
             {
-                if (type.Locations.Contains(_location))
+                if (!processed.Add(directiveType.Name)
+                    && !directiveType.IsRepeatable)
                 {
-                    _directives.Add(
-                        Directive.FromDescription(type, description, _source));
+                    context.ReportError(new SchemaError(
+                        $"The specified directive `@{directiveType.Name}` " +
+                        "is unique and cannot be added twice.",
+                        context.Type));
+                }
+                else if (directiveType.Locations.Contains(_location))
+                {
+                    _directives.Add(Directive.FromDescription(
+                        directiveType, description, _source));
                 }
                 else
                 {
                     context.ReportError(new SchemaError(
-                        $"The specified directive `{type.Name}` is not " +
-                        $"allowed on the current location `{_location}`.",
+                        $"The specified directive `@{directiveType.Name}` " +
+                        "is not allowed on the current location " +
+                        $"`{_location}`.",
                         context.Type));
                 }
             }

--- a/src/Core/Types/Types/DirectiveType.cs
+++ b/src/Core/Types/Types/DirectiveType.cs
@@ -27,7 +27,7 @@ namespace HotChocolate.Types
 
         public DirectiveDefinitionNode SyntaxNode { get; private set; }
 
-        public string Name { get; private set; }
+        public NameString Name { get; private set; }
 
         public string Description { get; private set; }
 

--- a/src/Core/Types/Types/DirectiveType.cs
+++ b/src/Core/Types/Types/DirectiveType.cs
@@ -31,6 +31,8 @@ namespace HotChocolate.Types
 
         public string Description { get; private set; }
 
+        public bool IsRepeatable { get; private set; }
+
         public ICollection<DirectiveLocation> Locations { get; private set; }
 
         public FieldCollection<InputField> Arguments { get; private set; }
@@ -69,6 +71,7 @@ namespace HotChocolate.Types
             SyntaxNode = description.SyntaxNode;
             Name = description.Name;
             Description = description.Description;
+            IsRepeatable = description.IsRepeatable;
             Locations = description.Locations.ToList().AsReadOnly();
             Arguments = new FieldCollection<InputField>(
                 description.Arguments.Select(t => new InputField(t)));

--- a/src/Core/Types/Types/IDirective.cs
+++ b/src/Core/Types/Types/IDirective.cs
@@ -5,7 +5,7 @@ namespace HotChocolate.Types
 {
     public interface IDirective
     {
-        string Name { get; }
+        NameString Name { get; }
 
         DirectiveType Type { get; }
 

--- a/src/Core/Types/Types/Introspection/__Directive.cs
+++ b/src/Core/Types/Types/Introspection/__Directive.cs
@@ -27,6 +27,10 @@ namespace HotChocolate.Types.Introspection
                 .Type<StringType>()
                 .Resolver(c => c.Parent<DirectiveType>().Description);
 
+            descriptor.Field("isRepeatable")
+                .Type<BooleanType>()
+                .Resolver(c => c.Parent<DirectiveType>().IsRepeatable);
+
             descriptor.Field("locations")
                 .Type<NonNullType<ListType<NonNullType<__DirectiveLocation>>>>()
                 .Resolver(c => c.Parent<DirectiveType>().Locations);

--- a/src/Core/Types/Types/ObjectField.cs
+++ b/src/Core/Types/Types/ObjectField.cs
@@ -114,7 +114,8 @@ namespace HotChocolate.Types
         private void CompleteExecutableDirectives(
             ITypeInitializationContext context)
         {
-            HashSet<string> processed = new HashSet<string>();
+            var processed = new HashSet<string>();
+
             if (context.Type is ObjectType ot)
             {
                 AddExectableDirectives(processed, ot.Directives);
@@ -129,9 +130,12 @@ namespace HotChocolate.Types
             foreach (IDirective directive in
                 directives.Where(t => t.IsExecutable))
             {
-                if (processed.Contains(directive.Name))
+                if (!processed.Add(directive.Name)
+                    && !directive.Type.IsRepeatable)
                 {
-                    _executableDirectives.Remove(directive);
+                    IDirective remove = _executableDirectives
+                        .First(t => t.Name.Equals(directive.Name));
+                    _executableDirectives.Remove(remove);
                 }
                 _executableDirectives.Add(directive);
             }

--- a/src/Core/Types/Utilities/TypeConversion.Setup.cs
+++ b/src/Core/Types/Utilities/TypeConversion.Setup.cs
@@ -17,6 +17,7 @@ namespace HotChocolate.Utilities
             RegisterUriConversions(registry);
             RegisterBooleanConversions(registry);
             RegisterStringConversions(registry);
+            RegisterNameStringConversions(registry);
 
             RegisterUInt16Conversions(registry);
             RegisterUInt32Conversions(registry);
@@ -112,6 +113,13 @@ namespace HotChocolate.Utilities
                     CultureInfo.InvariantCulture));
             registry.Register<string, bool>(from =>
                 bool.Parse(from));
+            registry.Register<string, NameString>(from => from);
+        }
+
+        private static void RegisterNameStringConversions(
+            ITypeConverterRegistry registry)
+        {
+            registry.Register<NameString, string>(from => from);
         }
 
         private static void RegisterUInt16Conversions(

--- a/src/Core/Types/Utilities/TypeConversion.cs
+++ b/src/Core/Types/Utilities/TypeConversion.cs
@@ -58,7 +58,9 @@ namespace HotChocolate.Utilities
                     ? source.GetType()
                     : from;
 
-                return TryConvertInternal(fromInternal, to, source, out converted);
+                return TryConvertInternal(
+                    fromInternal, to, source,
+                    out converted);
             }
             catch
             {
@@ -107,7 +109,9 @@ namespace HotChocolate.Utilities
         {
             if (_hasFactories)
             {
-                ImmutableList<ChangeTypeFactory> factories = _converterFactories;
+                ImmutableList<ChangeTypeFactory> factories =
+                    _converterFactories;
+
                 foreach (ChangeTypeFactory factory in factories)
                 {
                     if (factory(from, to, out converter))

--- a/src/Server/AspNetCore.Authorization/AspNetCore.Authorization.csproj
+++ b/src/Server/AspNetCore.Authorization/AspNetCore.Authorization.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>HotChocolate.Hosting.Authorization</AssemblyName>
-    <RootNamespace>HotChocolate.Hosting.Authorization</RootNamespace>
-    <PackageId>HotChocolate.Hosting.Authorization</PackageId>
+    <AssemblyName>HotChocolate.AspNetCore.Authorization</AssemblyName>
+    <RootNamespace>HotChocolate.AspNetCore.Authorization</RootNamespace>
+    <PackageId>HotChocolate.AspNetCore.Authorization</PackageId>
     <Description>Provides authorization extensions for the hot chocolate ASP.net core GraphQL middleware.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR implements #287.

- [x] Parser support for repeatable directives 
- [x] Type system support for repeatable directives
- [x] Let descriptors add multiple directives
- [x] Add errors for unique directives in the type system
- [x] Introspection