### PR TITLE
Resolves Issue #440

### DIFF
--- a/src/Server/AspNetCore.Authorization/AuthorizeDirective.cs
+++ b/src/Server/AspNetCore.Authorization/AuthorizeDirective.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -25,6 +25,9 @@ namespace HotChocolate.AspNetCore.Authorization
             Roles = roles.ToArray();
         }
 #else
+        public AuthorizeDirective()
+            : this(null, null) { }
+
         public AuthorizeDirective(string policy)
             : this(policy, null)
         { }
@@ -38,12 +41,18 @@ namespace HotChocolate.AspNetCore.Authorization
             ReadOnlyCollection<string> readOnlyRoles =
                 roles?.ToList().AsReadOnly();
 
+//mlm - I'm not sure if the other changes I've made in AuthorizeDirectiveType
+// are applicable only to AspNet Core or not. So, I'm keeping this in but gating
+// it for AspNetClassic until someone can confirm it's okay to remove this for both
+// AspNetClassic and AspNetCore.
+#if ASPNETCLASSIC
             if (string.IsNullOrEmpty(policy)
                 && (readOnlyRoles == null || readOnlyRoles.Any()))
             {
                 throw new ArgumentException(
                     "Either policy or roles has to be set.");
             }
+#endif
 
             Policy = policy;
             Roles = readOnlyRoles;

--- a/src/Server/AspNetCore.Authorization/AuthorizeDirectiveType.cs
+++ b/src/Server/AspNetCore.Authorization/AuthorizeDirectiveType.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading.Tasks;
@@ -54,14 +54,13 @@ namespace HotChocolate.AspNetCore.Authorization
             }
 
 #if !ASPNETCLASSIC
-            
-            AuthorizationPolicy policy = null;
-            if (string.IsNullOrWhiteSpace(directive.Policy))
-                policy = await policyProvider.GetDefaultPolicyAsync();
-            else
-                policy = await policyProvider.GetPolicyAsync(directive.Policy);
 
-            if(policy == null)
+            AuthorizationPolicy policy =
+                string.IsNullOrWhiteSpace(directive.Policy)
+                    ? await policyProvider.GetDefaultPolicyAsync()
+                    : await policyProvider.GetPolicyAsync(directive.Policy);
+
+            if (policy == null)
             {
                 context.Result = BuildUnauthorizedError(context, true);
                 return;
@@ -87,7 +86,9 @@ namespace HotChocolate.AspNetCore.Authorization
             string message =
                 "The current user is not authorized to access this resource.";
             if (policyNotfound)
+            {
                 message += " A valid authorization policy could not be found.";
+            }
 
             return QueryError.CreateFieldError(message,
                     context.Path,

--- a/src/Server/AspNetCore.Authorization/AuthorizeDirectiveType.cs
+++ b/src/Server/AspNetCore.Authorization/AuthorizeDirectiveType.cs
@@ -38,35 +38,60 @@ namespace HotChocolate.AspNetCore.Authorization
 #if !ASPNETCLASSIC
             IAuthorizationService authorizeService = context
                 .Service<IAuthorizationService>();
+            IAuthorizationPolicyProvider policyProvider =
+                context.Service<IAuthorizationPolicyProvider>();
 #endif
             ClaimsPrincipal principal = context
                 .CustomProperty<ClaimsPrincipal>(nameof(ClaimsPrincipal));
             AuthorizeDirective directive = context.Directive
                 .ToObject<AuthorizeDirective>();
-            bool allowed = IsInRoles(principal, directive.Roles);
+            
+
+            if(!IsInRoles(principal, directive.Roles))
+            {
+                context.Result = BuildUnauthorizedError(context);
+                return;
+            }
 
 #if !ASPNETCLASSIC
-            if (allowed && !string.IsNullOrEmpty(directive.Policy))
-            {
-                AuthorizationResult result = await authorizeService
-                    .AuthorizeAsync(principal, directive.Policy);
-
-                allowed = result.Succeeded;
-            }
-#endif
-
-            if (allowed)
-            {
-                await next(context);
-            }
+            
+            AuthorizationPolicy policy = null;
+            if (string.IsNullOrWhiteSpace(directive.Policy))
+                policy = await policyProvider.GetDefaultPolicyAsync();
             else
+                policy = await policyProvider.GetPolicyAsync(directive.Policy);
+
+            if(policy == null)
             {
-                context.Result = QueryError.CreateFieldError(
-                    "The current user is not authorized to " +
-                    "access this resource.",
+                context.Result = BuildUnauthorizedError(context, true);
+                return;
+            }
+
+            
+            AuthorizationResult result =
+                await authorizeService.AuthorizeAsync(principal, policy);
+
+            if(!result.Succeeded)
+            {
+                context.Result = BuildUnauthorizedError(context);
+                return;
+            }
+            
+#endif
+            await next(context);
+            
+        }
+
+        private static QueryError BuildUnauthorizedError(IDirectiveContext context, bool policyNotfound = false)
+        {
+            string message =
+                "The current user is not authorized to access this resource.";
+            if (policyNotfound)
+                message += " A valid authorization policy could not be found.";
+
+            return QueryError.CreateFieldError(message,
                     context.Path,
                     context.FieldSelection);
-            }
         }
 
         private static bool IsInRoles(


### PR DESCRIPTION
1. Add a default constructor to AuthorizeDirective
2. When no policy is specified on the directive usage, use the default policy.
3. Return an error if no policy could be found.
4. Remove a level of braces in AuthorizeDirectiveType.AuthorizeAsync where possible