### PR TITLE
Added totalCount as optional field to the connection type

### DIFF
--- a/src/Core/Abstractions/ResolverResult.cs
+++ b/src/Core/Abstractions/ResolverResult.cs
@@ -73,4 +73,40 @@ namespace HotChocolate
             return new ResolverResult<TValue>(value);
         }
     }
+
+    /// <summary>
+    /// This is a helper class in order to have a simpler api to
+    /// create a resolver result.
+    /// </summary>
+    public static class ResolverResult
+    {
+        /// <summary>
+        /// Creates a field error resolver result.
+        /// </summary>
+        /// <param name="errorMessage">
+        /// The error message.
+        /// </param>
+        /// <returns>
+        /// Returns a field error resolver result.
+        /// </returns>
+        public static ResolverResult<TValue> CreateError<TValue>(
+            string errorMessage)
+        {
+            return ResolverResult<TValue>.CreateError(errorMessage);
+        }
+
+        /// <summary>
+        /// Creates a value resolver result.
+        /// </summary>
+        /// <param name="value">
+        /// The reolver result value.
+        /// </param>
+        /// <returns>
+        /// Returns a value resolver result.
+        /// </returns>
+        public static ResolverResult<TValue> CreateValue<TValue>(TValue value)
+        {
+            return ResolverResult<TValue>.CreateValue(value);
+        }
+    }
 }

--- a/src/Core/Core/Execution/ExecutionStrategyBase.Resolver.cs
+++ b/src/Core/Core/Execution/ExecutionStrategyBase.Resolver.cs
@@ -97,7 +97,7 @@ namespace HotChocolate.Execution
         }
 
         protected static void CompleteValue(
-            FieldValueCompletionContext completionContext)
+            IFieldValueCompletionContext completionContext)
         {
             _fieldValueCompleter.CompleteValue(completionContext);
         }

