### PR TITLE
Fixed TotalCount Bug in Paging

### DIFF
--- a/src/Core/Types.Tests/Types/Relay/QueryableConnectionTests.cs
+++ b/src/Core/Types.Tests/Types/Relay/QueryableConnectionTests.cs
@@ -14,7 +14,7 @@ namespace HotChocolate.Types.Relay
         public async Task TakeFirst()
         {
             // arrange
-            var list = new List<string> { "a", "b", "c", "d", "e", "f", "g", };
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
 
             var pagingDetails = new PagingDetails
             {
@@ -54,7 +54,7 @@ namespace HotChocolate.Types.Relay
         public async Task TakeLast()
         {
             // arrange
-            var list = new List<string> { "a", "b", "c", "d", "e", "f", "g", };
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
 
             var pagingDetails = new PagingDetails
             {
@@ -94,10 +94,10 @@ namespace HotChocolate.Types.Relay
         public async Task TakeFirstAfter()
         {
             // arrange
-            var list = new List<string> { "a", "b", "c", "d", "e", "f", "g", };
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
 
             var connectionFactory = new QueryableConnectionResolver<string>(
-                list.AsQueryable(), new PagingDetails { First = 1 });
+                list.AsQueryable(), new PagingDetails {First = 1});
 
             var connection = await connectionFactory.ResolveAsync(
                 CancellationToken.None);
@@ -138,13 +138,75 @@ namespace HotChocolate.Types.Relay
         }
 
         [Fact]
+        public async Task TakeTwoAfterSecondTime()
+        {
+            // arrange
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
+
+            // 1. Page
+            var connectionFactory = new QueryableConnectionResolver<string>(
+                list.AsQueryable(), new PagingDetails {First = 2});
+
+            var connection = await connectionFactory.ResolveAsync(
+                CancellationToken.None);
+
+            //2. Page
+            var pagingDetails = new PagingDetails
+            {
+                After = connection.PageInfo.EndCursor,
+                First = 2
+            };
+
+            connectionFactory = new QueryableConnectionResolver<string>(
+                list.AsQueryable(), pagingDetails);
+
+            connection = await connectionFactory.ResolveAsync(
+                CancellationToken.None);
+
+            //3. Page
+            pagingDetails = new PagingDetails
+            {
+                After = connection.PageInfo.EndCursor,
+                First = 2
+            };
+
+            connectionFactory = new QueryableConnectionResolver<string>(
+                list.AsQueryable(), pagingDetails);
+
+            // act
+            connection = await connectionFactory.ResolveAsync(
+                CancellationToken.None);
+
+            // assert
+            Assert.Collection(connection.Edges,
+                t =>
+                {
+                    Assert.Equal("e", t.Node);
+                    Assert.Equal(4, GetPositionFromCursor(t.Cursor));
+                },
+                t =>
+                {
+                    Assert.Equal("f", t.Node);
+                    Assert.Equal(5, GetPositionFromCursor(t.Cursor));
+                });
+
+            Assert.True(
+                connection.PageInfo.HasPreviousPage,
+                "HasPreviousPage");
+
+            Assert.True(
+                connection.PageInfo.HasNextPage,
+                "HasNextPage");
+        }
+
+        [Fact]
         public async Task TakeLastBefore()
         {
             // arrange
-            var list = new List<string> { "a", "b", "c", "d", "e", "f", "g", };
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
 
             var connectionFactory = new QueryableConnectionResolver<string>(
-                list.AsQueryable(), new PagingDetails { First = 5 });
+                list.AsQueryable(), new PagingDetails {First = 5});
 
             var connection = await connectionFactory.ResolveAsync(
                 CancellationToken.None);
@@ -188,7 +250,7 @@ namespace HotChocolate.Types.Relay
         public async Task HasNextPage_True()
         {
             // arrange
-            var list = new List<string> { "a", "b", "c", "d", "e", "f", "g", };
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
 
             var pagingDetails = new PagingDetails
             {
@@ -210,7 +272,7 @@ namespace HotChocolate.Types.Relay
         public async Task HasNextPage_False()
         {
             // arrange
-            var list = new List<string> { "a", "b", "c", "d", "e", "f", "g", };
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
 
             var pagingDetails = new PagingDetails
             {
@@ -232,10 +294,10 @@ namespace HotChocolate.Types.Relay
         public async Task HasPrevious_True()
         {
             // arrange
-            var list = new List<string> { "a", "b", "c", "d", "e", "f", "g", };
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
 
             var connectionFactory = new QueryableConnectionResolver<string>(
-                list.AsQueryable(), new PagingDetails { First = 1 });
+                list.AsQueryable(), new PagingDetails {First = 1});
 
             var connection = await connectionFactory.ResolveAsync(
                 CancellationToken.None);
@@ -261,7 +323,7 @@ namespace HotChocolate.Types.Relay
         public async Task HasPrevious_False()
         {
             // arrange
-            var list = new List<string> { "a", "b", "c", "d", "e", "f", "g", };
+            var list = new List<string> {"a", "b", "c", "d", "e", "f", "g",};
 
             var pagingDetails = new PagingDetails();
 

--- a/src/Core/Types/Types/Relay/QueryableConnectionResolver.cs
+++ b/src/Core/Types/Types/Relay/QueryableConnectionResolver.cs
@@ -50,9 +50,9 @@ namespace HotChocolate.Types.Relay
             if (!_pageDetails.TotalCount.HasValue)
             {
                 _pageDetails.TotalCount = _source.Count();
-                _properties[_totalCount] =
-                    _pageDetails.TotalCount.Value;
             }
+
+            _properties[_totalCount] = _pageDetails.TotalCount.Value;
 
             IReadOnlyCollection<QueryableEdge> selectedEdges =
                 GetSelectedEdges();


### PR DESCRIPTION
The `QueryableConnectionResolver `has forgotten to add the `pageDetails.TotalCount` to the Properties for the Cursor. Therefore the Paging crashed as off the 3rd page