### PR TITLE
Fixed DateTimeType parsing issue

### DIFF
--- a/src/Core/Language/Visitors/DocumentWriter.cs
+++ b/src/Core/Language/Visitors/DocumentWriter.cs
@@ -8,11 +8,20 @@ namespace HotChocolate.Language
     public class DocumentWriter
         : TextWriter
     {
-        private TextWriter _writer;
+        private readonly TextWriter _writer;
 
         public DocumentWriter(TextWriter writer)
         {
             _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        }
+
+        public DocumentWriter(StringBuilder stringBuilder)
+        {
+            if (stringBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(stringBuilder));
+            }
+            _writer = new StringWriter(stringBuilder);
         }
 
         public int Indentation { get; private set; }

--- a/src/Core/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using HotChocolate.Language;
 using Xunit;
 
@@ -71,9 +73,37 @@ namespace HotChocolate.Types
             // arrange
             DateTimeType dateTimeType = new DateTimeType();
             StringValueNode literal = new StringValueNode(
-                "2018-06-11T08:46:14+04:00");
+                "2018-06-29T08:46:14+04:00");
             DateTimeOffset expectedDateTime = new DateTimeOffset(
-                new DateTime(2018, 6, 11, 8, 46, 14),
+                new DateTime(2018, 6, 29, 8, 46, 14),
+                new TimeSpan(4, 0, 0));
+
+            // act
+            DateTimeOffset dateTime = (DateTimeOffset)dateTimeType
+                .ParseLiteral(literal);
+
+            // assert
+            Assert.Equal(expectedDateTime, dateTime);
+        }
+
+        [InlineData("en-US")]
+        [InlineData("en-AU")]
+        [InlineData("en-GB")]
+        [InlineData("de-CH")]
+        [InlineData("de-de")]
+        [Theory]
+        public void ParseLiteral_StringValueNode_DifferentCulture(
+            string cultureName)
+        {
+            // arrange
+            Thread.CurrentThread.CurrentCulture =
+                CultureInfo.GetCultureInfo(cultureName);
+
+            DateTimeType dateTimeType = new DateTimeType();
+            StringValueNode literal = new StringValueNode(
+                "2018-06-29T08:46:14+04:00");
+            DateTimeOffset expectedDateTime = new DateTimeOffset(
+                new DateTime(2018, 6, 29, 8, 46, 14),
                 new TimeSpan(4, 0, 0));
 
             // act

--- a/src/Core/Types.Tests/Types/Scalars/DateTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/DateTypeTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using HotChocolate.Language;
 using Xunit;
 
@@ -84,8 +86,33 @@ namespace HotChocolate.Types
         {
             // arrange
             DateType dateType = new DateType();
-            StringValueNode literal = new StringValueNode("2018-06-11");
-            DateTime expectedDateTime = new DateTime(2018, 6, 11);
+            StringValueNode literal = new StringValueNode("2018-06-29");
+            DateTime expectedDateTime = new DateTime(2018, 6, 29);
+
+            // act
+            DateTime dateTime = (DateTime)dateType
+                .ParseLiteral(literal);
+
+            // assert
+            Assert.Equal(expectedDateTime, dateTime);
+        }
+
+        [InlineData("en-US")]
+        [InlineData("en-AU")]
+        [InlineData("en-GB")]
+        [InlineData("de-CH")]
+        [InlineData("de-de")]
+        [Theory]
+        public void ParseLiteral_StringValueNode_DifferentCulture(
+           string cultureName)
+        {
+            // arrange
+            Thread.CurrentThread.CurrentCulture =
+                CultureInfo.GetCultureInfo(cultureName);
+
+            DateType dateType = new DateType();
+            StringValueNode literal = new StringValueNode("2018-06-29");
+            DateTime expectedDateTime = new DateTime(2018, 6, 29);
 
             // act
             DateTime dateTime = (DateTime)dateType

--- a/src/Core/Types/Types/Scalars/DateTimeType.cs
+++ b/src/Core/Types/Types/Scalars/DateTimeType.cs
@@ -21,20 +21,28 @@ namespace HotChocolate.Types
         {
             if (value.Kind == DateTimeKind.Utc)
             {
-                return value.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffZ");
+                return value.ToString(
+                    "yyyy-MM-ddTHH\\:mm\\:ss.fffZ",
+                    CultureInfo.InvariantCulture);
             }
 
-            return value.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffzzz");
+            return value.ToString(
+                "yyyy-MM-ddTHH\\:mm\\:ss.fffzzz",
+                CultureInfo.InvariantCulture);
         }
 
         protected override string Serialize(DateTimeOffset value)
         {
             if (value.Offset == TimeSpan.Zero)
             {
-                return value.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffZ");
+                return value.ToString(
+                    "yyyy-MM-ddTHH\\:mm\\:ss.fffZ",
+                    CultureInfo.InvariantCulture);
             }
 
-            return value.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffzzz");
+            return value.ToString(
+                "yyyy-MM-ddTHH\\:mm\\:ss.fffzzz",
+                CultureInfo.InvariantCulture);
         }
 
         protected override bool TryParseLiteral(

--- a/src/Core/Types/Types/Scalars/DateType.cs
+++ b/src/Core/Types/Types/Scalars/DateType.cs
@@ -33,10 +33,10 @@ namespace HotChocolate.Types
             if (DateTime.TryParse(
                 literal.Value,
                 CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal,
+                DateTimeStyles.AssumeLocal,
                 out DateTime dateTime))
             {
-                obj = dateTime;
+                obj = dateTime.Date;
                 return true;
             }
 

--- a/src/Core/Types/Types/Scalars/DateType.cs
+++ b/src/Core/Types/Types/Scalars/DateType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using HotChocolate.Language;
 
 namespace HotChocolate.Types
@@ -18,18 +19,22 @@ namespace HotChocolate.Types
 
         protected override string Serialize(DateTime value)
         {
-            return value.ToString("yyyy-MM-dd");
+            return value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
 
         protected override string Serialize(DateTimeOffset value)
         {
-            return value.ToString("yyyy-MM-dd");
+            return value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
 
         protected override bool TryParseLiteral(
             StringValueNode literal, out object obj)
         {
-            if (DateTime.TryParse(literal.Value, out DateTime dateTime))
+            if (DateTime.TryParse(
+                literal.Value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out DateTime dateTime))
             {
                 obj = dateTime;
                 return true;

--- a/src/Core/Types/Types/Scalars/DateType.cs
+++ b/src/Core/Types/Types/Scalars/DateType.cs
@@ -33,7 +33,7 @@ namespace HotChocolate.Types
             if (DateTime.TryParse(
                 literal.Value,
                 CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
+                DateTimeStyles.AssumeUniversal,
                 out DateTime dateTime))
             {
                 obj = dateTime;


### PR DESCRIPTION
This PR fixes the DateTimeType and DateType parsing. We did not pass in the culture so the parsing did confuse the position of the month in some environments.

Addresses #545
