### PR TITLE
Fixed: Resolver NullReferenceExceptions

### DIFF
--- a/src/Core/Core.Tests/Integration/DataLoader/DataLoaderTests.cs
+++ b/src/Core/Core.Tests/Integration/DataLoader/DataLoaderTests.cs
@@ -138,7 +138,7 @@ namespace HotChocolate.Integration.DataLoader
                     c.BindResolver(async ctx =>
                     {
                         IDataLoader<string, string[]> dataLoader =
-                            ctx.GroupedDataLoader<string, string>(
+                            ctx.GroupDataLoader<string, string>(
                                 "fetchItems",
                                 keys =>
                                 Task.FromResult(keys.ToLookup(t => t)));

--- a/src/Core/Types/Configuration/ResolverRegistry.cs
+++ b/src/Core/Types/Configuration/ResolverRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using HotChocolate.Resolvers;
 using HotChocolate.Resolvers.CodeGeneration;
 
@@ -223,8 +224,10 @@ namespace HotChocolate.Configuration
             {
                 if (!ctx.IsResultModified && fieldResolver != null)
                 {
-                    ctx.Result = await fieldResolver.Invoke(ctx)
-                        .ConfigureAwait(false);
+                    Task<object> task = fieldResolver.Invoke(ctx);
+                    ctx.Result = task == null
+                        ? null
+                        : await task.ConfigureAwait(false);
                 }
             };
         }

--- a/src/Core/Types/DataLoader/DataLoaderRegistryExtensions.cs
+++ b/src/Core/Types/DataLoader/DataLoaderRegistryExtensions.cs
@@ -9,7 +9,7 @@ namespace HotChocolate.DataLoader
         public static bool Register<TKey, TValue>(
             this IDataLoaderRegistry registry,
             string key,
-            FetchFactory<TKey, TValue> factory)
+            FetchBatchFactory<TKey, TValue> factory)
         {
             if (string.IsNullOrEmpty(key))
             {
@@ -32,7 +32,7 @@ namespace HotChocolate.DataLoader
         public static bool Register<TKey, TValue>(
             this IDataLoaderRegistry registry,
             string key,
-            Fetch<TKey, TValue> fetch)
+            FetchBatch<TKey, TValue> fetch)
         {
             if (string.IsNullOrEmpty(key))
             {
@@ -54,7 +54,7 @@ namespace HotChocolate.DataLoader
         public static bool Register<TKey, TValue>(
             this IDataLoaderRegistry registry,
             string key,
-            FetchGroupedFactory<TKey, TValue> factory)
+            FetchGroupeFactory<TKey, TValue> factory)
         {
             if (string.IsNullOrEmpty(key))
             {
@@ -77,7 +77,7 @@ namespace HotChocolate.DataLoader
         public static bool Register<TKey, TValue>(
             this IDataLoaderRegistry registry,
             string key,
-            FetchGrouped<TKey, TValue> fetch)
+            FetchGroupe<TKey, TValue> fetch)
         {
             if (string.IsNullOrEmpty(key))
             {
@@ -99,7 +99,7 @@ namespace HotChocolate.DataLoader
         public static bool Register<TKey, TValue>(
             this IDataLoaderRegistry registry,
             string key,
-            FetchSingleFactory<TKey, TValue> factory)
+            FetchCacheFactory<TKey, TValue> factory)
         {
             if (string.IsNullOrEmpty(key))
             {
@@ -122,7 +122,7 @@ namespace HotChocolate.DataLoader
         public static bool Register<TKey, TValue>(
             this IDataLoaderRegistry registry,
             string key,
-            FetchSingle<TKey, TValue> fetch)
+            FetchCache<TKey, TValue> fetch)
         {
             if (string.IsNullOrEmpty(key))
             {

--- a/src/Core/Types/DataLoader/DataLoaderResolverContextExtensions.cs
+++ b/src/Core/Types/DataLoader/DataLoaderResolverContextExtensions.cs
@@ -89,7 +89,7 @@ namespace HotChocolate.Resolvers
         }
 
         public static IDataLoader<TKey, TValue[]>
-            GroupedDataLoader<TKey, TValue>(
+            GroupDataLoader<TKey, TValue>(
                 this IResolverContext context,
                 string key,
                 FetchGrouped<TKey, TValue> fetch)

--- a/src/Core/Types/DataLoader/DataLoaderResolverContextExtensions.cs
+++ b/src/Core/Types/DataLoader/DataLoaderResolverContextExtensions.cs
@@ -9,24 +9,12 @@ namespace HotChocolate.Resolvers
 {
     public static class DataLoaderResolverContextExtensions
     {
-        private static IDataLoader<TKey, TValue> DataLoader<TKey, TValue>(
-            this IResolverContext context,
-            string key,
-            FetchFactory<TKey, TValue> factory)
+        private static IDataLoader<TKey, TValue>
+            BatchDataLoaderFactory<TKey, TValue>(
+                this IResolverContext context,
+                string key,
+                FetchBatchFactory<TKey, TValue> factory)
         {
-            if (string.IsNullOrEmpty(key))
-            {
-                // TODO : resources
-                throw new ArgumentException(
-                    "The DataLoader key cannot be null or empty.",
-                    nameof(key));
-            }
-
-            if (factory == null)
-            {
-                throw new ArgumentNullException(nameof(factory));
-            }
-
             if (TryGetDataLoader(context, key,
                 out IDataLoader<TKey, TValue> dataLoader,
                 out IDataLoaderRegistry registry))
@@ -41,8 +29,13 @@ namespace HotChocolate.Resolvers
         public static IDataLoader<TKey, TValue> BatchDataLoader<TKey, TValue>(
             this IResolverContext context,
             string key,
-            Fetch<TKey, TValue> fetch)
+            FetchBatch<TKey, TValue> fetch)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (string.IsNullOrEmpty(key))
             {
                 // TODO : resources
@@ -56,14 +49,19 @@ namespace HotChocolate.Resolvers
                 throw new ArgumentNullException(nameof(fetch));
             }
 
-            return DataLoader(context, key, services => fetch);
+            return BatchDataLoaderFactory(context, key, services => fetch);
         }
 
-        private static IDataLoader<TKey, TValue[]> DataLoader<TKey, TValue>(
+        public static IDataLoader<TKey, TValue> BatchDataLoader<TKey, TValue>(
             this IResolverContext context,
             string key,
-            FetchGroupedFactory<TKey, TValue> factory)
+            FetchBatchCt<TKey, TValue> fetch)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (string.IsNullOrEmpty(key))
             {
                 // TODO : resources
@@ -72,11 +70,23 @@ namespace HotChocolate.Resolvers
                     nameof(key));
             }
 
-            if (factory == null)
+            if (fetch == null)
             {
-                throw new ArgumentNullException(nameof(factory));
+                throw new ArgumentNullException(nameof(fetch));
             }
 
+            return BatchDataLoader<TKey, TValue>(
+                context,
+                key,
+                keys => fetch(keys, context.RequestAborted));
+        }
+
+        private static IDataLoader<TKey, TValue[]>
+            GroupDataLoaderFactory<TKey, TValue>(
+                this IResolverContext context,
+                string key,
+                FetchGroupeFactory<TKey, TValue> factory)
+        {
             if (TryGetDataLoader(context, key,
                 out IDataLoader<TKey, TValue[]> dataLoader,
                 out IDataLoaderRegistry registry))
@@ -92,8 +102,13 @@ namespace HotChocolate.Resolvers
             GroupDataLoader<TKey, TValue>(
                 this IResolverContext context,
                 string key,
-                FetchGrouped<TKey, TValue> fetch)
+                FetchGroupe<TKey, TValue> fetch)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (string.IsNullOrEmpty(key))
             {
                 // TODO : resources
@@ -107,14 +122,20 @@ namespace HotChocolate.Resolvers
                 throw new ArgumentNullException(nameof(fetch));
             }
 
-            return DataLoader(context, key, services => fetch);
+            return GroupDataLoaderFactory(context, key, services => fetch);
         }
 
-        private static IDataLoader<TKey, TValue> DataLoader<TKey, TValue>(
-            this IResolverContext context,
-            string key,
-            FetchSingleFactory<TKey, TValue> factory)
+        public static IDataLoader<TKey, TValue[]>
+            GroupDataLoader<TKey, TValue>(
+                this IResolverContext context,
+                string key,
+                FetchGroupeCt<TKey, TValue> fetch)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (string.IsNullOrEmpty(key))
             {
                 // TODO : resources
@@ -123,11 +144,23 @@ namespace HotChocolate.Resolvers
                     nameof(key));
             }
 
-            if (factory == null)
+            if (fetch == null)
             {
-                throw new ArgumentNullException(nameof(factory));
+                throw new ArgumentNullException(nameof(fetch));
             }
 
+            return GroupDataLoader<TKey, TValue>(
+                context,
+                key,
+                keys => fetch(keys, context.RequestAborted));
+        }
+
+        private static IDataLoader<TKey, TValue>
+            CacheDataLoaderFactory<TKey, TValue>(
+                this IResolverContext context,
+                string key,
+                FetchCacheFactory<TKey, TValue> factory)
+        {
             if (TryGetDataLoader(context, key,
                 out IDataLoader<TKey, TValue> dataLoader,
                 out IDataLoaderRegistry registry))
@@ -142,8 +175,13 @@ namespace HotChocolate.Resolvers
         public static IDataLoader<TKey, TValue> CacheDataLoader<TKey, TValue>(
             this IResolverContext context,
             string key,
-            FetchSingle<TKey, TValue> fetch)
+            FetchCache<TKey, TValue> fetch)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (string.IsNullOrEmpty(key))
             {
                 // TODO : resources
@@ -157,14 +195,19 @@ namespace HotChocolate.Resolvers
                 throw new ArgumentNullException(nameof(fetch));
             }
 
-            return DataLoader(context, key, services => fetch);
+            return CacheDataLoaderFactory(context, key, services => fetch);
         }
 
-        private static Func<Task<TValue>> DataLoader<TValue>(
+        public static IDataLoader<TKey, TValue> CacheDataLoader<TKey, TValue>(
             this IResolverContext context,
             string key,
-            FetchOnceFactory<TValue> factory)
+            FetchCacheCt<TKey, TValue> fetch)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (string.IsNullOrEmpty(key))
             {
                 // TODO : resources
@@ -173,11 +216,22 @@ namespace HotChocolate.Resolvers
                     nameof(key));
             }
 
-            if (factory == null)
+            if (fetch == null)
             {
-                throw new ArgumentNullException(nameof(factory));
+                throw new ArgumentNullException(nameof(fetch));
             }
 
+            return CacheDataLoader<TKey, TValue>(
+                context,
+                key,
+                keys => fetch(keys, context.RequestAborted));
+        }
+
+        private static Func<Task<TValue>> FetchOnceFactory<TValue>(
+            this IResolverContext context,
+            string key,
+            FetchOnceFactory<TValue> factory)
+        {
             if (!TryGetDataLoader(context, key,
                 out IDataLoader<string, TValue> dataLoader,
                 out IDataLoaderRegistry registry))
@@ -194,6 +248,11 @@ namespace HotChocolate.Resolvers
             string key,
             FetchOnce<TValue> fetch)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (string.IsNullOrEmpty(key))
             {
                 // TODO : resources
@@ -207,7 +266,36 @@ namespace HotChocolate.Resolvers
                 throw new ArgumentNullException(nameof(fetch));
             }
 
-            return DataLoader(context, key, services => fetch)();
+            return FetchOnceFactory(context, key, services => fetch)();
+        }
+
+        public static Task<TValue> FetchOnceAsync<TValue>(
+            this IResolverContext context,
+            string key,
+            FetchOnceCt<TValue> fetch)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (string.IsNullOrEmpty(key))
+            {
+                // TODO : resources
+                throw new ArgumentException(
+                    "The DataLoader key cannot be null or empty.",
+                    nameof(key));
+            }
+
+            if (fetch == null)
+            {
+                throw new ArgumentNullException(nameof(fetch));
+            }
+
+            return FetchOnceAsync(
+                context,
+                key,
+                () => fetch(context.RequestAborted));
         }
 
         public static T DataLoader<T>(
@@ -215,6 +303,11 @@ namespace HotChocolate.Resolvers
             string key)
             where T : class, IDataLoader
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (string.IsNullOrEmpty(key))
             {
                 // TODO : resources

--- a/src/Core/Types/DataLoader/FetchDataLoader.cs
+++ b/src/Core/Types/DataLoader/FetchDataLoader.cs
@@ -9,9 +9,9 @@ namespace HotChocolate.DataLoader
     internal sealed class FetchDataLoader<TKey, TValue>
         : DataLoaderBase<TKey, TValue>
     {
-        private readonly Fetch<TKey, TValue> _fetch;
+        private readonly FetchBatch<TKey, TValue> _fetch;
 
-        public FetchDataLoader(Fetch<TKey, TValue> fetch)
+        public FetchDataLoader(FetchBatch<TKey, TValue> fetch)
             : base(new DataLoaderOptions<TKey>
             {
                 AutoDispatching = false,

--- a/src/Core/Types/DataLoader/FetchGroupedDataLoader.cs
+++ b/src/Core/Types/DataLoader/FetchGroupedDataLoader.cs
@@ -10,9 +10,9 @@ namespace HotChocolate.DataLoader
     internal sealed class FetchGroupedDataLoader<TKey, TValue>
         : DataLoaderBase<TKey, TValue[]>
     {
-        private readonly FetchGrouped<TKey, TValue> _fetch;
+        private readonly FetchGroupe<TKey, TValue> _fetch;
 
-        public FetchGroupedDataLoader(FetchGrouped<TKey, TValue> fetch)
+        public FetchGroupedDataLoader(FetchGroupe<TKey, TValue> fetch)
             : base(new DataLoaderOptions<TKey>
             {
                 AutoDispatching = false,

--- a/src/Core/Types/DataLoader/FetchSingleDataLoader.cs
+++ b/src/Core/Types/DataLoader/FetchSingleDataLoader.cs
@@ -9,15 +9,15 @@ namespace HotChocolate.DataLoader
     internal sealed class FetchSingleDataLoader<TKey, TValue>
         : DataLoaderBase<TKey, TValue>
     {
-        private readonly FetchSingle<TKey, TValue> _fetch;
+        private readonly FetchCache<TKey, TValue> _fetch;
 
-        public FetchSingleDataLoader(FetchSingle<TKey, TValue> fetch)
+        public FetchSingleDataLoader(FetchCache<TKey, TValue> fetch)
             : this(fetch, DataLoaderDefaults.CacheSize)
         {
         }
 
         public FetchSingleDataLoader(
-            FetchSingle<TKey, TValue> fetch,
+            FetchCache<TKey, TValue> fetch,
             int cacheSize)
             : base(new DataLoaderOptions<TKey>
             {

--- a/src/Core/Types/DataLoader/IDataLoaderRegistry.cs
+++ b/src/Core/Types/DataLoader/IDataLoaderRegistry.cs
@@ -1,32 +1,49 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GreenDonut;
 
 namespace HotChocolate.DataLoader
 {
-    public delegate Fetch<TKey, TValue> FetchFactory<TKey, TValue>(
+    public delegate FetchBatch<TKey, TValue> FetchBatchFactory<TKey, TValue>(
         IServiceProvider services);
 
-    public delegate Task<IReadOnlyDictionary<TKey, TValue>> Fetch<TKey, TValue>(
+    public delegate Task<IReadOnlyDictionary<TKey, TValue>>
+        FetchBatch<TKey, TValue>(IReadOnlyList<TKey> keys);
+
+    public delegate Task<IReadOnlyDictionary<TKey, TValue>>
+        FetchBatchCt<TKey, TValue>(
+            IReadOnlyList<TKey> keys,
+            CancellationToken cancellationToken);
+
+    public delegate FetchGroupe<TKey, TValue> FetchGroupeFactory<TKey, TValue>(
+        IServiceProvider services);
+
+    public delegate Task<ILookup<TKey, TValue>> FetchGroupe<TKey, TValue>(
         IReadOnlyList<TKey> keys);
 
-    public delegate FetchGrouped<TKey, TValue> FetchGroupedFactory<TKey, TValue>(
+    public delegate Task<ILookup<TKey, TValue>> FetchGroupeCt<TKey, TValue>(
+        IReadOnlyList<TKey> keys,
+        CancellationToken cancellationToken);
+
+    public delegate FetchCache<TKey, TValue> FetchCacheFactory<TKey, TValue>(
         IServiceProvider services);
 
-    public delegate Task<ILookup<TKey, TValue>> FetchGrouped<TKey, TValue>(
-        IReadOnlyList<TKey> keys);
+    public delegate Task<TValue> FetchCache<TKey, TValue>(TKey key);
 
-    public delegate FetchSingle<TKey, TValue> FetchSingleFactory<TKey, TValue>(
-        IServiceProvider services);
-
-    public delegate Task<TValue> FetchSingle<TKey, TValue>(TKey key);
+    public delegate Task<TValue> FetchCacheCt<TKey, TValue>(
+        TKey key,
+        CancellationToken cancellationToken);
 
     public delegate FetchOnce<TValue> FetchOnceFactory<TValue>(
         IServiceProvider services);
 
     public delegate Task<TValue> FetchOnce<TValue>();
+
+    public delegate Task<TValue> FetchOnceCt<TValue>(
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// The DataLoader-registry holds the instances of DataLoders

--- a/src/Stitching/Stitching/Extensions/StitchingServiceCollectionExtensions.cs
+++ b/src/Stitching/Stitching/Extensions/StitchingServiceCollectionExtensions.cs
@@ -143,14 +143,21 @@ namespace HotChocolate
                 throw new ArgumentNullException(nameof(configure));
             }
 
-            return services.AddSingleton(Schema.Create(
+            services.AddSingleton<
+                IQueryResultSerializer,
+                JsonQueryResultSerializer>();
+
+            IQueryExecutor executor = Schema.Create(
                 schema,
                 c =>
                 {
                     configure(c);
                     c.UseSchemaStitching();
                 })
-                .MakeExecutable(b => b.UseStitchingPipeline()));
+                .MakeExecutable(b => b.UseStitchingPipeline());
+
+            return services.AddSingleton(executor)
+                .AddSingleton(executor.Schema);
         }
     }
 }


### PR DESCRIPTION
In certain cases a `NullReferenceException` could occur in the field resolver middleware.

- Fixed `NullReferenceException` issues
- Fixed GroupDataLoader name

Fixes #573 #572
