### PR TITLE
Added temporary directive stitching fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Delegate Directive not being assigned correctly with ITypeRewriter. [#766](https://github.com/ChilliCream/hotchocolate/issues/766)
 - Format Exception when registering types. [#787](https://github.com/ChilliCream/hotchocolate/issues/787)
 - The schema factory does not throw an exception if an annotated directive is not correct. [#619](https://github.com/ChilliCream/hotchocolate/issues/619)
+- Temprarily fixed issues with type system directives. We will add a final patch with the next release.
+- Fixed issues with external resolver overwrites.
 
 ## [0.8.2] - 2019-04-10
 

--- a/src/Core/Language/Visitors/SchemaSyntaxRewriter.cs
+++ b/src/Core/Language/Visitors/SchemaSyntaxRewriter.cs
@@ -126,8 +126,8 @@ namespace HotChocolate.Language
         {
             SchemaDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = RewriteMany(current, current.OperationTypes, context,
                 RewriteOperationTypeDefinition, current.WithOperationTypes);
@@ -141,8 +141,8 @@ namespace HotChocolate.Language
         {
             SchemaExtensionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = RewriteMany(current, current.OperationTypes, context,
                 RewriteOperationTypeDefinition, current.WithOperationTypes);
@@ -190,8 +190,8 @@ namespace HotChocolate.Language
         {
             ScalarTypeDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -208,8 +208,8 @@ namespace HotChocolate.Language
         {
             ScalarTypeExtensionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -223,8 +223,8 @@ namespace HotChocolate.Language
         {
             ObjectTypeDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -247,8 +247,8 @@ namespace HotChocolate.Language
         {
             ObjectTypeExtensionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -271,8 +271,8 @@ namespace HotChocolate.Language
         {
             FieldDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -296,8 +296,8 @@ namespace HotChocolate.Language
         {
             InputObjectTypeDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -318,8 +318,8 @@ namespace HotChocolate.Language
         {
             InputObjectTypeExtensionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -336,8 +336,8 @@ namespace HotChocolate.Language
         {
             InputValueDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -361,8 +361,8 @@ namespace HotChocolate.Language
         {
             InterfaceTypeDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -383,8 +383,8 @@ namespace HotChocolate.Language
         {
             InterfaceTypeExtensionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -401,8 +401,8 @@ namespace HotChocolate.Language
         {
             UnionTypeDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -422,8 +422,8 @@ namespace HotChocolate.Language
         {
             UnionTypeExtensionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -440,8 +440,8 @@ namespace HotChocolate.Language
         {
             EnumTypeDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -461,8 +461,8 @@ namespace HotChocolate.Language
         {
             EnumTypeExtensionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);
@@ -479,8 +479,8 @@ namespace HotChocolate.Language
         {
             EnumValueDefinitionNode current = node;
 
-            current = RewriteMany(current, current.Directives, context,
-                RewriteDirective, current.WithDirectives);
+            current = RewriteDirectives(current, current.Directives,
+                context, current.WithDirectives);
 
             current = Rewrite(current, current.Name, context,
                 RewriteName, current.WithName);

--- a/src/Core/Language/Visitors/SyntaxRewriter.cs
+++ b/src/Core/Language/Visitors/SyntaxRewriter.cs
@@ -121,6 +121,16 @@ namespace HotChocolate.Language
             return node;
         }
 
+        protected virtual TParent RewriteDirectives<TParent>(
+            TParent parent,
+            IReadOnlyList<DirectiveNode> directives,
+            TContext context,
+            Func<IReadOnlyList<DirectiveNode>, TParent> rewrite)
+        {
+            return RewriteMany(parent, directives, context,
+                RewriteDirective, rewrite);
+        }
+
         protected virtual NamedTypeNode RewriteNamedType(
             NamedTypeNode node,
             TContext context)

--- a/src/Stitching/Stitching.Tests/Middleware/TypeSystemDirectivesTests.cs
+++ b/src/Stitching/Stitching.Tests/Middleware/TypeSystemDirectivesTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Xunit;
+using HotChocolate.AspNetCore;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using HotChocolate.Execution;
+using Snapshooter.Xunit;
+using Moq;
+using Microsoft.AspNetCore.TestHost;
+using HotChocolate.Stitching.Merge.Rewriters;
+using HotChocolate.Language;
+using HotChocolate.Stitching.Merge;
+using HotChocolate.Stitching.Delegation;
+using System.Linq;
+using Snapshooter;
+
+namespace HotChocolate.Stitching
+{
+    public class TypeSystemDirectivesTests
+        : StitchingTestBase
+    {
+        public TypeSystemDirectivesTests(TestServerFactory testServerFactory)
+            : base(testServerFactory)
+        {
+        }
+
+        [Fact]
+        public async Task SourceSchemaHasTypeSystemDirectives()
+        {
+            // arrange
+            var serviceCollection = new ServiceCollection();
+
+            var connections = new Dictionary<string, HttpClient>();
+            serviceCollection.AddSingleton(CreateRemoteSchemas(connections));
+
+            serviceCollection.AddStitchedSchema(builder => builder
+                .AddSchemaFromString(
+                    "server_1",
+                    @"
+                    type Query { foo: String @bar }
+                    directive @bar on FIELD_DEFINITION
+                    "));
+
+            IServiceProvider services =
+                serviceCollection.BuildServiceProvider();
+
+            IQueryExecutor executor = services
+                .GetRequiredService<IQueryExecutor>();
+
+            // act
+            IExecutionResult result = null;
+
+            using (IServiceScope scope = services.CreateScope())
+            {
+                IReadOnlyQueryRequest request = QueryRequestBuilder.New()
+                    .SetQuery("{ foo }")
+                    .SetServices(scope.ServiceProvider)
+                    .Create();
+
+                result = await executor.ExecuteAsync(request);
+            }
+
+            // assert
+            result.MatchSnapshot(new SnapshotNameExtension("result"));
+            executor.Schema.ToString().MatchSnapshot(
+                new SnapshotNameExtension("schema"));
+        }
+
+        protected override IHttpClientFactory CreateRemoteSchemas(
+               Dictionary<string, HttpClient> connections)
+        {
+            TestServer server_1 = TestServerFactory.Create(
+                SchemaBuilder.New()
+                    .AddDocumentFromString
+                    (
+                        @"
+                        type Query { foo: String @bar }
+                        directive @bar on FIELD_DEFINITION
+                        "
+                    )
+                    .AddResolver("Query", "foo", "bar")
+                    .Create(),
+                new QueryMiddlewareOptions());
+
+            connections["server_1"] = server_1.CreateClient();
+
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            httpClientFactory.Setup(t => t.CreateClient(It.IsAny<string>()))
+                .Returns(new Func<string, HttpClient>(n =>
+                {
+                    if (connections.ContainsKey(n))
+                    {
+                        return connections[n];
+                    }
+
+                    throw new Exception();
+                }));
+            return httpClientFactory.Object;
+        }
+    }
+}

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/TypeSystemDirectivesTests.SourceSchemaHasTypeSystemDirectives_result.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/TypeSystemDirectivesTests.SourceSchemaHasTypeSystemDirectives_result.snap
@@ -1,0 +1,8 @@
+﻿{
+  "Data": {
+    "foo": "bar"
+  },
+  "Extensions": {},
+  "Errors": [],
+  "ContextData": {}
+}

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/TypeSystemDirectivesTests.SourceSchemaHasTypeSystemDirectives_schema.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/TypeSystemDirectivesTests.SourceSchemaHasTypeSystemDirectives_schema.snap
@@ -1,0 +1,15 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  foo: String @delegate(schema: "server_1")
+}
+
+directive @delegate(path: String "The name of the schema to which this field shall be delegated to." schema: Name!) on FieldDefinition
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String
+
+"The name scalar represents a valid GraphQL name as specified in the spec and can be used to refer to fields or types."
+scalar Name

--- a/src/Stitching/Stitching/Directives/DirectiveNames.cs
+++ b/src/Stitching/Stitching/Directives/DirectiveNames.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 namespace HotChocolate.Stitching
 {
     internal static class DirectiveNames

--- a/src/Stitching/Stitching/Extensions/StitchingBuilderExtensions.cs
+++ b/src/Stitching/Stitching/Extensions/StitchingBuilderExtensions.cs
@@ -455,7 +455,7 @@ namespace HotChocolate.Stitching
 
         public static IStitchingBuilder AddMergeHandler<T>(
             this IStitchingBuilder builder)
-            where T : ITypeMergeHanlder
+            where T : ITypeMergeHandler
         {
             if (builder == null)
             {

--- a/src/Stitching/Stitching/Merge/Handlers/EnumTypeMergeHandler.cs
+++ b/src/Stitching/Stitching/Merge/Handlers/EnumTypeMergeHandler.cs
@@ -6,7 +6,7 @@ using HotChocolate.Language;
 namespace HotChocolate.Stitching.Merge.Handlers
 {
     internal class EnumTypeMergeHandler
-        : ITypeMergeHanlder
+        : ITypeMergeHandler
     {
         private readonly MergeTypeRuleDelegate _next;
 

--- a/src/Stitching/Stitching/Merge/Handlers/RootTypeMergeHandler.cs
+++ b/src/Stitching/Stitching/Merge/Handlers/RootTypeMergeHandler.cs
@@ -8,7 +8,7 @@ using HotChocolate.Stitching.Delegation;
 namespace HotChocolate.Stitching.Merge.Handlers
 {
     internal class RootTypeMergeHandler
-         : ITypeMergeHanlder
+         : ITypeMergeHandler
     {
         private readonly MergeTypeRuleDelegate _next;
 

--- a/src/Stitching/Stitching/Merge/Handlers/ScalarTypeMergeHandler.cs
+++ b/src/Stitching/Stitching/Merge/Handlers/ScalarTypeMergeHandler.cs
@@ -6,7 +6,7 @@ using HotChocolate.Language;
 namespace HotChocolate.Stitching.Merge.Handlers
 {
     internal class ScalarTypeMergeHandler
-        : ITypeMergeHanlder
+        : ITypeMergeHandler
     {
         private readonly MergeTypeRuleDelegate _next;
 

--- a/src/Stitching/Stitching/Merge/Handlers/TypeMergeHanlderBase.cs
+++ b/src/Stitching/Stitching/Merge/Handlers/TypeMergeHanlderBase.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace HotChocolate.Stitching.Merge.Handlers
 {
     public abstract class TypeMergeHanlderBase<T>
-        : ITypeMergeHanlder
+        : ITypeMergeHandler
         where T : ITypeInfo
     {
         private readonly MergeTypeRuleDelegate _next;

--- a/src/Stitching/Stitching/Merge/Handlers/UnionTypeMergeHandler.cs
+++ b/src/Stitching/Stitching/Merge/Handlers/UnionTypeMergeHandler.cs
@@ -8,7 +8,7 @@ using HotChocolate.Language;
 namespace HotChocolate.Stitching.Merge.Handlers
 {
     internal class UnionTypeMergeHandler
-        : ITypeMergeHanlder
+        : ITypeMergeHandler
     {
         private readonly MergeTypeRuleDelegate _next;
 

--- a/src/Stitching/Stitching/Merge/ITypeMergeHandler.cs
+++ b/src/Stitching/Stitching/Merge/ITypeMergeHandler.cs
@@ -2,7 +2,7 @@
 
 namespace HotChocolate.Stitching.Merge
 {
-    public interface ITypeMergeHanlder
+    public interface ITypeMergeHandler
     {
         void Merge(
             ISchemaMergeContext context,

--- a/src/Stitching/Stitching/Merge/RemoveDirectivesRewriter.cs
+++ b/src/Stitching/Stitching/Merge/RemoveDirectivesRewriter.cs
@@ -10,12 +10,13 @@ namespace HotChocolate.Stitching.Merge
     internal sealed class RemoveDirectivesRewriter
         : SchemaSyntaxRewriter<object>
     {
-        private HashSet<NameString> _knownDirectives = new HashSet<NameString>
-        {
-            DirectiveNames.Computed,
-            DirectiveNames.Delegate,
-            DirectiveNames.Source
-        };
+        private readonly HashSet<NameString> _knownDirectives =
+            new HashSet<NameString>
+            {
+                DirectiveNames.Computed,
+                DirectiveNames.Delegate,
+                DirectiveNames.Source
+            };
 
         public DocumentNode RemoveDirectives(
             DocumentNode document)

--- a/src/Stitching/Stitching/Merge/RemoveDirectivesRewriter.cs
+++ b/src/Stitching/Stitching/Merge/RemoveDirectivesRewriter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HotChocolate;
+using HotChocolate.Language;
+using HotChocolate.Resolvers;
+
+namespace HotChocolate.Stitching.Merge
+{
+    internal sealed class RemoveDirectivesRewriter
+        : SchemaSyntaxRewriter<object>
+    {
+        private HashSet<NameString> _knownDirectives = new HashSet<NameString>
+        {
+            DirectiveNames.Computed,
+            DirectiveNames.Delegate,
+            DirectiveNames.Source
+        };
+
+        public DocumentNode RemoveDirectives(
+            DocumentNode document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            return RewriteDocument(document, new object());
+        }
+
+        protected override TParent RewriteDirectives<TParent>(
+            TParent parent,
+            IReadOnlyList<DirectiveNode> directives,
+            object context,
+            Func<IReadOnlyList<DirectiveNode>, TParent> rewrite)
+        {
+            var rewritten = new List<DirectiveNode>();
+
+            foreach (DirectiveNode directive in directives)
+            {
+                if (_knownDirectives.Contains(directive.Name.Value))
+                {
+                    rewritten.Add(directive);
+                }
+            }
+
+            return rewrite(rewritten);
+        }
+    }
+}

--- a/src/Stitching/Stitching/Merge/SchemaMergerExtensions.cs
+++ b/src/Stitching/Stitching/Merge/SchemaMergerExtensions.cs
@@ -192,7 +192,7 @@ namespace HotChocolate.Stitching.Merge
 
         public static ISchemaMerger AddMergeHandler<T>(
            this ISchemaMerger merger)
-           where T : ITypeMergeHanlder
+           where T : ITypeMergeHandler
         {
             if (merger == null)
             {
@@ -205,7 +205,7 @@ namespace HotChocolate.Stitching.Merge
         }
 
         internal static MergeTypeRuleFactory CreateHandler<T>()
-            where T : ITypeMergeHanlder
+            where T : ITypeMergeHandler
         {
             ConstructorInfo constructor = typeof(T).GetTypeInfo()
                 .DeclaredConstructors.SingleOrDefault(c =>
@@ -224,7 +224,7 @@ namespace HotChocolate.Stitching.Merge
 
             return next =>
             {
-                ITypeMergeHanlder handler = (ITypeMergeHanlder)constructor
+                ITypeMergeHandler handler = (ITypeMergeHandler)constructor
                     .Invoke(new object[] { next });
                 return handler.Merge;
             };

--- a/src/Stitching/Stitching/Merge/TypeReferenceRewriter.cs
+++ b/src/Stitching/Stitching/Merge/TypeReferenceRewriter.cs
@@ -10,6 +10,13 @@ namespace HotChocolate.Stitching.Merge
     internal sealed class TypeReferenceRewriter
         : SchemaSyntaxRewriter<TypeReferenceRewriter.Context>
     {
+        private HashSet<NameString> _knownDirectives = new HashSet<NameString>
+        {
+            DirectiveNames.Computed,
+            DirectiveNames.Delegate,
+            DirectiveNames.Source
+        };
+
         public DocumentNode RewriteSchema(
             DocumentNode document,
             NameString schemaName)

--- a/src/Stitching/Stitching/Merge/TypeReferenceRewriter.cs
+++ b/src/Stitching/Stitching/Merge/TypeReferenceRewriter.cs
@@ -10,13 +10,6 @@ namespace HotChocolate.Stitching.Merge
     internal sealed class TypeReferenceRewriter
         : SchemaSyntaxRewriter<TypeReferenceRewriter.Context>
     {
-        private HashSet<NameString> _knownDirectives = new HashSet<NameString>
-        {
-            DirectiveNames.Computed,
-            DirectiveNames.Delegate,
-            DirectiveNames.Source
-        };
-
         public DocumentNode RewriteSchema(
             DocumentNode document,
             NameString schemaName)

--- a/src/Stitching/Stitching/StitchingBuilder.Factory.cs
+++ b/src/Stitching/Stitching/StitchingBuilder.Factory.cs
@@ -102,6 +102,8 @@ namespace HotChocolate.Stitching
                 mergedSchema = AddExtensions(mergedSchema, extensions);
                 mergedSchema = RewriteMerged(builder, mergedSchema);
                 mergedSchema = RemoveBuiltInTypes(mergedSchema);
+                mergedSchema = RemoveDirectives(mergedSchema);
+
                 VisitMerged(builder, mergedSchema);
 
                 // create factory
@@ -290,6 +292,12 @@ namespace HotChocolate.Stitching
                 }
 
                 return new DocumentNode(definitions);
+            }
+
+            private static DocumentNode RemoveDirectives(DocumentNode document)
+            {
+                var rewriter = new RemoveDirectivesRewriter();
+                return rewriter.RemoveDirectives(document);
             }
         }
     }


### PR DESCRIPTION
For version 9 we will ignore type system directives in merged schemas. We will fix this with #791.