### PR TITLE
Fixed: options on stitched schema are now passed

### DIFF
--- a/src/Stitching/Stitching/Extensions/StitchingServiceCollectionExtensions.cs
+++ b/src/Stitching/Stitching/Extensions/StitchingServiceCollectionExtensions.cs
@@ -164,7 +164,7 @@ namespace HotChocolate
                     configure(c);
                     c.UseSchemaStitching();
                 })
-                .MakeExecutable(b => b.UseStitchingPipeline());
+                .MakeExecutable(b => b.UseStitchingPipeline(options));
 
             return services.AddSingleton(executor)
                 .AddSingleton(executor.Schema);


### PR DESCRIPTION
The execution options on AddStitchedSchema were not passed to the pipeline 