--- a/src/Core/Core/Execution/ExecutionStrategyBase.cs
+++ b/src/Core/Core/Execution/ExecutionStrategyBase.cs
@@ -64,7 +64,7 @@ namespace HotChocolate.Execution
         private static async Task ExecuteResolverBatchAsync(
             IExecutionContext executionContext,
             IReadOnlyCollection<ResolverTask> currentBatch,
-            List<ResolverTask> nextBatch,
+            ICollection<ResolverTask> nextBatch,
             BatchOperationHandler batchOperationHandler,
             CancellationToken cancellationToken)
         {

--- a/src/Core/Core/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/Core/Core/Execution/SubscriptionExecutionStrategy.cs
@@ -14,7 +14,7 @@ namespace HotChocolate.Execution
     internal sealed class SubscriptionExecutionStrategy
         : ExecutionStrategyBase
     {
-        private IRequestTimeoutOptionsAccessor _options;
+        private readonly IRequestTimeoutOptionsAccessor _options;
 
         public SubscriptionExecutionStrategy(
             IRequestTimeoutOptionsAccessor options)

--- a/src/Core/Core/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/Core/Core/Execution/SubscriptionExecutionStrategy.cs
@@ -99,7 +99,7 @@ namespace HotChocolate.Execution
 
         private static Task<IEventStream> SubscribeAsync(
             IServiceProvider services,
-            EventDescription @event)
+            IEventDescription @event)
         {
             var eventRegistry = (IEventRegistry)services
                 .GetService(typeof(IEventRegistry));

--- a/src/Core/Core/Execution/Utilities/ArgumentValueBuilder.cs
+++ b/src/Core/Core/Execution/Utilities/ArgumentValueBuilder.cs
@@ -38,7 +38,7 @@ namespace HotChocolate.Execution
 
         private static ArgumentValue CreateArgumentValue(
             InputField argument,
-            Dictionary<string, IValueNode> argumentValues,
+            IDictionary<string, IValueNode> argumentValues,
             IVariableCollection variables,
             Func<string, IError> createError)
         {
@@ -67,7 +67,7 @@ namespace HotChocolate.Execution
         private static object CoerceArgumentValue(
             InputField argument,
             IVariableCollection variables,
-            Dictionary<string, IValueNode> argumentValues)
+            IDictionary<string, IValueNode> argumentValues)
         {
             if (argumentValues.TryGetValue(argument.Name,
                 out IValueNode literal))

--- a/src/Core/Core/Execution/Utilities/FieldCollector.cs
+++ b/src/Core/Core/Execution/Utilities/FieldCollector.cs
@@ -141,7 +141,7 @@ namespace HotChocolate.Execution
         }
 
 
-        private bool ShouldBeIncluded(ISelectionNode selection)
+        private bool ShouldBeIncluded(Language.IHasDirectives selection)
         {
             if (selection.Directives.Skip(_variables))
             {
@@ -150,7 +150,9 @@ namespace HotChocolate.Execution
             return selection.Directives.Include(_variables);
         }
 
-        private static bool DoesTypeApply(IType typeCondition, ObjectType current)
+        private static bool DoesTypeApply(
+            IType typeCondition,
+            ObjectType current)
         {
             if (typeCondition is ObjectType ot)
             {

--- a/src/Core/Core/Execution/Utilities/VariableValueBuilder.cs
+++ b/src/Core/Core/Execution/Utilities/VariableValueBuilder.cs
@@ -135,7 +135,7 @@ namespace HotChocolate.Execution
             return value;
         }
 
-        private object EnsureClrTypeIsCorrect(IInputType type, object value)
+        private object EnsureClrTypeIsCorrect(IHasClrType type, object value)
         {
             if (type.ClrType != typeof(object)
                 && value.GetType() != type.ClrType

--- a/src/Core/Core/Validation/InputObjectFieldUniquenessVisitor.cs
+++ b/src/Core/Core/Validation/InputObjectFieldUniquenessVisitor.cs
@@ -36,8 +36,8 @@ namespace HotChocolate.Validation
         }
 
         private void VisitInputField(
-            HashSet<string> visitedFields,
-            InputField field,
+            ISet<string> visitedFields,
+            FieldBase<IInputType> field,
             ObjectFieldNode fieldValue)
         {
             if (visitedFields.Add(field.Name))

--- a/src/Core/Types.Tests/Types/Relay/ConnectionTests.cs
+++ b/src/Core/Types.Tests/Types/Relay/ConnectionTests.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.Types.Relay
         public void CreateConnection_PageInfoAndEdges_PassedCorrectly()
         {
             // arrange
-            var pageInfo = new PageInfo(true, true, "a", "b");
+            var pageInfo = new PageInfo(true, true, "a", "b", null);
             var edges = new List<Edge<string>>();
 
             // act
@@ -38,7 +38,7 @@ namespace HotChocolate.Types.Relay
         public void CreateConnection_EdgesNull_ArgumentNullException()
         {
             // arrange
-            var pageInfo = new PageInfo(true, true, "a", "b");
+            var pageInfo = new PageInfo(true, true, "a", "b", null);
 
             // act
             Action a = () => new Connection<string>(pageInfo, null);

--- a/src/Core/Types.Tests/Types/Relay/ConnectionTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Relay/ConnectionTypeTests.cs
@@ -76,6 +76,7 @@ namespace HotChocolate.Types.Relay
                     {
                         hasNextPage
                     }
+                    totalCount
                 }
             }
             ";
@@ -98,7 +99,7 @@ namespace HotChocolate.Types.Relay
             {
                 descriptor.Name("Query");
                 descriptor.Field("s")
-                    .UsePaging<StringType, string>()
+                    .UsePaging<StringType>()
                     .Resolver(ctx => _source);
             }
         }

--- a/src/Core/Types.Tests/Types/Relay/PageInfoTests.cs
+++ b/src/Core/Types.Tests/Types/Relay/PageInfoTests.cs
@@ -4,27 +4,35 @@ namespace HotChocolate.Types.Relay
 {
     public class PageInfoTests
     {
-        [InlineData(true, true, "a", "b")]
-        [InlineData(true, false, "a", "b")]
-        [InlineData(false, true, "a", "b")]
-        [InlineData(true, true, null, "b")]
-        [InlineData(true, true, "a", null)]
+        [InlineData(true, true, "a", "b", null)]
+        [InlineData(true, false, "a", "b", null)]
+        [InlineData(false, true, "a", "b", null)]
+        [InlineData(true, true, null, "b", null)]
+        [InlineData(true, true, "a", null, null)]
+        [InlineData(true, true, "a", "b", 1)]
+        [InlineData(true, false, "a", "b", 2)]
+        [InlineData(false, true, "a", "b", 3)]
+        [InlineData(true, true, null, "b", 4)]
+        [InlineData(true, true, "a", null, 5)]
         [Theory]
         public void CreatePageInfo_ArgumentsArePassedCorrectly(
             bool hasNextPage, bool hasPreviousPage,
-            string startCursor, string endCursor)
+            string startCursor, string endCursor,
+            long? totalCount)
         {
             // arrange
             // act
             var pageInfo = new PageInfo(
                 hasNextPage, hasPreviousPage,
-                startCursor, endCursor);
+                startCursor, endCursor,
+                totalCount);
 
             // assert
             Assert.Equal(hasNextPage, pageInfo.HasNextPage);
             Assert.Equal(hasPreviousPage, pageInfo.HasPreviousPage);
             Assert.Equal(startCursor, pageInfo.StartCursor);
             Assert.Equal(endCursor, pageInfo.EndCursor);
+            Assert.Equal(totalCount, pageInfo.TotalCount);
         }
     }
 }

--- a/src/Core/Types.Tests/__snapshots__/ExecuteQueryWithPaging.json
+++ b/src/Core/Types.Tests/__snapshots__/ExecuteQueryWithPaging.json
@@ -13,7 +13,8 @@
       ],
       "pageInfo": {
         "hasNextPage": false
-      }
+      },
+      "totalCount": 7
     }
   },
   "Extensions": {},

