### PR TITLE
Simplify Build Scripts

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -107,7 +107,6 @@ Task("Publish")
 });
 
 Task("Tests")
-    .IsDependentOn("CoreTests")
     .Does(() =>
 {
     var buildSettings = new DotNetCoreBuildSettings
@@ -127,11 +126,16 @@ Task("Tests")
         ArgumentCustomization = args => args
             .Append($"/p:CollectCoverage=true")
             .Append("/p:CoverletOutputFormat=opencover")
-            .Append($"/p:CoverletOutput=\"../../{testOutputDir}/classic_{i++}\" --blame")
+            .Append($"/p:CoverletOutput=\"../../{testOutputDir}/full_{i++}\" --blame")
     };
 
-    DotNetCoreBuild("./src/Server/AspNetClassic.Tests", buildSettings);
-    DotNetCoreTest("./src/Server/AspNetClassic.Tests", testSettings);
+    DotNetCoreBuild("./src/Core", buildSettings);
+    DotNetCoreBuild("./src/Server", buildSettings);
+
+    foreach(var file in GetFiles("./src/**/*.Tests.csproj"))
+    {
+        DotNetCoreTest(file.FullPath, testSettings);
+    }
 });
 
 Task("CoreTests")
@@ -158,17 +162,13 @@ Task("CoreTests")
     };
 
     DotNetCoreBuild("./src/Core", buildSettings);
-    DotNetCoreBuild("./src/Server/AspNetCore.Tests", buildSettings);
 
-    DotNetCoreTest("./src/Core/Utilities.Tests", testSettings);
-    DotNetCoreTest("./src/Core/Abstractions.Tests", testSettings);
-    DotNetCoreTest("./src/Core/Runtime.Tests", testSettings);
-    DotNetCoreTest("./src/Core/Language.Tests", testSettings);
-    DotNetCoreTest("./src/Core/Types.Tests", testSettings);
-    DotNetCoreTest("./src/Core/Validation.Tests", testSettings);
-    DotNetCoreTest("./src/Core/Core.Tests", testSettings);
-    DotNetCoreTest("./src/Core/Subscriptions.Tests", testSettings);
-    DotNetCoreTest("./src/Core/Stitching.Tests", testSettings);
+    foreach(var file in GetFiles("./src/Core/**/*.Tests.csproj"))
+    {
+        DotNetCoreTest(file.FullPath, testSettings);
+    }
+
+    DotNetCoreBuild("./src/Server/AspNetCore.Tests", buildSettings);
     DotNetCoreTest("./src/Server/AspNetCore.Tests", testSettings);
 });
 

--- a/src/Package.props
+++ b/src/Package.props
@@ -7,12 +7,23 @@
     <Copyright>Copyright © 2018 ChilliCream (Michael &amp; Rafael Staib)</Copyright>
     <PackageLicenseUrl>https://github.com/ChilliCream/hotchocolate/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ChilliCream/hotchocolate</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/ChilliCream/hotchocolate</RepositoryUrl>
-    <PackageTags>GraphQL ChilliCream</PackageTags>
     <PackageReleaseNotes>Release notes: https://github.com/ChilliCream/hotchocolate/releases/$(PackageVersion)</PackageReleaseNotes>
+    <PackageTags>GraphQL ChilliCream</PackageTags>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIconUrl>https://cdn.rawgit.com/ChilliCream/hotchocolate-logo/master/img/hotchocolate-signet.png</PackageIconUrl>
-    <RepositoryType>GitHub</RepositoryType>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <RepositoryUrl>https://github.com/ChilliCream/hotchocolate.git</RepositoryUrl>
+    <RepositoryType>GitHub</RepositoryType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Currently every test project has to be added to the build test section in order to be executed in the build. This is difficult to maintain and we are now collection the tests with a name filter.

- Test Discovery
- Support for NuGet SourceLink

Addresses #494
