### PR TITLE
Added delegation path helper to the stitching layer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for directives on arguments [spec](https://graphql.github.io/graphql-spec/June2018/#ArgumentsDefinition)
 - Added support for XML documentation [715](https://github.com/ChilliCream/hotchocolate/issues/715)
 - Added access to stitched http response headers (e.g. Set-Cookie) [679](https://github.com/ChilliCream/hotchocolate/issues/679)
+- Added helper to add delegation paths to a field.
 
 ### Changed
 

--- a/src/Stitching/Stitching.Tests/Merge/MergeSyntaxNodeExtensionsTests.cs
+++ b/src/Stitching/Stitching.Tests/Merge/MergeSyntaxNodeExtensionsTests.cs
@@ -51,6 +51,49 @@ namespace HotChocolate.Stitching.Merge
         }
 
         [Fact]
+        public void AddDelegationPath_SingleComponent_TwoArgs()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            var path = new SelectionPathComponent(
+                new NameNode("bar"),
+                new[]
+                {
+                    new ArgumentNode("baz",
+                        new ScopedVariableNode(
+                            null,
+                            new NameNode("qux"),
+                            new NameNode("quux"))),
+                    new ArgumentNode("value_arg", "value")
+                });
+
+            fieldNode = fieldNode.AddDelegationPath("schemName", path);
+
+            // assert
+            var schema = new DocumentNode(new[]
+                {
+                    new ObjectTypeDefinitionNode
+                    (
+                        null,
+                        new NameNode("Object"),
+                        null,
+                        Array.Empty<DirectiveNode>(),
+                        Array.Empty<NamedTypeNode>(),
+                        new[] { fieldNode }
+                    )
+                });
+            SchemaSyntaxSerializer.Serialize(schema).MatchSnapshot();
+        }
+
+        [Fact]
         public void AddDelegationPath_SingleComponent_SchemNameIsEmpty()
         {
             // arrange

--- a/src/Stitching/Stitching.Tests/Merge/MergeSyntaxNodeExtensionsTests.cs
+++ b/src/Stitching/Stitching.Tests/Merge/MergeSyntaxNodeExtensionsTests.cs
@@ -1,0 +1,294 @@
+using System;
+using HotChocolate.Language;
+using HotChocolate.Stitching.Delegation;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace HotChocolate.Stitching.Merge
+{
+    public class MergeSyntaxNodeExtensionsTests
+    {
+        [Fact]
+        public void AddDelegationPath_SingleComponent()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            var path = new SelectionPathComponent(
+                new NameNode("bar"),
+                new[]
+                {
+                    new ArgumentNode("baz",
+                        new ScopedVariableNode(
+                            null,
+                            new NameNode("qux"),
+                            new NameNode("quux")))
+                });
+
+            fieldNode = fieldNode.AddDelegationPath("schemName", path);
+
+            // assert
+            var schema = new DocumentNode(new[]
+                {
+                    new ObjectTypeDefinitionNode
+                    (
+                        null,
+                        new NameNode("Object"),
+                        null,
+                        Array.Empty<DirectiveNode>(),
+                        Array.Empty<NamedTypeNode>(),
+                        new[] { fieldNode }
+                    )
+                });
+            SchemaSyntaxSerializer.Serialize(schema).MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDelegationPath_SingleComponent_SchemNameIsEmpty()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            var path = new SelectionPathComponent(
+                new NameNode("bar"),
+                new[]
+                {
+                    new ArgumentNode("baz",
+                        new ScopedVariableNode(
+                            null,
+                            new NameNode("qux"),
+                            new NameNode("quux")))
+                });
+
+            Action action = () => fieldNode.AddDelegationPath(default, path);
+
+            // assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void AddDelegationPath_SingleComponent_PathIsNull()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            Action action = () => fieldNode.AddDelegationPath(
+                "Schema", (SelectionPathComponent)null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddDelegationPath_MultipleComponents()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            var a = new SelectionPathComponent(
+                new NameNode("bar"),
+                new[]
+                {
+                    new ArgumentNode("baz",
+                        new ScopedVariableNode(
+                            null,
+                            new NameNode("qux"),
+                            new NameNode("quux")))
+                });
+
+            var b = new SelectionPathComponent(
+                new NameNode("bar2"),
+                new[]
+                {
+                    new ArgumentNode("baz2",
+                        new ScopedVariableNode(
+                            null,
+                            new NameNode("qux2"),
+                            new NameNode("quux2")))
+                });
+
+            fieldNode = fieldNode.AddDelegationPath(
+                "schemName", new[] { a, b });
+
+            // assert
+            var schema = new DocumentNode(new[]
+                {
+                    new ObjectTypeDefinitionNode
+                    (
+                        null,
+                        new NameNode("Object"),
+                        null,
+                        Array.Empty<DirectiveNode>(),
+                        Array.Empty<NamedTypeNode>(),
+                        new[] { fieldNode }
+                    )
+                });
+            SchemaSyntaxSerializer.Serialize(schema).MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDelegationPath_MultipleComponents_SingleComponent()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            var path = new SelectionPathComponent(
+                new NameNode("bar"),
+                new[]
+                {
+                    new ArgumentNode("baz",
+                        new ScopedVariableNode(
+                            null,
+                            new NameNode("qux"),
+                            new NameNode("quux")))
+                });
+
+            fieldNode = fieldNode.AddDelegationPath(
+                "schemName", new[] { path });
+
+            // assert
+            var schema = new DocumentNode(new[]
+                {
+                    new ObjectTypeDefinitionNode
+                    (
+                        null,
+                        new NameNode("Object"),
+                        null,
+                        Array.Empty<DirectiveNode>(),
+                        Array.Empty<NamedTypeNode>(),
+                        new[] { fieldNode }
+                    )
+                });
+            SchemaSyntaxSerializer.Serialize(schema).MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDelegationPath_MultipleComponents_EmptyPath()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            var path = new SelectionPathComponent(
+                new NameNode("bar"),
+                new[]
+                {
+                    new ArgumentNode("baz",
+                        new ScopedVariableNode(
+                            null,
+                            new NameNode("qux"),
+                            new NameNode("quux")))
+                });
+
+            fieldNode = fieldNode.AddDelegationPath(
+                "schemName", Array.Empty<SelectionPathComponent>());
+
+            // assert
+            var schema = new DocumentNode(new[]
+                {
+                    new ObjectTypeDefinitionNode
+                    (
+                        null,
+                        new NameNode("Object"),
+                        null,
+                        Array.Empty<DirectiveNode>(),
+                        Array.Empty<NamedTypeNode>(),
+                        new[] { fieldNode }
+                    )
+                });
+            SchemaSyntaxSerializer.Serialize(schema).MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDelegationPath_MultipleComponents_SchemNameIsEmpty()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            var path = new SelectionPathComponent(
+                new NameNode("bar"),
+                new[]
+                {
+                    new ArgumentNode("baz",
+                        new ScopedVariableNode(
+                            null,
+                            new NameNode("qux"),
+                            new NameNode("quux")))
+                });
+
+            Action action = () => fieldNode.AddDelegationPath(
+                default, new[] { path });
+
+            // assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void AddDelegationPath_MultipleComponents_PathIsNull()
+        {
+            // arrange
+            var fieldNode = new FieldDefinitionNode(
+                null,
+                new NameNode("foo"),
+                null,
+                Array.Empty<InputValueDefinitionNode>(),
+                new NamedTypeNode(new NameNode("Type")),
+                Array.Empty<DirectiveNode>());
+
+            // act
+            Action action = () => fieldNode.AddDelegationPath(
+                "Schema", (SelectionPathComponent[])null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+    }
+}

--- a/src/Stitching/Stitching.Tests/Merge/__snapshots__/MergeSyntaxNodeExtensionsTests.AddDelegationPath_MultipleComponents.snap
+++ b/src/Stitching/Stitching.Tests/Merge/__snapshots__/MergeSyntaxNodeExtensionsTests.AddDelegationPath_MultipleComponents.snap
@@ -1,0 +1,3 @@
+﻿type Object {
+  foo: Type @delegate(schema: "schemName", path: "bar(baz: $qux:quux).bar2(baz2: $qux2:quux2)")
+}

--- a/src/Stitching/Stitching.Tests/Merge/__snapshots__/MergeSyntaxNodeExtensionsTests.AddDelegationPath_MultipleComponents_EmptyPath.snap
+++ b/src/Stitching/Stitching.Tests/Merge/__snapshots__/MergeSyntaxNodeExtensionsTests.AddDelegationPath_MultipleComponents_EmptyPath.snap
@@ -1,0 +1,3 @@
+﻿type Object {
+  foo: Type @delegate(schema: "schemName")
+}

--- a/src/Stitching/Stitching.Tests/Merge/__snapshots__/MergeSyntaxNodeExtensionsTests.AddDelegationPath_MultipleComponents_SingleComponent.snap
+++ b/src/Stitching/Stitching.Tests/Merge/__snapshots__/MergeSyntaxNodeExtensionsTests.AddDelegationPath_MultipleComponents_SingleComponent.snap
@@ -1,0 +1,3 @@
+﻿type Object {
+  foo: Type @delegate(schema: "schemName", path: "bar(baz: $qux:quux)")
+}

--- a/src/Stitching/Stitching.Tests/Merge/__snapshots__/MergeSyntaxNodeExtensionsTests.AddDelegationPath_SingleComponent.snap
+++ b/src/Stitching/Stitching.Tests/Merge/__snapshots__/MergeSyntaxNodeExtensionsTests.AddDelegationPath_SingleComponent.snap
@@ -1,0 +1,3 @@
+﻿type Object {
+  foo: Type @delegate(schema: "schemName", path: "bar(baz: $qux:quux)")
+}

--- a/src/Stitching/Stitching/Delegation/ScopedVariableNode.cs
+++ b/src/Stitching/Stitching/Delegation/ScopedVariableNode.cs
@@ -3,7 +3,7 @@ using HotChocolate.Language;
 
 namespace HotChocolate.Stitching.Delegation
 {
-    internal sealed class ScopedVariableNode
+    public sealed class ScopedVariableNode
         : IValueNode<string>
         , IEquatable<ScopedVariableNode>
     {

--- a/src/Stitching/Stitching/Delegation/SelectionPathComponent.cs
+++ b/src/Stitching/Stitching/Delegation/SelectionPathComponent.cs
@@ -35,6 +35,8 @@ namespace HotChocolate.Stitching.Delegation
 
             for (int i = 1; i < Arguments.Count; i++)
             {
+                sb.Append(',');
+                sb.Append(' ');
                 sb.Append(SerializeArgument(Arguments[i]));
             }
 

--- a/src/Stitching/Stitching/Merge/Handlers/RootTypeMergeHandler.cs
+++ b/src/Stitching/Stitching/Merge/Handlers/RootTypeMergeHandler.cs
@@ -81,7 +81,7 @@ namespace HotChocolate.Stitching.Merge.Handlers
                             new ScopedVariableNode(
                                 null,
                                 new NameNode(ScopeNames.Arguments),
-                                t.Name))).ToList()).ToString();
+                                t.Name))).ToList());
 
                     var newName = new NameNode(
                         typeInfo.CreateUniqueName(current));

