### PR TITLE
Stitching Introspection Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.8.1] - 2019-03-29
+
+### Added
+
 - Added operation start/stop event.
 - Added error filter support for schema stitching.
 
@@ -31,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Non-nullable types are now validated when query uses variables. [#651](https://github.com/ChilliCream/hotchocolate/issues/651)
 - Variable handling im middleware does not convert the DateTime value anymore. [#664](https://github.com/ChilliCream/hotchocolate/issues/664)
 - Directives are now correctly merged when declared in an extension file. [#665](https://github.com/ChilliCream/hotchocolate/issues/665)
+- Subscription is now optional in the 2-phase introspection call [#668](https://github.com/ChilliCream/hotchocolate/issues/668)
 
 ## [0.8.0] - 2019-03-03
 

--- a/src/Core/Language.Tests/Lexer/LexerTests.cs
+++ b/src/Core/Language.Tests/Lexer/LexerTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace HotChocolate.Language
 {

--- a/src/Core/Language.Tests/Lexer/LexerTests.cs
+++ b/src/Core/Language.Tests/Lexer/LexerTests.cs
@@ -32,5 +32,48 @@ namespace HotChocolate.Language
             Assert.Equal(token.Next.Next, token.Next.Next.Next.Previous);
             Assert.Null(token.Next.Next.Next.Next);
         }
+
+        [Fact]
+        public void SourceIsNull_ArgumentNullException()
+        {
+            // arrange
+            Lexer lexer = new Lexer();
+
+            // act
+            Action action = () => lexer.Read(null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void UnexpectedCharacter()
+        {
+            // arrange
+            Source source = new Source("~");
+            Lexer lexer = new Lexer();
+
+            // act
+            Action action = () => lexer.Read(source);
+
+            // assert
+            Assert.Equal("Unexpected character.",
+                Assert.Throws<SyntaxException>(action).Message);
+        }
+
+        [Fact]
+        public void UnexpectedTokenSequence()
+        {
+            // arrange
+            Source source = new Source("\"foo");
+            Lexer lexer = new Lexer();
+
+            // act
+            Action action = () => lexer.Read(source);
+
+            // assert
+            Assert.Equal("Unexpected token sequence.",
+                Assert.Throws<SyntaxException>(action).Message);
+        }
     }
 }

--- a/src/Core/Language.Tests/Parser/ValueParserTests.cs
+++ b/src/Core/Language.Tests/Parser/ValueParserTests.cs
@@ -28,22 +28,23 @@ namespace HotChocolate.Language
             Type expectedNodeType)
         {
             // arrange
-            SyntaxToken start = Lexer.Default.Read(
-                new Source(value));
-
-            var context = new ParserContext(
-                new Source(value),
-                start,
-                ParserOptions.Default,
-                Parser.ParseName);
-            context.MoveNext();
-
             // act
             IValueNode valueNode = ParseValue(value);
 
             // assert
             Assert.Equal(expectedNodeType, valueNode.GetType());
             Assert.Equal(expectedValue, valueNode.Value);
+        }
+
+        [Fact]
+        public void ZeroZeroIsNotAllowed()
+        {
+            // arrange
+            // act
+            Action action = () => ParseValue("00");
+
+            // assert
+            Assert.Throws<SyntaxException>(action);
         }
 
         private static IValueNode ParseValue(string value)

--- a/src/Core/Language.Tests/Parser/ValueParserTests.cs
+++ b/src/Core/Language.Tests/Parser/ValueParserTests.cs
@@ -9,9 +9,17 @@ namespace HotChocolate.Language
         [InlineData("false", false, typeof(BooleanValueNode))]
         [InlineData("0", "0", typeof(IntValueNode))]
         [InlineData("123", "123", typeof(IntValueNode))]
+        [InlineData("-123", "-123", typeof(IntValueNode))]
+        [InlineData("2.3e-5", "2.3e-5", typeof(FloatValueNode))]
+        [InlineData("2.3e+5", "2.3e+5", typeof(FloatValueNode))]
         [InlineData("123.456", "123.456", typeof(FloatValueNode))]
         [InlineData("\"123\"", "123", typeof(StringValueNode))]
+        [InlineData("\"\"\"123\n456\"\"\"", "123\n456",
+            typeof(StringValueNode))]
+        [InlineData("\"\\u0031\"", "1", typeof(StringValueNode))]
         [InlineData("\"\\u004E\"", "N", typeof(StringValueNode))]
+        [InlineData("\"\\u0061\"", "a", typeof(StringValueNode))]
+        [InlineData("\"\\u003A\"", ":", typeof(StringValueNode))]
         [InlineData("FOO", "FOO", typeof(EnumValueNode))]
         [Theory]
         public void ParseSimpleValue(

--- a/src/Core/Language.Tests/Parser/ValueParserTests.cs
+++ b/src/Core/Language.Tests/Parser/ValueParserTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Xunit;
+
+namespace HotChocolate.Language
+{
+    public class ValueParserTests
+    {
+        [InlineData("true", true, typeof(BooleanValueNode))]
+        [InlineData("false", false, typeof(BooleanValueNode))]
+        [InlineData("0", "0", typeof(IntValueNode))]
+        [InlineData("123", "123", typeof(IntValueNode))]
+        [InlineData("123.456", "123.456", typeof(FloatValueNode))]
+        [InlineData("\"123\"", "123", typeof(StringValueNode))]
+        [InlineData("\"\\u004E\"", "N", typeof(StringValueNode))]
+        [InlineData("FOO", "FOO", typeof(EnumValueNode))]
+        [Theory]
+        public void ParseSimpleValue(
+            string value,
+            object expectedValue,
+            Type expectedNodeType)
+        {
+            // arrange
+            SyntaxToken start = Lexer.Default.Read(
+                new Source(value));
+
+            var context = new ParserContext(
+                new Source(value),
+                start,
+                ParserOptions.Default,
+                Parser.ParseName);
+            context.MoveNext();
+
+            // act
+            IValueNode valueNode = ParseValue(value);
+
+            // assert
+            Assert.Equal(expectedNodeType, valueNode.GetType());
+            Assert.Equal(expectedValue, valueNode.Value);
+        }
+
+        private static IValueNode ParseValue(string value)
+        {
+            SyntaxToken start = Lexer.Default.Read(
+                new Source(value));
+
+            var context = new ParserContext(
+                new Source(value),
+                start,
+                ParserOptions.Default,
+                Parser.ParseName);
+            context.MoveNext();
+
+            return Parser.ParseValueLiteral(context, true);
+        }
+    }
+}
+

--- a/src/Core/Language/AST/BooleanValueNode.cs
+++ b/src/Core/Language/AST/BooleanValueNode.cs
@@ -26,6 +26,8 @@ namespace HotChocolate.Language
 
         public bool Value { get; }
 
+        object IValueNode.Value => Value;
+
         /// <summary>
         /// Determines whether the specified <see cref="BooleanValueNode"/>
         /// is equal to the current <see cref="BooleanValueNode"/>.

--- a/src/Core/Language/AST/EnumValueNode.cs
+++ b/src/Core/Language/AST/EnumValueNode.cs
@@ -35,6 +35,8 @@ namespace HotChocolate.Language
 
         public string Value { get; }
 
+        object IValueNode.Value => Value;
+
         /// <summary>
         /// Determines whether the specified <see cref="EnumValueNode"/>
         /// is equal to the current <see cref="EnumValueNode"/>.

--- a/src/Core/Language/AST/FloatValueNode.cs
+++ b/src/Core/Language/AST/FloatValueNode.cs
@@ -32,6 +32,8 @@ namespace HotChocolate.Language
 
         public string Value { get; }
 
+        object IValueNode.Value => Value;
+
         /// <summary>
         /// Determines whether the specified <see cref="FloatValueNode"/>
         /// is equal to the current <see cref="FloatValueNode"/>.

--- a/src/Core/Language/AST/IValueNode.cs
+++ b/src/Core/Language/AST/IValueNode.cs
@@ -6,11 +6,12 @@ namespace HotChocolate.Language
         : ISyntaxNode
         , IEquatable<IValueNode>
     {
+        object Value { get; }
     }
 
     public interface IValueNode<out T>
         : IValueNode
     {
-        T Value { get; }
+        new T Value { get; }
     }
 }

--- a/src/Core/Language/AST/IntValueNode.cs
+++ b/src/Core/Language/AST/IntValueNode.cs
@@ -38,6 +38,8 @@ namespace HotChocolate.Language
 
         public string Value { get; }
 
+        object IValueNode.Value => Value;
+
         /// <summary>
         /// Determines whether the specified <see cref="IntValueNode"/>
         /// is equal to the current <see cref="IntValueNode"/>.

--- a/src/Core/Language/AST/ListValueNode.cs
+++ b/src/Core/Language/AST/ListValueNode.cs
@@ -51,6 +51,8 @@ namespace HotChocolate.Language
         IReadOnlyList<IValueNode> IValueNode<IReadOnlyList<IValueNode>>.Value =>
             Items;
 
+        object IValueNode.Value => Items;
+
         /// <summary>
         /// Determines whether the specified <see cref="ListValueNode"/>
         /// is equal to the current <see cref="ListValueNode"/>.

--- a/src/Core/Language/AST/ObjectValueNode.cs
+++ b/src/Core/Language/AST/ObjectValueNode.cs
@@ -38,6 +38,8 @@ namespace HotChocolate.Language
         IReadOnlyList<ObjectFieldNode>
             IValueNode<IReadOnlyList<ObjectFieldNode>>.Value => Fields;
 
+        object IValueNode.Value => Fields;
+
         /// <summary>
         /// Determines whether the specified <see cref="ObjectValueNode"/>
         /// is equal to the current <see cref="ObjectValueNode"/>.

--- a/src/Core/Language/AST/StringValueNode.cs
+++ b/src/Core/Language/AST/StringValueNode.cs
@@ -52,6 +52,8 @@ namespace HotChocolate.Language
 
         public string Value { get; }
 
+        object IValueNode.Value => Value;
+
         /// <summary>
         /// Gets a value indicating whether this <see cref="StringValueNode"/>
         /// was parsed from a block string.

--- a/src/Core/Language/AST/VariableNode.cs
+++ b/src/Core/Language/AST/VariableNode.cs
@@ -28,6 +28,8 @@ namespace HotChocolate.Language
 
         public string Value => Name.Value;
 
+        object IValueNode.Value => Value;
+
         /// <summary>
         /// Determines whether the specified <see cref="VariableNode"/>
         /// is equal to the current <see cref="VariableNode"/>.

--- a/src/Core/Language/Lexer/Lexer.cs
+++ b/src/Core/Language/Lexer/Lexer.cs
@@ -299,11 +299,14 @@ namespace HotChocolate.Language
 
             if (code == '0')
             {
-                code = state.SourceText[++state.Position];
-                if (char.IsDigit(code))
+                if (!state.IsEndOfStream(++state.Position))
                 {
-                    throw new SyntaxException(state,
-                        $"Invalid number, unexpected digit after 0: {code}.");
+                    code = state.SourceText[state.Position];
+                    if (char.IsDigit(code))
+                    {
+                        throw new SyntaxException(state,
+                            $"Invalid number, unexpected digit after 0: {code}.");
+                    }
                 }
             }
             else

--- a/src/Core/Language/Lexer/Lexer.cs
+++ b/src/Core/Language/Lexer/Lexer.cs
@@ -57,7 +57,7 @@ namespace HotChocolate.Language
 
                 return start;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is SyntaxException))
             {
                 throw new SyntaxException(state,
                     "Unexpected token sequence.",

--- a/src/Core/Language/Lexer/LexerState.cs
+++ b/src/Core/Language/Lexer/LexerState.cs
@@ -86,5 +86,15 @@ namespace HotChocolate.Language
         {
             return Position >= SourceText.Length;
         }
+
+        /// <summary>
+        /// Checks if the lexer source pointer has reached
+        /// the end of the GraphQL source text.
+        /// </summary>
+        /// <returns></returns>
+        public bool IsEndOfStream(int position)
+        {
+            return position >= SourceText.Length;
+        }
     }
 }

--- a/src/Stitching/Stitching.Tests/Introspection/IntrospectionClientTests.cs
+++ b/src/Stitching/Stitching.Tests/Introspection/IntrospectionClientTests.cs
@@ -1,0 +1,111 @@
+using HotChocolate.Language;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace HotChocolate.Stitching.Introspection
+{
+    public class IntrospectionClientTests
+    {
+        [Fact]
+        public void IntrospectionWithSubscription()
+        {
+            // arrange
+            var features = new SchemaFeatures
+            {
+                HasSubscriptionSupport = true
+            };
+
+            // act
+            DocumentNode document =
+                IntrospectionClient.CreateIntrospectionQuery(features);
+
+            // assert
+            QuerySyntaxSerializer.Serialize(document).MatchSnapshot();
+        }
+
+        [Fact]
+        public void IntrospectionWithoutSubscription()
+        {
+            // arrange
+            var features = new SchemaFeatures
+            {
+                HasSubscriptionSupport = false
+            };
+
+            // act
+            DocumentNode document =
+                IntrospectionClient.CreateIntrospectionQuery(features);
+
+            // assert
+            QuerySyntaxSerializer.Serialize(document).MatchSnapshot();
+        }
+
+        [Fact]
+        public void IntrospectionWithDirectiveLocationField()
+        {
+            // arrange
+            var features = new SchemaFeatures
+            {
+                HasDirectiveLocations = true
+            };
+
+            // act
+            DocumentNode document =
+                IntrospectionClient.CreateIntrospectionQuery(features);
+
+            // assert
+            QuerySyntaxSerializer.Serialize(document).MatchSnapshot();
+        }
+
+        [Fact]
+        public void IntrospectionWithoutDirectiveLocationField()
+        {
+            // arrange
+            var features = new SchemaFeatures
+            {
+                HasDirectiveLocations = false
+            };
+
+            // act
+            DocumentNode document =
+                IntrospectionClient.CreateIntrospectionQuery(features);
+
+            // assert
+            QuerySyntaxSerializer.Serialize(document).MatchSnapshot();
+        }
+
+        [Fact]
+        public void IntrospectionWithDirectiveIsRepeatableField()
+        {
+            // arrange
+            var features = new SchemaFeatures
+            {
+                HasRepeatableDirectives = true
+            };
+
+            // act
+            DocumentNode document =
+                IntrospectionClient.CreateIntrospectionQuery(features);
+
+            // assert
+            QuerySyntaxSerializer.Serialize(document).MatchSnapshot();
+        }
+
+        [Fact]
+        public void IntrospectionWithoutDirectiveIsRepeatableField()
+        {
+            // arrange
+            var features = new SchemaFeatures
+            {
+                HasRepeatableDirectives = false
+            };
+
+            // act
+            DocumentNode document =
+                IntrospectionClient.CreateIntrospectionQuery(features);
+
+            // assert
+            QuerySyntaxSerializer.Serialize(document).MatchSnapshot();
+        }
+    }
+}

--- a/src/Stitching/Stitching.Tests/Introspection/IntrospectionDeserializerTests.cs
+++ b/src/Stitching/Stitching.Tests/Introspection/IntrospectionDeserializerTests.cs
@@ -31,5 +31,19 @@ namespace HotChocolate.Stitching.Introspection
             // assert
             Assert.Throws<ArgumentException>(action).Message.MatchSnapshot();
         }
