### PR TITLE
Fixes a bug that causes an ArgumentExceptions when roles are used to authorize.

### DIFF
--- a/src/Server/AspNetCore.Authorization/AuthErrorCodes.cs
+++ b/src/Server/AspNetCore.Authorization/AuthErrorCodes.cs
@@ -8,6 +8,6 @@ namespace HotChocolate.AspNetCore.Authorization
     {
         public const string NotAuthorized = "AUTH_NOT_AUTHORIZED";
         public const string NoDefaultPolicy = "AUTH_NO_DEFAULT_POLICY";
-        public const string PolicyNotFound = "AUTH_POLICY_NOT_FOUNT";
+        public const string PolicyNotFound = "AUTH_POLICY_NOT_FOUND";
     }
 }

--- a/src/Server/AspNetCore.Authorization/AuthorizeDirective.cs
+++ b/src/Server/AspNetCore.Authorization/AuthorizeDirective.cs
@@ -76,25 +76,23 @@ namespace HotChocolate.AspNetCore.Authorization
             : this(policy, null)
         { }
 
-        public AuthorizeDirective(IEnumerable<string> roles)
+        public AuthorizeDirective(IReadOnlyCollection<string> roles)
             : this(null, roles)
         { }
 
-        public AuthorizeDirective(string policy, IEnumerable<string> roles)
+        public AuthorizeDirective(
+            string policy,
+            IReadOnlyCollection<string> roles)
         {
-            ReadOnlyCollection<string> readOnlyRoles =
-                roles?.ToList().AsReadOnly();
-
             if (string.IsNullOrEmpty(policy)
-                && (readOnlyRoles == null || !readOnlyRoles.Any()))
+                && (roles == null || roles.Count == 0))
             {
                 throw new ArgumentException(
                     "Either policy or roles has to be set.");
             }
 
             Policy = policy;
-            Roles = (IReadOnlyCollection<string>)readOnlyRoles 
-                ?? Array.Empty<string>();
+            Roles = (IReadOnlyCollection<string>)roles ?? Array.Empty<string>();
         }
 
         public AuthorizeDirective(

--- a/src/Server/AspNetCore.Authorization/AuthorizeDirective.cs
+++ b/src/Server/AspNetCore.Authorization/AuthorizeDirective.cs
@@ -86,7 +86,7 @@ namespace HotChocolate.AspNetCore.Authorization
                 roles?.ToList().AsReadOnly();
 
             if (string.IsNullOrEmpty(policy)
-                && (readOnlyRoles == null || readOnlyRoles.Count > 0))
+                && (readOnlyRoles == null || !readOnlyRoles.Any()))
             {
                 throw new ArgumentException(
                     "Either policy or roles has to be set.");

--- a/src/Server/AspNetCore.Tests/Authorization/AuthorizeDirectiveTests.cs
+++ b/src/Server/AspNetCore.Tests/Authorization/AuthorizeDirectiveTests.cs
@@ -1,0 +1,134 @@
+using System.Reflection;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace HotChocolate.AspNetCore.Authorization
+{
+    public class AuthorizeDirectiveTests
+    {
+        [Fact]
+        public void CreateInstance_Policy_PolicyIsNull()
+        {
+            // arrange
+            // act
+            Action action = () => new AuthorizeDirective((string)null);
+
+            // assert
+            Assert.Equal(
+                "Either policy or roles has to be set.",
+                Assert.Throws<ArgumentException>(action).Message);
+        }
+
+        [Fact]
+        public void CreateInstance_Roles_RolesIsNull()
+        {
+            // arrange
+            // act
+            Action action = () => new AuthorizeDirective(
+                (IReadOnlyCollection<string>)null);
+
+            // assert
+            Assert.Equal(
+                "Either policy or roles has to be set.",
+                Assert.Throws<ArgumentException>(action).Message);
+        }
+
+        [Fact]
+        public void CreateInstance_PolicyRoles_PolicyIsNullRolesIsNull()
+        {
+            // arrange
+            // act
+            Action action = () => new AuthorizeDirective(null, null);
+
+            // assert
+            Assert.Equal(
+                "Either policy or roles has to be set.",
+                Assert.Throws<ArgumentException>(action).Message);
+        }
+
+        [Fact]
+        public void CreateInstance_PolicyRoles_PolicyIsNullRolesIsEmpty()
+        {
+            // arrange
+            // act
+            Action action = () => new AuthorizeDirective(
+                null,
+                Array.Empty<string>());
+
+            // assert
+            Assert.Equal(
+                "Either policy or roles has to be set.",
+                Assert.Throws<ArgumentException>(action).Message);
+        }
+
+        [Fact]
+        public void CreateInstance_PolicyRoles_PolicyIsNullRolesHasItems()
+        {
+            // arrange
+            // act
+            var authorizeDirective = new AuthorizeDirective(
+                null,
+                new[] { "a", "b" });
+
+            // assert
+            Assert.Null(authorizeDirective.Policy);
+            Assert.Collection(authorizeDirective.Roles,
+                t => Assert.Equal("a", t),
+                t => Assert.Equal("b", t));
+        }
+
+        [Fact]
+        public void CreateInstance_PolicyRoles_PolicyIsSetRolesIsEmpty()
+        {
+            // arrange
+            // act
+            var authorizeDirective = new AuthorizeDirective(
+                "abc", Array.Empty<string>());
+
+            // assert
+            Assert.Equal("abc", authorizeDirective.Policy);
+            Assert.Empty(authorizeDirective.Roles);
+        }
+
+        [Fact]
+        public void CreateInstance_PolicyRoles_PolicyIsSetRolesIsNull()
+        {
+            // arrange
+            // act
+            var authorizeDirective = new AuthorizeDirective(
+                "abc", Array.Empty<string>());
+
+            // assert
+            Assert.Equal("abc", authorizeDirective.Policy);
+            Assert.Empty(authorizeDirective.Roles);
+        }
+
+        [Fact]
+        public void CreateInstance_Policy_PolicyIsSet()
+        {
+            // arrange
+            // act
+            var authorizeDirective = new AuthorizeDirective("abc");
+
+            // assert
+            Assert.Equal("abc", authorizeDirective.Policy);
+            Assert.Empty(authorizeDirective.Roles);
+        }
+
+        [Fact]
+        public void CreateInstance_Roles_RolesHasItems()
+        {
+            // arrange
+            // act
+            var authorizeDirective = new AuthorizeDirective(
+                new[] { "a", "b" });
+
+            // assert
+            Assert.Null(authorizeDirective.Policy);
+            Assert.Collection(authorizeDirective.Roles,
+                t => Assert.Equal("a", t),
+                t => Assert.Equal("b", t));
+        }
+    }
+}

--- a/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizationTests.Policy_NotFound.snap
+++ b/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizationTests.Policy_NotFound.snap
@@ -1,4 +1,4 @@
-﻿{
+{
   "Data": {
     "age": null
   },
@@ -15,7 +15,7 @@
         "age"
       ],
       "extensions": {
-        "code": "AUTH_POLICY_NOT_FOUNT"
+        "code": "AUTH_POLICY_NOT_FOUND"
       }
     }
   ]


### PR DESCRIPTION
Fixes a few bugs in the authorize directive and middleware

- Fixed the typo in the policy not found error code
- Fixed a bug in the authorize directive where passing in only roles would cause an error to be thrown

Addresses a bug I haven't raised as it was easier to fix than to try and explain it.