--- a/src/Core/Types/Configuration/TypeRegistry.GetType.cs
+++ b/src/Core/Types/Configuration/TypeRegistry.GetType.cs
@@ -51,6 +51,13 @@ namespace HotChocolate.Configuration
                 throw new ArgumentNullException(nameof(typeReference));
             }
 
+            if (typeReference.IsSchemaTypeReference())
+            {
+                return TryGetType(
+                    typeReference.SchemaType.NamedType().Name,
+                    out type);
+            }
+
             if (typeReference.IsClrTypeReference())
             {
                 return TryGetTypeFromClrType(

--- a/src/Core/Types/Configuration/TypeRegistry.RegisterType.cs
+++ b/src/Core/Types/Configuration/TypeRegistry.RegisterType.cs
@@ -31,13 +31,19 @@ namespace HotChocolate.Configuration
                 throw new ArgumentNullException(nameof(typeReference));
             }
 
-            if (!_sealed
-                && typeReference.IsClrTypeReference()
-                && !BaseTypes.IsNonGenericBaseType(typeReference.ClrType))
+            if (!_sealed)
             {
-                RegisterType(
-                    typeReference.ClrType,
-                    typeReference.Context);
+                if (typeReference.IsSchemaTypeReference())
+                {
+                    TryUpdateNamedType(typeReference.SchemaType.NamedType());
+                }
+                else if (typeReference.IsClrTypeReference()
+                    && !BaseTypes.IsNonGenericBaseType(typeReference.ClrType))
+                {
+                    RegisterType(
+                        typeReference.ClrType,
+                        typeReference.Context);
+                }
             }
         }
 