+
+        [Fact]
+        public void DeserializeIntrospectionWithIntDefaultValues()
+        {
+            // arrange
+            string json = FileResource.Open(
+                "IntrospectionWithDefaultValues.json");
+
+            // act
+            DocumentNode schema = IntrospectionDeserializer.Deserialize(json);
+
+            // assert
+            SchemaSyntaxSerializer.Serialize(schema).MatchSnapshot();
+        }
     }
 }

--- a/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithDirectiveIsRepeatableField.snap
+++ b/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithDirectiveIsRepeatableField.snap
@@ -1,0 +1,91 @@
+query introspection_phase_2 {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    types {
+      ... FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ... InputValue
+      }
+      onField
+      onFragment
+      onOperation
+      isRepeatable
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ... InputValue
+    }
+    type {
+      ... TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ... InputValue
+  }
+  interfaces {
+    ... TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ... TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ... TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithDirectiveLocationField.snap
+++ b/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithDirectiveLocationField.snap
@@ -1,0 +1,88 @@
+query introspection_phase_2 {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    types {
+      ... FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ... InputValue
+      }
+      locations
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ... InputValue
+    }
+    type {
+      ... TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ... InputValue
+  }
+  interfaces {
+    ... TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ... TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ... TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithSubscription.snap
+++ b/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithSubscription.snap
@@ -1,0 +1,93 @@
+query introspection_phase_2 {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
+    types {
+      ... FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ... InputValue
+      }
+      onField
+      onFragment
+      onOperation
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ... InputValue
+    }
+    type {
+      ... TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ... InputValue
+  }
+  interfaces {
+    ... TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ... TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ... TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithoutDirectiveIsRepeatableField.snap
+++ b/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithoutDirectiveIsRepeatableField.snap
@@ -1,0 +1,90 @@
+query introspection_phase_2 {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    types {
+      ... FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ... InputValue
+      }
+      onField
+      onFragment
+      onOperation
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ... InputValue
+    }
+    type {
+      ... TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ... InputValue
+  }
+  interfaces {
+    ... TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ... TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ... TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithoutDirectiveLocationField.snap
+++ b/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithoutDirectiveLocationField.snap
@@ -1,0 +1,90 @@
+query introspection_phase_2 {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    types {
+      ... FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ... InputValue
+      }
+      onField
+      onFragment
+      onOperation
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ... InputValue
+    }
+    type {
+      ... TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ... InputValue
+  }
+  interfaces {
+    ... TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ... TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ... TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithoutSubscription.snap
+++ b/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionClientTests.IntrospectionWithoutSubscription.snap
@@ -1,0 +1,90 @@
+query introspection_phase_2 {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    types {
+      ... FullType
+    }
+    directives {
+      name
+      description
+      args {
+        ... InputValue
+      }
+      onField
+      onFragment
+      onOperation
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ... InputValue
+    }
+    type {
+      ... TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ... InputValue
+  }
+  interfaces {
+    ... TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ... TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ... TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionDeserializerTests.DeserializeIntrospectionWithIntDefaultValues.snap
+++ b/src/Stitching/Stitching.Tests/Introspection/__snapshots__/IntrospectionDeserializerTests.DeserializeIntrospectionWithIntDefaultValues.snap
@@ -1,0 +1,142 @@
+schema {
+  query: Query
+}
+
+"An enum describing what kind of type a given __Type is"
+enum __TypeKind {
+  "Indicates this type is a scalar."
+  SCALAR
+  "Indicates this type is an object. `fields` and `interfaces` are valid fields."
+  OBJECT
+  "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields."
+  INTERFACE
+  "Indicates this type is a union. `possibleTypes` is a valid field."
+  UNION
+  "Indicates this type is an enum. `enumValues` is a valid field."
+  ENUM
+  "Indicates this type is an input object. `inputFields` is a valid field."
+  INPUT_OBJECT
+  "Indicates this type is a list. `ofType` is a valid field."
+  LIST
+  "Indicates this type is a non-null. `ofType` is a valid field."
+  NON_NULL
+}
+
+type __Field {
+  name: String!
+  description: String
+  args: [__InputValue!]!
+  type: __Type!
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+type Query {
+  Questions(skip: Int = 0 first: Int = 10): [Question]
+}
+
+"A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations."
+type __Schema {
+  "A list of all types supported by this server."
+  types: [__Type!]!
+  "The type that query operations will be rooted at."
+  queryType: __Type!
+  "If this server supports mutation, the type that mutation operations will be rooted at."
+  mutationType: __Type
+  "'A list of all directives supported by this server."
+  directives: [__Directive!]!
+  "'If this server support subscription, the type that subscription operations will be rooted at."
+  subscriptionType: __Type
+}
+
+type __Type {
+  kind: __TypeKind!
+  name: String
+  description: String
+  fields(includeDeprecated: Boolean = false): [__Field!]
+  interfaces: [__Type!]
+  possibleTypes: [__Type!]
+  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+  inputFields: [__InputValue!]
+  ofType: __Type
+}
+
+type __EnumValue {
+  name: String!
+  description: String
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+"An enum describing valid locations where a directive can be placed"
+enum __DirectiveLocation {
+  "Indicates the directive is valid on queries."
+  QUERY
+  "Indicates the directive is valid on mutations."
+  MUTATION
+  "Indicates the directive is valid on fields."
+  FIELD
+  "Indicates the directive is valid on fragment definitions."
+  FRAGMENT_DEFINITION
+  "Indicates the directive is valid on fragment spreads."
+  FRAGMENT_SPREAD
+  "Indicates the directive is valid on inline fragments."
+  INLINE_FRAGMENT
+  "Indicates the directive is valid on a schema SDL definition."
+  SCHEMA
+  "Indicates the directive is valid on a scalar SDL definition."
+  SCALAR
+  "Indicates the directive is valid on an object SDL definition."
+  OBJECT
+  "Indicates the directive is valid on a field SDL definition."
+  FIELD_DEFINITION
+  "Indicates the directive is valid on a field argument SDL definition."
+  ARGUMENT_DEFINITION
+  "Indicates the directive is valid on an interface SDL definition."
+  INTERFACE
+  "Indicates the directive is valid on an union SDL definition."
+  UNION
+  "Indicates the directive is valid on an enum SDL definition."
+  ENUM
+  "Indicates the directive is valid on an enum value SDL definition."
+  ENUM_VALUE
+  "Indicates the directive is valid on an input object SDL definition."
+  INPUT_OBJECT
+  "Indicates the directive is valid on an input object field SDL definition."
+  INPUT_FIELD_DEFINITION
+}
+
+"Built-in String"
+scalar String
+
+"Built-in Int"
+scalar Int
+
+type Question {
+  id: ID
+  question: String
+  userId: Int
+}
+
+"Built-in ID"
+scalar ID
+
+type __InputValue {
+  name: String!
+  description: String
+  type: __Type!
+  defaultValue: String
+}
+
+"Built-in Boolean"
+scalar Boolean
+
+type __Directive {
+  name: String
+  description: String
+  locations: [__DirectiveLocation!]
+  args: [__InputValue!]!
+  onOperation: Boolean
+  onFragment: Boolean
+  onField: Boolean
+}

--- a/src/Stitching/Stitching.Tests/__resources__/IntrospectionWithDefaultValues.json
+++ b/src/Stitching/Stitching.Tests/__resources__/IntrospectionWithDefaultValues.json
@@ -1,0 +1,1003 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given __Type is",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": "",
+          "fields": [
+            {
+              "name": "Questions",
+              "description": "",
+              "args": [
+                {
+                  "name": "skip",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "first",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "10"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Question",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "'A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": null,
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "An enum describing valid locations where a directive can be placed",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Indicates the directive is valid on queries.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Indicates the directive is valid on mutations.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Indicates the directive is valid on fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Indicates the directive is valid on fragment definitions.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Indicates the directive is valid on fragment spreads.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Indicates the directive is valid on inline fragments.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Indicates the directive is valid on a schema SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Indicates the directive is valid on a scalar SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates the directive is valid on an object SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Indicates the directive is valid on a field SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Indicates the directive is valid on a field argument SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates the directive is valid on an interface SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates the directive is valid on an union SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates the directive is valid on an enum SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Indicates the directive is valid on an enum value SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates the directive is valid on an input object SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Indicates the directive is valid on an input object field SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "Built-in String",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "Built-in Int",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Question",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "question",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userId",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "Built-in ID",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "Built-in Boolean",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "__DirectiveLocation",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onOperation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            },
+            {
+              "name": "onFragment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            },
+            {
+              "name": "onField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "defer",
+          "description": "This directive allows results to be deferred during execution",
+          "args": []
+        }
+      ]
+    }
+  }
+}

--- a/src/Stitching/Stitching/Delegation/ScopedVariableNode.cs
+++ b/src/Stitching/Stitching/Delegation/ScopedVariableNode.cs
@@ -27,6 +27,8 @@ namespace HotChocolate.Stitching.Delegation
 
         public string Value => Scope.Value + ":" + Name.Value;
 
+        object IValueNode.Value => Value;
+
         /// <summary>
         /// Determines whether the specified <see cref="ScopedVariableNode"/>
         /// is equal to the current <see cref="ScopedVariableNode"/>.

--- a/src/Stitching/Stitching/Introspection/IntrospectionClient.cs
+++ b/src/Stitching/Stitching/Introspection/IntrospectionClient.cs
@@ -20,6 +20,7 @@ namespace HotChocolate.Stitching.Introspection
         private const string _phase1 = "introspection_phase_1.graphql";
         private const string _phase2 = "introspection_phase_2.graphql";
 
+        private const string _schemaName = "__Schema";
         private const string _directiveName = "__Directive";
         private const string _locations = "locations";
         private const string _isRepeatable = "isRepeatable";
@@ -27,6 +28,7 @@ namespace HotChocolate.Stitching.Introspection
         private const string _onFragment = "onFragment";
         private const string _onField = "onField";
         private const string _directivesField = "directives";
+        private const string _subscriptionType = "subscriptionType";
 
         public static DocumentNode LoadSchema(
             HttpClient httpClient)
@@ -78,12 +80,18 @@ namespace HotChocolate.Stitching.Introspection
             IntrospectionResult result =
                 JsonConvert.DeserializeObject<IntrospectionResult>(json);
 
-            FullType type = result.Data.Schema.Types.First(t =>
+            FullType directive = result.Data.Schema.Types.First(t =>
                  t.Name.Equals(_directiveName, StringComparison.Ordinal));
-            features.HasRepeatableDirectives = type.Fields.Any(t =>
+            features.HasRepeatableDirectives = directive.Fields.Any(t =>
                 t.Name.Equals(_isRepeatable, StringComparison.Ordinal));
-            features.HasDirectiveLocations = type.Fields.Any(t =>
+            features.HasDirectiveLocations = directive.Fields.Any(t =>
                 t.Name.Equals(_locations, StringComparison.Ordinal));
+
+            FullType schema = result.Data.Schema.Types.First(t =>
+                 t.Name.Equals(_schemaName, StringComparison.Ordinal));
+            features.HasSubscriptionSupport = schema.Fields.Any(t =>
+                t.Name.Equals(_subscriptionType, StringComparison.Ordinal));
+
             return features;
         }
 
@@ -120,31 +128,18 @@ namespace HotChocolate.Stitching.Introspection
 
             FieldNode directives =
                 schema.SelectionSet.Selections.OfType<FieldNode>().First(t =>
-                    t.Name.Value.Equals(_directivesField
-                        , StringComparison.Ordinal));
+                    t.Name.Value.Equals(_directivesField,
+                        StringComparison.Ordinal));
 
             var selections = directives.SelectionSet.Selections.ToList();
-
-            if (features.HasDirectiveLocations)
-            {
-                selections.Add(CreateField(_locations));
-            }
-            else
-            {
-                selections.Add(CreateField(_onField));
-                selections.Add(CreateField(_onFragment));
-                selections.Add(CreateField(_onOperation));
-            }
-
-            if (features.HasRepeatableDirectives)
-            {
-                selections.Add(CreateField(_isRepeatable));
-            }
+            AddDirectiveFeatures(features, selections);
 
             FieldNode newField = directives.WithSelectionSet(
                 directives.SelectionSet.WithSelections(selections));
 
             selections = schema.SelectionSet.Selections.ToList();
+            RemoveSubscriptionIfNotSupported(features, selections);
+
             selections.Remove(directives);
             selections.Add(newField);
 
@@ -163,6 +158,40 @@ namespace HotChocolate.Stitching.Introspection
             definitions.Insert(0, newOp);
 
             return query.WithDefinitions(definitions);
+        }
+
+        private static void AddDirectiveFeatures(
+            SchemaFeatures features,
+            ICollection<ISelectionNode> selections)
+        {
+            if (features.HasDirectiveLocations)
+            {
+                selections.Add(CreateField(_locations));
+            }
+            else
+            {
+                selections.Add(CreateField(_onField));
+                selections.Add(CreateField(_onFragment));
+                selections.Add(CreateField(_onOperation));
+            }
+
+            if (features.HasRepeatableDirectives)
+            {
+                selections.Add(CreateField(_isRepeatable));
+            }
+        }
+
+        private static void RemoveSubscriptionIfNotSupported(
+            SchemaFeatures features,
+            ICollection<ISelectionNode> selections)
+        {
+            if (!features.HasSubscriptionSupport)
+            {
+                FieldNode subscriptionField = selections.OfType<FieldNode>()
+                    .First(t => t.Name.Value.Equals(_subscriptionType,
+                        StringComparison.Ordinal));
+                selections.Remove(subscriptionField);
+            }
         }
 
         private static FieldNode CreateField(string name) =>

--- a/src/Stitching/Stitching/Introspection/IntrospectionClient.cs
+++ b/src/Stitching/Stitching/Introspection/IntrospectionClient.cs
@@ -114,7 +114,7 @@ namespace HotChocolate.Stitching.Introspection
             return IntrospectionDeserializer.Deserialize(json);
         }
 
-        private static DocumentNode CreateIntrospectionQuery(
+        internal static DocumentNode CreateIntrospectionQuery(
             SchemaFeatures features)
         {
             DocumentNode query = Parser.Default.Parse(

--- a/src/Stitching/Stitching/Introspection/SchemaFeatures.cs
+++ b/src/Stitching/Stitching/Introspection/SchemaFeatures.cs
@@ -5,5 +5,7 @@
         public bool HasDirectiveLocations { get; set; }
 
         public bool HasRepeatableDirectives { get; set; }
+
+        public bool HasSubscriptionSupport { get; set; }
     }
 }


### PR DESCRIPTION
This issue fixes two introspection issues when stitching schemas:

- The subscription field on schema will only be requested if the source schema supports it
- We fixed an issue in our parser when parsing partial GraphQL documents where the document itself is not fully valid. 

Fixes #668
