### PR TITLE
Exception was not added to the initial error object when IncludeExceptionDetails was false.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Custom diagnostic observer registration issue [#629](https://github.com/ChilliCream/hotchocolate/issues/629).
-- Authorization argument coercion is now fixed. https://github.com/ChilliCream/hotchocolate/issues/624
+- Authorization argument coercion is now fixed. [#624](https://github.com/ChilliCream/hotchocolate/issues/624)
 - The request path is now compared correctly.
+- IErrorFilter is not given the exception unless IncludeExceptionDetails is enabled. [#637](https://github.com/ChilliCream/hotchocolate/issues/638)
 
 ## [0.8.0] - 2019-03-03
 

--- a/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs
+++ b/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs
@@ -21,7 +21,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -37,7 +38,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -53,7 +55,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -69,7 +72,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -84,7 +88,8 @@ namespace HotChocolate.Execution
 
             // assert
             Assert.NotNull(result.Errors);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -100,7 +105,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -116,7 +122,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -132,7 +139,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -148,7 +156,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -164,7 +173,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -180,7 +190,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -196,7 +207,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -212,7 +224,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -228,7 +241,8 @@ namespace HotChocolate.Execution
             // assert
             Assert.NotNull(result.Errors);
             Assert.Equal(1, i);
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -246,7 +260,8 @@ namespace HotChocolate.Execution
             IExecutionResult result = await executor.ExecuteAsync(query);
 
             // assert
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -264,7 +279,8 @@ namespace HotChocolate.Execution
             IExecutionResult result = await executor.ExecuteAsync(query);
 
             // assert
-            result.MatchSnapshot();
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
         }
 
         private async Task<IExecutionResult> ExecuteQuery(

--- a/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs
+++ b/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using HotChocolate.Execution.Configuration;
 using HotChocolate.Types;
 using Snapshooter.Xunit;
 using Xunit;

--- a/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs
+++ b/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs
@@ -299,7 +299,10 @@ namespace HotChocolate.Execution
                     }
                     return error;
                 })
-                .UseDefaultPipeline());
+                .UseDefaultPipeline(new QueryExecutionOptions
+                {
+                    IncludeExceptionDetails = false
+                }));
 
             // act
             IExecutionResult result = await executor.ExecuteAsync(query);

--- a/src/Core/Core.Tests/Execution/Errors/ErrorHandlerTests.cs
+++ b/src/Core/Core.Tests/Execution/Errors/ErrorHandlerTests.cs
@@ -33,7 +33,8 @@ namespace HotChocolate.Execution.Errors
             IExecutionResult result = await executor.ExecuteAsync("{ foo }");
 
             // assert
-            result.MatchSnapshot();
+            result.MatchSnapshot(o =>
+                o.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -81,7 +82,8 @@ namespace HotChocolate.Execution.Errors
                 await executor.ExecuteAsync("{ foo bar }");
 
             // assert
-            result.MatchSnapshot();
+            result.MatchSnapshot(o =>
+                o.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -108,7 +110,8 @@ namespace HotChocolate.Execution.Errors
             IExecutionResult result = await executor.ExecuteAsync("{ foo }");
 
             // assert
-            result.MatchSnapshot();
+            result.MatchSnapshot(o =>
+                o.IgnoreField("Errors[0].Exception"));
         }
 
         [Fact]
@@ -135,7 +138,8 @@ namespace HotChocolate.Execution.Errors
             IExecutionResult result = await executor.ExecuteAsync("{ foo }");
 
             // assert
-            result.MatchSnapshot();
+            result.MatchSnapshot(o =>
+                o.IgnoreField("Errors[0].Exception"));
         }
 
         public class DummyErrorFilter

--- a/src/Core/Core.Tests/Execution/Errors/ErrorHandlerTests.cs
+++ b/src/Core/Core.Tests/Execution/Errors/ErrorHandlerTests.cs
@@ -83,7 +83,8 @@ namespace HotChocolate.Execution.Errors
 
             // assert
             result.MatchSnapshot(o =>
-                o.IgnoreField("Errors[0].Exception"));
+                o.IgnoreField("Errors[0].Exception")
+                .IgnoreField("Errors[1].Exception"));
         }
 
         [Fact]

--- a/src/Core/Core.Tests/Execution/Errors/__snapshots__/ErrorBehaviourTests.ErrorFilterHandlesException.snap
+++ b/src/Core/Core.Tests/Execution/Errors/__snapshots__/ErrorBehaviourTests.ErrorFilterHandlesException.snap
@@ -1,0 +1,37 @@
+{
+  "Data": {
+    "error14": null
+  },
+  "Extensions": {},
+  "Errors": [
+    {
+      "Message": "Value cannot be null.\nParameter name: Error14",
+      "Code": null,
+      "Path": [
+        "error14"
+      ],
+      "Locations": [
+        {
+          "line": 1,
+          "column": 3
+        }
+      ],
+      "Exception": {
+        "ClassName": "System.ArgumentNullException",
+        "Message": "Value cannot be null.",
+        "Data": null,
+        "InnerException": null,
+        "HelpURL": null,
+        "StackTraceString": "   at HotChocolate.Execution.ErrorBehaviourTests.Query.get_Error14() in /Users/michael/local/hotchocolate/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs:line 407\n   at HotChocolate.Resolvers.CodeGeneration.___CompiledResolvers__efe4cc33f3b646969dac4dc67c8e4ce8.<>c.<.cctor>b__32_24(IResolverContext ctx)\n   at HotChocolate.Configuration.ResolverRegistry.<>c__DisplayClass21_0.<<CreateResolverMiddleware>b__0>d.MoveNext() in /Users/michael/local/hotchocolate/src/Core/Types/Configuration/ResolverRegistry.cs:line 227\n--- End of stack trace from previous location where exception was thrown ---\n   at HotChocolate.Execution.ExecutionStrategyBase.ExecuteFieldMiddlewareAsync(ResolverTask resolverTask) in /Users/michael/local/hotchocolate/src/Core/Core/Execution/ExecutionStrategyBase.Resolver.cs:line 91\n   at HotChocolate.Execution.ExecutionStrategyBase.ExecuteMiddlewareAsync(ResolverTask resolverTask, IErrorHandler errorHandler) in /Users/michael/local/hotchocolate/src/Core/Core/Execution/ExecutionStrategyBase.Resolver.cs:line 51",
+        "RemoteStackTraceString": null,
+        "RemoteStackIndex": 0,
+        "ExceptionMethod": null,
+        "HResult": -2147467261,
+        "Source": "HotChocolate.Core.Tests",
+        "WatsonBuckets": null,
+        "ParamName": "Error14"
+      },
+      "Extensions": {}
+    }
+  ]
+}

