### PR TITLE
Changed Paging LongCount to Count

### DIFF
--- a/src/Core/Types/Types/Relay/QueryableConnectionResolver.cs
+++ b/src/Core/Types/Types/Relay/QueryableConnectionResolver.cs
@@ -49,7 +49,7 @@ namespace HotChocolate.Types.Relay
         {
             if (!_pageDetails.TotalCount.HasValue)
             {
-                _pageDetails.TotalCount = _source.LongCount();
+                _pageDetails.TotalCount = _source.Count();
             }
 
             _properties[_totalCount] = _pageDetails.TotalCount.Value;


### PR DESCRIPTION
In order to be compatible with more databases we have changed the paging to use `Count()` on `IQueryable<T>` instead of `LongCount()`

Fixes #660