--- a/src/Stitching/Stitching/Merge/MergeSyntaxNodeExtensions.cs
+++ b/src/Stitching/Stitching/Merge/MergeSyntaxNodeExtensions.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using HotChocolate.Language;
+using HotChocolate.Stitching.Delegation;
 using HotChocolate.Stitching.Properties;
 
 namespace HotChocolate.Stitching.Merge
@@ -314,7 +316,69 @@ namespace HotChocolate.Stitching.Merge
         public static FieldDefinitionNode AddDelegationPath(
             this FieldDefinitionNode field,
             NameString schemaName) =>
-            AddDelegationPath(field, schemaName, null);
+            AddDelegationPath(field, schemaName, (string)null);
+
+        public static FieldDefinitionNode AddDelegationPath(
+            this FieldDefinitionNode field,
+            NameString schemaName,
+            SelectionPathComponent selectionPath)
+        {
+            if (field == null)
+            {
+                throw new ArgumentNullException(nameof(field));
+            }
+
+            if (selectionPath == null)
+            {
+                throw new ArgumentNullException(nameof(selectionPath));
+            }
+
+            schemaName.EnsureNotEmpty(nameof(schemaName));
+
+            return AddDelegationPath(field, schemaName, selectionPath);
+        }
+
+        public static FieldDefinitionNode AddDelegationPath(
+            this FieldDefinitionNode field,
+            NameString schemaName,
+            IReadOnlyCollection<SelectionPathComponent> selectionPath)
+        {
+            if (field == null)
+            {
+                throw new ArgumentNullException(nameof(field));
+            }
+
+            if (selectionPath == null)
+            {
+                throw new ArgumentNullException(nameof(selectionPath));
+            }
+
+            schemaName.EnsureNotEmpty(nameof(schemaName));
+
+            if (selectionPath.Count == 0)
+            {
+                return AddDelegationPath(field, schemaName);
+            }
+
+            if (selectionPath.Count == 1)
+            {
+                return AddDelegationPath(
+                    field,
+                    schemaName,
+                    selectionPath.Single());
+            }
+
+            var path = new StringBuilder();
+            path.Append(selectionPath.First().ToString());
+
+            foreach (SelectionPathComponent component in selectionPath.Skip(1))
+            {
+                path.Append('.');
+                path.Append(component.ToString());
+            }
+
+            return AddDelegationPath(field, schemaName, path.ToString());
+        }
 
         public static FieldDefinitionNode AddDelegationPath(
             this FieldDefinitionNode field,

--- a/src/Stitching/Stitching/Merge/MergeSyntaxNodeExtensions.cs
+++ b/src/Stitching/Stitching/Merge/MergeSyntaxNodeExtensions.cs
@@ -335,7 +335,10 @@ namespace HotChocolate.Stitching.Merge
 
             schemaName.EnsureNotEmpty(nameof(schemaName));
 
-            return AddDelegationPath(field, schemaName, selectionPath);
+            return AddDelegationPath(
+                field,
+                schemaName,
+                selectionPath.ToString());
         }
 
         public static FieldDefinitionNode AddDelegationPath(


### PR DESCRIPTION
This new helper method allows to programmatically add a delegation path to a field definition.

Example Usage:

```csharp
var path = new SelectionPathComponent(
    field.Name,
    field.Arguments.Select(t => new ArgumentNode(
        t.Name,
        new ScopedVariableNode(
            null,
            new NameNode(ScopeNames.Arguments),
            t.Name))).ToList());

field.AddDelegationPath("schemaName", path);
```

#Fixes #761