### PR TITLE
Resolves null reference exception in Path.Equals

### DIFF
--- a/src/Core/Abstractions.Tests/PathTests.cs
+++ b/src/Core/Abstractions.Tests/PathTests.cs
@@ -39,5 +39,47 @@ namespace HotChocolate.Execution.Instrumentation
             // assert
             result.MatchSnapshot();
         }
+
+        [Fact]
+        public void Path_Equals_Null()
+        {
+            // arrange
+            Path hero = Path.New("hero");
+            Path friends = null;
+
+            // act
+            var areEqual = hero.Equals(friends);
+
+            // assert
+            Assert.False(areEqual);
+        }
+
+        [Fact]
+        public void Path_Equals_False()
+        {
+            // arrange
+            Path hero = Path.New("hero");
+            Path friends = Path.New("hero").Append("friends");
+
+            // act
+            var areEqual = hero.Equals(friends);
+
+            // assert
+            Assert.False(areEqual);
+        }
+
+        [Fact]
+        public void Path_Equals_True()
+        {
+            // arrange
+            Path friends1 = Path.New("hero").Append("friends");
+            Path friends2 = Path.New("hero").Append("friends");
+
+            // act
+            var areEqual = friends1.Equals(friends2);
+
+            // assert
+            Assert.True(areEqual);
+        }
     }
 }

--- a/src/Core/Abstractions/Path.cs
+++ b/src/Core/Abstractions/Path.cs
@@ -47,9 +47,14 @@ namespace HotChocolate
                 return true;
             }
 
-            return (other.Parent.Equals(Parent)
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            return ((Parent == null && other.Parent == null) || other.Parent.Equals(Parent))
                 && string.Equals(other.Name, Name, StringComparison.Ordinal)
-                && other.Index.Equals(Index));
+                && other.Index.Equals(Index);
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
Nothing complicated, just added some null guards for when `Parent` can be null.

Fixes #801 