--- a/src/Core/Types/Resolvers/CodeGeneration/ResolverSourceCodeGeneratorBase.cs
+++ b/src/Core/Types/Resolvers/CodeGeneration/ResolverSourceCodeGeneratorBase.cs
@@ -39,7 +39,7 @@ namespace HotChocolate.Resolvers.CodeGeneration
             StringBuilder source);
 
         protected void GenerateArguments(
-            DirectiveMiddlewareDescriptor resolverDescriptor,
+            IDirectiveMiddlewareDescriptor resolverDescriptor,
             StringBuilder source)
         {
             if (resolverDescriptor.Arguments.Count > 0)

--- a/src/Core/Types/SchemaSerializer.cs
+++ b/src/Core/Types/SchemaSerializer.cs
@@ -357,7 +357,7 @@ namespace HotChocolate
 
         private static NamedTypeNode SerializeNamedType(
             INamedType namedType,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             referenced.Add(namedType.Name);
             return new NamedTypeNode(null, new NameNode(namedType.Name));

--- a/src/Core/Types/SchemaSerializer.cs
+++ b/src/Core/Types/SchemaSerializer.cs
@@ -80,7 +80,7 @@ namespace HotChocolate
 
         private static SchemaDefinitionNode SerializeSchemaTypeDefinition(
             ISchema schema,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             var operations = new List<OperationTypeDefinitionNode>();
 
@@ -116,7 +116,7 @@ namespace HotChocolate
         private static OperationTypeDefinitionNode SerializeOperationType(
            ObjectType type,
            OperationType operation,
-           HashSet<string> referenced)
+           ISet<string> referenced)
         {
             return new OperationTypeDefinitionNode
             (
@@ -128,7 +128,7 @@ namespace HotChocolate
 
         private static ITypeDefinitionNode SerializeNonScalarTypeDefinition(
             INamedType namedType,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             switch (namedType)
             {
@@ -154,7 +154,7 @@ namespace HotChocolate
 
         private static ObjectTypeDefinitionNode SerializeObjectType(
             ObjectType objectType,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             var directives = objectType.Directives
                 .Select(t => t.ToNode())
@@ -182,7 +182,7 @@ namespace HotChocolate
 
         private static InterfaceTypeDefinitionNode SerializeInterfaceType(
             InterfaceType interfaceType,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             var directives = interfaceType.Directives
                 .Select(t => t.ToNode())
@@ -204,7 +204,7 @@ namespace HotChocolate
 
         private static InputObjectTypeDefinitionNode SerializeInputObjectType(
             InputObjectType inputObjectType,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             var directives = inputObjectType.Directives
                 .Select(t => t.ToNode())
@@ -226,7 +226,7 @@ namespace HotChocolate
 
         private static UnionTypeDefinitionNode SerializeUnionType(
             UnionType unionType,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             var directives = unionType.Directives
                 .Select(t => t.ToNode())
@@ -294,7 +294,7 @@ namespace HotChocolate
 
         private static FieldDefinitionNode SerializeObjectField(
             IOutputField field,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             var arguments = field.Arguments
                 .Select(t => SerializeInputField(t, referenced))
@@ -317,7 +317,7 @@ namespace HotChocolate
 
         private static InputValueDefinitionNode SerializeInputField(
             IInputField inputValue,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             return new InputValueDefinitionNode
             (
@@ -332,7 +332,7 @@ namespace HotChocolate
 
         private static ITypeNode SerializeType(
             IType type,
-            HashSet<string> referenced)
+            ISet<string> referenced)
         {
             if (type is NonNullType nt)
             {

--- a/src/Core/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
@@ -257,8 +257,8 @@ namespace HotChocolate.Types
         }
 
         private void AddExplicitArguments(
-            Dictionary<string, DirectiveArgumentDescription> descriptors,
-            List<PropertyInfo> handledProperties)
+            IDictionary<string, DirectiveArgumentDescription> descriptors,
+            ICollection<PropertyInfo> handledProperties)
         {
             foreach (DirectiveArgumentDescription argumentDescription in
                 DirectiveDescription.Arguments)
@@ -276,8 +276,8 @@ namespace HotChocolate.Types
         }
 
         private void AddImplicitArguments(
-            Dictionary<string, DirectiveArgumentDescription> descriptors,
-            Dictionary<PropertyInfo, string> properties)
+            IDictionary<string, DirectiveArgumentDescription> descriptors,
+            IDictionary<PropertyInfo, string> properties)
         {
             foreach (KeyValuePair<PropertyInfo, string> property in properties)
             {
@@ -297,7 +297,7 @@ namespace HotChocolate.Types
         }
 
         private Dictionary<PropertyInfo, string> GetPossibleImplicitArguments(
-            List<PropertyInfo> handledProperties)
+            ICollection<PropertyInfo> handledProperties)
         {
             Dictionary<PropertyInfo, string> properties = GetProperties(
                 DirectiveDescription.ClrType);

--- a/src/Core/Types/Types/Descriptors/DirectiveUtils.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveUtils.cs
@@ -8,7 +8,7 @@ namespace HotChocolate.Types
     internal static class DirectiveUtils
     {
         public static void AddDirective<T>(
-            this IList<DirectiveDescription> directives,
+            this ICollection<DirectiveDescription> directives,
             T directive)
             where T : class
         {
@@ -35,7 +35,7 @@ namespace HotChocolate.Types
         }
 
         public static void AddDirective(
-            this IList<DirectiveDescription> directives,
+            this ICollection<DirectiveDescription> directives,
             NameString name,
             IEnumerable<ArgumentNode> arguments)
         {

--- a/src/Core/Types/Types/Descriptors/IInterfaceFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/IInterfaceFieldDescriptor.cs
@@ -17,6 +17,9 @@ namespace HotChocolate.Types
         IInterfaceFieldDescriptor Type<TOutputType>()
             where TOutputType : IOutputType;
 
+        IInterfaceFieldDescriptor Type<TOutputType>(TOutputType type)
+            where TOutputType : class, IOutputType;
+
         IInterfaceFieldDescriptor Type(ITypeNode type);
 
         IInterfaceFieldDescriptor Ignore();

--- a/src/Core/Types/Types/Descriptors/IObjectFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/IObjectFieldDescriptor.cs
@@ -18,6 +18,9 @@ namespace HotChocolate.Types
         IObjectFieldDescriptor Type<TOutputType>()
             where TOutputType : IOutputType;
 
+        IObjectFieldDescriptor Type<TOutputType>(TOutputType type)
+            where TOutputType : class, IOutputType;
+
         IObjectFieldDescriptor Type(ITypeNode type);
 
         IObjectFieldDescriptor Argument(NameString name,

--- a/src/Core/Types/Types/Descriptors/IObjectTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/IObjectTypeDescriptor.cs
@@ -45,6 +45,14 @@ namespace HotChocolate.Types
         /// Specifies an interface that is implemented by the
         /// <see cref="ObjectType"/>.
         /// </summary>
+        /// <typeparam name="T">The interface type.</typeparam>
+        IObjectTypeDescriptor Interface<T>(T type)
+            where T : InterfaceType;
+
+        /// <summary>
+        /// Specifies an interface that is implemented by the
+        /// <see cref="ObjectType"/>.
+        /// </summary>
         /// <param name="type">
         /// A syntax node representing an interface type.
         /// </param>
@@ -142,6 +150,15 @@ namespace HotChocolate.Types
         /// </summary>
         /// <typeparam name="T">The interface type.</typeparam>
         new IObjectTypeDescriptor<T> Interface<TInterface>()
+            where TInterface : InterfaceType;
+
+        /// <summary>
+        /// Specifies an interface that is implemented by the
+        /// <see cref="ObjectType"/>.
+        /// </summary>
+        /// <typeparam name="T">The interface type.</typeparam>
+        new IObjectTypeDescriptor<T> Interface<TInterface>(
+            TInterface type)
             where TInterface : InterfaceType;
 
         /// <summary>

--- a/src/Core/Types/Types/Descriptors/IUnionTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/IUnionTypeDescriptor.cs
@@ -14,6 +14,9 @@ namespace HotChocolate.Types
         IUnionTypeDescriptor Type<TObjectType>()
             where TObjectType : ObjectType;
 
+        IUnionTypeDescriptor Type<TObjectType>(TObjectType type)
+            where TObjectType : ObjectType;
+
         IUnionTypeDescriptor Type(NamedTypeNode objectType);
 
         IUnionTypeDescriptor ResolveAbstractType(

--- a/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -92,6 +92,13 @@ namespace HotChocolate.Types
             return this;
         }
 
+        IInterfaceFieldDescriptor IInterfaceFieldDescriptor.Type<TOutputType>(
+            TOutputType type)
+        {
+            Type<TOutputType>(type);
+            return this;
+        }
+
         IInterfaceFieldDescriptor IInterfaceFieldDescriptor.Type(ITypeNode type)
         {
             Type(type);

--- a/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -126,6 +126,13 @@ namespace HotChocolate.Types
             return this;
         }
 
+        IObjectFieldDescriptor IObjectFieldDescriptor.Type<TOutputType>(
+            TOutputType type)
+        {
+            Type<TOutputType>(type);
+            return this;
+        }
+
         IObjectFieldDescriptor IObjectFieldDescriptor.Type(ITypeNode type)
         {
             Type(type);

--- a/src/Core/Types/Types/Descriptors/ObjectFieldDescriptorBase.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectFieldDescriptorBase.cs
@@ -35,12 +35,24 @@ namespace HotChocolate.Types
             FieldDescription.Description = description;
         }
 
-        protected void Type<TOutputType>() where TOutputType : IOutputType
+        protected void Type<TOutputType>()
+            where TOutputType : IOutputType
         {
             FieldDescription.TypeReference = FieldDescription
                 .TypeReference.GetMoreSpecific(
                     typeof(TOutputType),
                     TypeContext.Output);
+        }
+
+        protected void Type<TOutputType>(TOutputType type)
+            where TOutputType : class, IOutputType
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            FieldDescription.TypeReference = new TypeReference(type);
         }
 
         protected void Type(ITypeNode type)

--- a/src/Core/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -102,7 +102,8 @@ namespace HotChocolate.Types
                 typeof(TInterface).GetOutputType());
         }
 
-        protected void Interface<TInterface>(InterfaceType type)
+        protected void Interface<TInterface>(TInterface type)
+            where TInterface : InterfaceType
         {
             if (type == null)
             {

--- a/src/Core/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -102,6 +102,16 @@ namespace HotChocolate.Types
                 typeof(TInterface).GetOutputType());
         }
 
+        protected void Interface<TInterface>(InterfaceType type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            ObjectDescription.Interfaces.Add(new TypeReference(type));
+        }
+
         protected void Interface(NamedTypeNode type)
         {
             if (type == null)
@@ -294,6 +304,13 @@ namespace HotChocolate.Types
             return this;
         }
 
+        IObjectTypeDescriptor IObjectTypeDescriptor.Interface<TInterface>(
+            TInterface type)
+        {
+            Interface<TInterface>();
+            return this;
+        }
+
         IObjectTypeDescriptor IObjectTypeDescriptor.Interface(
             NamedTypeNode type)
         {
@@ -437,6 +454,13 @@ namespace HotChocolate.Types
             .Interface<TInterface>()
         {
             Interface<TInterface>();
+            return this;
+        }
+
+        IObjectTypeDescriptor<T> IObjectTypeDescriptor<T>
+            .Interface<TInterface>(TInterface type)
+        {
+            Interface<TInterface>(type);
             return this;
         }
 

--- a/src/Core/Types/Types/Descriptors/UnionTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/UnionTypeDescriptor.cs
@@ -43,8 +43,20 @@ namespace HotChocolate.Types
         }
 
         public void Type<TObjectType>()
+            where TObjectType : ObjectType
         {
             UnionDescription.Types.Add(typeof(TObjectType).GetOutputType());
+        }
+
+        public void Type<TObjectType>(TObjectType type)
+            where TObjectType : ObjectType
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            UnionDescription.Types.Add(new TypeReference(type));
         }
 
         public void Type(NamedTypeNode objectType)
@@ -83,6 +95,13 @@ namespace HotChocolate.Types
         IUnionTypeDescriptor IUnionTypeDescriptor.Type<TObjectType>()
         {
             Type<TObjectType>();
+            return this;
+        }
+
+        IUnionTypeDescriptor IUnionTypeDescriptor.Type<TObjectType>(
+            TObjectType type)
+        {
+            Type<TObjectType>(type);
             return this;
         }
 

--- a/src/Core/Types/Types/DirectiveCollection.cs
+++ b/src/Core/Types/Types/DirectiveCollection.cs
@@ -50,7 +50,7 @@ namespace HotChocolate.Types
         private void CompleteDirective(
             ITypeInitializationContext context,
             DirectiveDescription description,
-            HashSet<string> processed)
+            ISet<string> processed)
         {
             DirectiveReference reference =
                 DirectiveReference.FromDescription(description);

--- a/src/Core/Types/Types/ObjectField.cs
+++ b/src/Core/Types/Types/ObjectField.cs
@@ -137,7 +137,7 @@ namespace HotChocolate.Types
         }
 
         private void AddExectableDirectives(
-            HashSet<string> processed,
+            ISet<string> processed,
             IEnumerable<IDirective> directives)
         {
             foreach (IDirective directive in

--- a/src/Core/Types/Types/ObjectType.cs
+++ b/src/Core/Types/Types/ObjectType.cs
@@ -100,8 +100,8 @@ namespace HotChocolate.Types
 
         private void CreateFieldsAndBindings(
             IEnumerable<ObjectFieldDescription> fieldDescriptions,
-            List<FieldBinding> fieldBindings,
-            List<ObjectField> fields)
+            ICollection<FieldBinding> fieldBindings,
+            ICollection<ObjectField> fields)
         {
             foreach (ObjectFieldDescription fieldDescription in
                 fieldDescriptions)

--- a/src/Core/Types/Types/Relay/ConnectionType.cs
+++ b/src/Core/Types/Types/Relay/ConnectionType.cs
@@ -1,17 +1,39 @@
-﻿namespace HotChocolate.Types.Relay
+﻿using System;
+using HotChocolate.Resolvers;
+using HotChocolate.Utilities;
+
+namespace HotChocolate.Types.Relay
 {
     public class ConnectionType<T>
         : ObjectType<IConnection>
         , IConnectionType
-        where T : INamedOutputType, new()
+        where T : IOutputType, new()
     {
+        private readonly Action<IObjectTypeDescriptor<IConnection>> _configure;
+
+        public ConnectionType()
+        {
+        }
+
+        public ConnectionType(
+            Action<IObjectTypeDescriptor<IConnection>> configure)
+        {
+            _configure = configure;
+        }
+
         public IEdgeType EdgeType { get; private set; }
 
         protected override void Configure(
             IObjectTypeDescriptor<IConnection> descriptor)
         {
-            // TODO : Fix this with the new schema builder
-            descriptor.Name($"{new T().Name}Connection");
+            if (!NamedTypeInfoFactory.Default.TryExtractName(
+                typeof(T), out NameString name))
+            {
+                throw new InvalidOperationException(
+                    $"Unable to extract a name from {typeof(T).FullName}.");
+            }
+
+            descriptor.Name(name + "Connection");
             descriptor.Description("A connection to a list of items.");
 
             descriptor.Field(t => t.PageInfo)
@@ -23,6 +45,8 @@
                 .Name("edges")
                 .Description("A list of edges.")
                 .Type<ListType<NonNullType<EdgeType<T>>>>();
+
+            _configure?.Invoke(descriptor);
         }
 
         protected override void OnRegisterDependencies(
@@ -41,6 +65,27 @@
                 new TypeReference(typeof(EdgeType<T>)));
 
             base.OnCompleteType(context);
+        }
+
+        public static ConnectionType<T> CreateWithTotalCount()
+        {
+            return new ConnectionType<T>(c => c
+                .Field("totalCount")
+                .Type<NonNullType<IntType>>()
+                .Resolver(ctx => GetTotalCount(ctx)));
+        }
+
+        private static IResolverResult<long> GetTotalCount(
+            IResolverContext context)
+        {
+            IConnection connection = context.Parent<IConnection>();
+            if (connection.PageInfo.TotalCount.HasValue)
+            {
+                return ResolverResult.CreateValue(
+                    connection.PageInfo.TotalCount.Value);
+            }
+            return ResolverResult.CreateError<long>(
+                "The total count was not provided by the connection.");
         }
     }
 }

--- a/src/Core/Types/Types/Relay/EdgeType.cs
+++ b/src/Core/Types/Types/Relay/EdgeType.cs
@@ -23,6 +23,8 @@ namespace HotChocolate.Types.Relay
             descriptor.Name(name + "Edge");
             descriptor.Description("An edge in a connection.");
 
+            descriptor.BindFields(BindingBehavior.Explicit);
+
             descriptor.Field(t => t.Cursor)
                 .Name("cursor")
                 .Description("A cursor for use in pagination.")

--- a/src/Core/Types/Types/Relay/EdgeType.cs
+++ b/src/Core/Types/Types/Relay/EdgeType.cs
@@ -1,17 +1,26 @@
-﻿namespace HotChocolate.Types.Relay
+﻿using System;
+using HotChocolate.Utilities;
+
+namespace HotChocolate.Types.Relay
 {
     public class EdgeType<T>
         : ObjectType<IEdge>
         , IEdgeType
-        where T : INamedOutputType, new()
+        where T : IOutputType, new()
     {
-        public INamedOutputType EntityType { get; private set; }
+        public IOutputType EntityType { get; private set; }
 
         protected override void Configure(
             IObjectTypeDescriptor<IEdge> descriptor)
         {
-            // TODO : Fix this with the new schema builder
-            descriptor.Name($"{new T().Name}Edge");
+            if (!NamedTypeInfoFactory.Default.TryExtractName(
+                typeof(T), out NameString name))
+            {
+                throw new InvalidOperationException(
+                    $"Unable to extract a name from {typeof(T).FullName}.");
+            }
+
+            descriptor.Name(name + "Edge");
             descriptor.Description("An edge in a connection.");
 
             descriptor.Field(t => t.Cursor)

--- a/src/Core/Types/Types/Relay/IEdgeType.cs
+++ b/src/Core/Types/Types/Relay/IEdgeType.cs
@@ -3,6 +3,6 @@
     public interface IEdgeType
         : IComplexOutputType
     {
-        INamedOutputType EntityType { get; }
+        IOutputType EntityType { get; }
     }
 }

--- a/src/Core/Types/Types/Relay/IPageInfo.cs
+++ b/src/Core/Types/Types/Relay/IPageInfo.cs
@@ -9,5 +9,7 @@
         string StartCursor { get; }
 
         string EndCursor { get; }
+
+        long? TotalCount { get; }
     }
 }

--- a/src/Core/Types/Types/Relay/ObjectFieldDescriptorExtensions.cs
+++ b/src/Core/Types/Types/Relay/ObjectFieldDescriptorExtensions.cs
@@ -4,11 +4,11 @@
     {
         public static IObjectFieldDescriptor UsePaging<TSchemaType, TClrType>(
             this IObjectFieldDescriptor descriptor)
-            where TSchemaType : INamedOutputType, new()
+            where TSchemaType : IOutputType, new()
         {
             return descriptor
                 .AddPagingArguments()
-                .Type<ConnectionType<TSchemaType>>()
+                .Type(ConnectionType<TSchemaType>.CreateWithTotalCount())
                 .Use<QueryableConnectionMiddleware<TClrType>>();
         }
 

--- a/src/Core/Types/Types/Relay/ObjectFieldDescriptorExtensions.cs
+++ b/src/Core/Types/Types/Relay/ObjectFieldDescriptorExtensions.cs
@@ -1,7 +1,28 @@
-﻿namespace HotChocolate.Types.Relay
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using HotChocolate.Utilities;
+
+namespace HotChocolate.Types.Relay
 {
     public static class ObjectFieldDescriptorExtensions
     {
+        private static MethodInfo _use =
+            typeof(MiddlewareObjectFieldDescriptorExtensions)
+            .GetTypeInfo().DeclaredMethods.First(t =>
+            {
+                if (t.Name.EqualsOrdinal(
+                    nameof(MiddlewareObjectFieldDescriptorExtensions.Use))
+                    && t.GetGenericArguments().Length == 1)
+                {
+                    ParameterInfo[] parameters = t.GetParameters();
+                    return (parameters.Length == 1
+                        && parameters[0].ParameterType ==
+                            typeof(IObjectFieldDescriptor));
+                }
+                return false;
+            });
+
         public static IObjectFieldDescriptor UsePaging<TSchemaType, TClrType>(
             this IObjectFieldDescriptor descriptor)
             where TSchemaType : IOutputType, new()
@@ -10,6 +31,26 @@
                 .AddPagingArguments()
                 .Type(ConnectionType<TSchemaType>.CreateWithTotalCount())
                 .Use<QueryableConnectionMiddleware<TClrType>>();
+        }
+
+        public static IObjectFieldDescriptor UsePaging<TSchemaType>(
+            this IObjectFieldDescriptor descriptor)
+            where TSchemaType : IOutputType, new()
+        {
+            descriptor
+                .AddPagingArguments()
+                .Type(ConnectionType<TSchemaType>.CreateWithTotalCount());
+
+            if (NamedTypeInfoFactory.Default.TryExtractClrType(
+                typeof(TSchemaType), out Type clrType))
+            {
+                Type middlewareType = typeof(QueryableConnectionMiddleware<>)
+                    .MakeGenericType(clrType);
+                _use.MakeGenericMethod(middlewareType)
+                    .Invoke(null, new object[] { descriptor });
+            }
+
+            return descriptor;
         }
 
         public static IObjectFieldDescriptor AddPagingArguments(

--- a/src/Core/Types/Types/Relay/PageInfo.cs
+++ b/src/Core/Types/Types/Relay/PageInfo.cs
@@ -5,12 +5,14 @@
     {
         public PageInfo(
             bool hasNextPage, bool hasPreviousPage,
-            string startCursor, string endCursor)
+            string startCursor, string endCursor,
+            long? totalCount)
         {
             HasNextPage = hasNextPage;
             HasPreviousPage = hasPreviousPage;
             StartCursor = startCursor;
             EndCursor = endCursor;
+            TotalCount = totalCount;
         }
 
         public bool HasNextPage { get; }
@@ -20,5 +22,7 @@
         public string StartCursor { get; }
 
         public string EndCursor { get; }
+
+        public long? TotalCount { get; }
     }
 }

--- a/src/Core/Types/Types/Relay/PageInfoType.cs
+++ b/src/Core/Types/Types/Relay/PageInfoType.cs
@@ -10,6 +10,8 @@
             descriptor.Description(
                 "Information about pagination in a connection.");
 
+            descriptor.BindFields(BindingBehavior.Explicit);
+
             descriptor.Field(t => t.HasNextPage)
                 .Type<NonNullType<BooleanType>>()
                 .Name("hasNextPage")

--- a/src/Core/Types/Types/Relay/QueryableConnectionResolver.cs
+++ b/src/Core/Types/Types/Relay/QueryableConnectionResolver.cs
@@ -49,7 +49,7 @@ namespace HotChocolate.Types.Relay
         {
             if (!_pageDetails.TotalCount.HasValue)
             {
-                _pageDetails.TotalCount = _source.Count();
+                _pageDetails.TotalCount = _source.LongCount();
             }
 
             _properties[_totalCount] = _pageDetails.TotalCount.Value;
@@ -63,7 +63,8 @@ namespace HotChocolate.Types.Relay
                 lastEdge?.Index < (_pageDetails.TotalCount.Value - 1),
                 firstEdge?.Index > 0,
                 selectedEdges.FirstOrDefault()?.Cursor,
-                selectedEdges.LastOrDefault()?.Cursor);
+                selectedEdges.LastOrDefault()?.Cursor,
+                _pageDetails.TotalCount);
 
             return new Connection<T>(pageInfo, selectedEdges);
         }
@@ -230,7 +231,7 @@ namespace HotChocolate.Types.Relay
 
         protected class QueryablePagingDetails
         {
-            public int? TotalCount { get; set; }
+            public long? TotalCount { get; set; }
             public int? Before { get; set; }
             public int? After { get; set; }
             public int? First { get; set; }

--- a/src/Core/Types/Types/Relay/QueryableConnectionResolver.cs
+++ b/src/Core/Types/Types/Relay/QueryableConnectionResolver.cs
@@ -194,7 +194,7 @@ namespace HotChocolate.Types.Relay
         }
 
         private static int? GetPositionFromCurser(
-            Dictionary<string, object> properties)
+            IDictionary<string, object> properties)
         {
             if (properties == null)
             {
@@ -205,7 +205,7 @@ namespace HotChocolate.Types.Relay
         }
 
         private static int? GetTotalCountFromCursor(
-            Dictionary<string, object> properties)
+            IDictionary<string, object> properties)
         {
             if (properties == null)
             {

--- a/src/Core/Types/Types/TypeContext.cs
+++ b/src/Core/Types/Types/TypeContext.cs
@@ -2,6 +2,7 @@
 {
     public enum TypeContext
     {
+        None,
         Output,
         Input
     }

--- a/src/Core/Types/Types/TypeReference.cs
+++ b/src/Core/Types/Types/TypeReference.cs
@@ -25,9 +25,18 @@ namespace HotChocolate.Types
             Context = context;
         }
 
+        public TypeReference(IType schemaType)
+        {
+            SchemaType = schemaType
+                ?? throw new ArgumentNullException(nameof(schemaType));
+            Context = TypeContext.None;
+        }
+
         public TypeContext Context { get; }
 
         public Type ClrType { get; }
+
+        public IType SchemaType { get; }
 
         public ITypeNode Type { get; }
 
@@ -87,9 +96,21 @@ namespace HotChocolate.Types
             return typeReference.ClrType != null;
         }
 
+        public static bool IsSchemaTypeReference(
+            this TypeReference typeReference)
+        {
+            return typeReference.SchemaType != null;
+        }
+
         public static bool IsTypeMoreSpecific(
             this TypeReference typeReference, Type type)
         {
+            if (typeReference != null
+                && typeReference.IsSchemaTypeReference())
+            {
+                return false;
+            }
+
             if (typeReference == null
                 || BaseTypes.IsSchemaType(type))
             {
@@ -108,6 +129,12 @@ namespace HotChocolate.Types
         public static bool IsTypeMoreSpecific(
            this TypeReference typeReference, ITypeNode typeNode)
         {
+            if (typeReference != null
+                && typeReference.IsSchemaTypeReference())
+            {
+                return false;
+            }
+
             return typeNode != null
                 && (typeReference == null
                     || !typeReference.IsClrTypeReference());

--- a/src/Core/Types/Utilities/NamedTypeInfoFactory.cs
+++ b/src/Core/Types/Utilities/NamedTypeInfoFactory.cs
@@ -48,6 +48,25 @@ namespace HotChocolate.Utilities
             return false;
         }
 
+        public bool TryExtractClrType(Type type, out Type clrType)
+        {
+            if (TryCreate(type, out TypeInfo typeInfo))
+            {
+                ConstructorInfo constructor = typeInfo.ClrType.GetTypeInfo()
+                    .DeclaredConstructors
+                    .FirstOrDefault(c => !c.GetParameters().Any());
+
+                if (constructor?.Invoke(Array.Empty<object>()) is IHasClrType t)
+                {
+                    clrType = t.ClrType;
+                    return true;
+                }
+            }
+
+            clrType = default;
+            return false;
+        }
+
         private static List<Type> DecomposeType(Type type)
         {
             List<Type> components = new List<Type>();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added optional totalCount field to the connection type
- UsePaging can now be used without specifying the clr type
- The edge node type can now be any output type including list
- Support for dynamic generated schema types

Addresses #525 