--- a/src/Core/Core.Tests/Execution/Errors/__snapshots__/ErrorHandlerTests.FilterOnlyNullRefExceptions.snap
+++ b/src/Core/Core.Tests/Execution/Errors/__snapshots__/ErrorHandlerTests.FilterOnlyNullRefExceptions.snap
@@ -17,12 +17,25 @@
           "column": 3
         }
       ],
-      "Exception": null,
+      "Exception": {
+        "ClassName": "System.Exception",
+        "Message": "Foo",
+        "Data": null,
+        "InnerException": null,
+        "HelpURL": null,
+        "StackTraceString": "   at HotChocolate.Execution.Errors.ErrorHandlerTests.<>c.<FilterOnlyNullRefExceptions>b__1_3(IResolverContext ctx) in /Users/michael/local/hotchocolate/src/Core/Core.Tests/Execution/Errors/ErrorHandlerTests.cs:line 52\n   at HotChocolate.Configuration.ResolverRegistry.<>c__DisplayClass21_0.<<CreateResolverMiddleware>b__0>d.MoveNext()\n--- End of stack trace from previous location where exception was thrown ---\n   at HotChocolate.Execution.ExecutionStrategyBase.ExecuteFieldMiddlewareAsync(ResolverTask resolverTask)\n   at HotChocolate.Execution.ExecutionStrategyBase.ExecuteMiddlewareAsync(ResolverTask resolverTask, IErrorHandler errorHandler)",
+        "RemoteStackTraceString": null,
+        "RemoteStackIndex": 0,
+        "ExceptionMethod": null,
+        "HResult": -2146233088,
+        "Source": "HotChocolate.Core.Tests",
+        "WatsonBuckets": null
+      },
       "Extensions": {}
     },
     {
       "Message": "Unexpected Execution Error",
-      "Code": null,
+      "Code": "NullRef",
       "Path": [
         "bar"
       ],
@@ -32,8 +45,23 @@
           "column": 7
         }
       ],
-      "Exception": null,
-      "Extensions": {}
+      "Exception": {
+        "ClassName": "System.NullReferenceException",
+        "Message": "Foo",
+        "Data": null,
+        "InnerException": null,
+        "HelpURL": null,
+        "StackTraceString": "   at HotChocolate.Execution.Errors.ErrorHandlerTests.<>c.<FilterOnlyNullRefExceptions>b__1_4(IResolverContext ctx) in /Users/michael/local/hotchocolate/src/Core/Core.Tests/Execution/Errors/ErrorHandlerTests.cs:line 59\n   at HotChocolate.Configuration.ResolverRegistry.<>c__DisplayClass21_0.<<CreateResolverMiddleware>b__0>d.MoveNext()\n--- End of stack trace from previous location where exception was thrown ---\n   at HotChocolate.Execution.ExecutionStrategyBase.ExecuteFieldMiddlewareAsync(ResolverTask resolverTask)\n   at HotChocolate.Execution.ExecutionStrategyBase.ExecuteMiddlewareAsync(ResolverTask resolverTask, IErrorHandler errorHandler)",
+        "RemoteStackTraceString": null,
+        "RemoteStackIndex": 0,
+        "ExceptionMethod": null,
+        "HResult": -2147467261,
+        "Source": "HotChocolate.Core.Tests",
+        "WatsonBuckets": null
+      },
+      "Extensions": {
+        "code": "NullRef"
+      }
     }
   ]
 }

--- a/src/Core/Core/Execution/Errors/ErrorHandler.cs
+++ b/src/Core/Core/Execution/Errors/ErrorHandler.cs
@@ -72,8 +72,6 @@ namespace HotChocolate.Execution
                 throw new ArgumentNullException(nameof(configure));
             }
 
-
-
             IErrorBuilder builder = CreateErrorFromException(exception);
             configure(builder);
 
@@ -96,11 +94,12 @@ namespace HotChocolate.Execution
         private IErrorBuilder CreateErrorFromException(Exception exception)
         {
             IErrorBuilder builder = ErrorBuilder.New()
-                .SetMessage("Unexpected Execution Error");
+                .SetMessage("Unexpected Execution Error")
+                .SetException(exception);
 
             if (_includeExceptionDetails)
             {
-                builder.SetException(exception)
+                builder
                     .SetExtension("message", exception.Message)
                     .SetExtension("stackTrace", exception.StackTrace);
             }


### PR DESCRIPTION
Fixes #636.