### PR TITLE
Infer field/enum deprecation from ObsoleteAttribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- nothing yet ;)
+- Added support to infer if a field or enum value is deprecated. [#826](https://github.com/ChilliCream/hotchocolate/pull/826)
 
 ### Changed
 

--- a/src/Core/Abstractions/AttributeExtensions.cs
+++ b/src/Core/Abstractions/AttributeExtensions.cs
@@ -104,12 +104,37 @@ namespace HotChocolate
                 false))
             {
                 GraphQLDescriptionAttribute attribute =
-                    attributeProvider.GetCustomAttributes(
-                        typeof(GraphQLDescriptionAttribute),
-                        false)
-                        .OfType<GraphQLDescriptionAttribute>()
-                        .FirstOrDefault();
+                    (GraphQLDescriptionAttribute)
+                        attributeProvider.GetCustomAttributes(
+                            typeof(GraphQLDescriptionAttribute),
+                            false)[0];
                 return attribute.Description;
+            }
+
+            return null;
+        }
+
+        public static string GetGraphQLDeprecationReason(
+            this ICustomAttributeProvider attributeProvider)
+        {
+            if (attributeProvider.IsDefined(
+                typeof(ObsoleteAttribute),
+                false))
+            {
+                ObsoleteAttribute attribute =
+                    (ObsoleteAttribute)attributeProvider.GetCustomAttributes(
+                        typeof(ObsoleteAttribute),
+                        false)[0];
+
+                if (string.IsNullOrEmpty(attribute.Message))
+                {
+                    // TODO : resources
+                    return "This field is no longer supported.";
+                }
+                else
+                {
+                    return attribute.Message;
+                }
             }
 
             return null;

--- a/src/Core/Types.Tests/Types/EnumTypeTests.cs
+++ b/src/Core/Types.Tests/Types/EnumTypeTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace HotChocolate.Types
 {
     public class EnumTypeTests
+        : TypeTestBase
     {
         [Fact]
         public void EnumType_DynamicName()
@@ -431,6 +432,23 @@ namespace HotChocolate.Types
             Assert.Throws<ArgumentException>(action);
         }
 
+        [Fact]
+        public void Deprecate_Obsolete_Values()
+        {
+            // act
+            var schema = SchemaBuilder.New()
+                .AddQueryType(c => c
+                    .Name("Query")
+                    .Field("foo")
+                    .Type<StringType>()
+                    .Resolver("bar"))
+                .AddType<FooObsolete>()
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public enum Foo
         {
             Bar1,
@@ -438,5 +456,13 @@ namespace HotChocolate.Types
         }
 
         public class Bar { }
+
+        public enum FooObsolete
+        {
+            Bar1,
+
+            [Obsolete]
+            Bar2
+        }
     }
 }

--- a/src/Core/Types.Tests/Types/InterfaceTypeTests.cs
+++ b/src/Core/Types.Tests/Types/InterfaceTypeTests.cs
@@ -436,6 +436,24 @@ namespace HotChocolate.Types
             schema.ToString().MatchSnapshot();
         }
 
+        [Fact]
+        public void Deprecate_Obsolete_Fields()
+        {
+            // arrange
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType(c => c
+                    .Name("Query")
+                    .Field("foo")
+                    .Type<StringType>()
+                    .Resolver("bar"))
+                .AddType(new InterfaceType<FooObsolete>())
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public interface IFoo
         {
             bool Bar { get; }
@@ -472,5 +490,11 @@ namespace HotChocolate.Types
         }
 
         public class FooDirective { }
+
+        public class FooObsolete
+        {
+            [Obsolete("Baz")]
+            public string Bar() => "foo";
+        }
     }
 }

--- a/src/Core/Types.Tests/Types/ObjectTypeTests.cs
+++ b/src/Core/Types.Tests/Types/ObjectTypeTests.cs
@@ -1262,6 +1262,24 @@ namespace HotChocolate.Types
                 .Errors.MatchSnapshot();
         }
 
+        [Fact]
+        public void Deprecate_Obsolete_Fields()
+        {
+            // arrange
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType(c => c
+                    .Name("Query")
+                    .Field("foo")
+                    .Type<StringType>()
+                    .Resolver("bar"))
+                .AddType(new ObjectType<FooObsolete>())
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public class GenericFoo<T>
         {
             public T Value { get; }
@@ -1319,6 +1337,12 @@ namespace HotChocolate.Types
                     .Resolver(() => new List<string>())
                     .Type<ListType<StringType>>();
             }
+        }
+
+        public class FooObsolete
+        {
+            [Obsolete("Baz")]
+            public string Bar() => "foo";
         }
     }
 }

--- a/src/Core/Types.Tests/Types/__snapshots__/EnumTypeTests.Deprecate_Obsolete_Values.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/EnumTypeTests.Deprecate_Obsolete_Values.snap
@@ -1,0 +1,15 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  foo: String
+}
+
+enum FooObsolete {
+  BAR1
+  BAR2 @deprecated(reason: "This field is no longer supported.")
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Deprecate_Obsolete_Fields.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Deprecate_Obsolete_Fields.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: Query
+}
+
+interface FooObsolete {
+  bar: String @deprecated(reason: "Baz")
+}
+
+type Query {
+  foo: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecate_Obsolete_Fields.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecate_Obsolete_Fields.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: Query
+}
+
+type FooObsolete {
+  bar: String @deprecated(reason: "Baz")
+}
+
+type Query {
+  foo: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.InterfaceFieldDeprecationReason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.InterfaceFieldDeprecationReason.snap
@@ -1,9 +1,9 @@
-schema {
+﻿schema {
   query: DummyQuery
 }
 
 interface Simple {
-  a: String
+  a: String @deprecated(reason: "reason123")
 }
 
 type DummyQuery {

--- a/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.ObjectFieldDeprecationReason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.ObjectFieldDeprecationReason.snap
@@ -1,9 +1,9 @@
-schema {
+﻿schema {
   query: Simple
 }
 
 type Simple {
-  a: String
+  a: String @deprecated(reason: "reason123")
 }
 
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."

--- a/src/Core/Types/SchemaSerializer.cs
+++ b/src/Core/Types/SchemaSerializer.cs
@@ -339,6 +339,15 @@ namespace HotChocolate
                 .Select(t => SerializeDirective(t, referenced))
                 .ToList();
 
+            if(enumValue.IsDeprecated)
+            {
+                directives.Add(new DirectiveNode(
+                    WellKnownDirectives.Deprecated,
+                    new ArgumentNode(
+                        WellKnownDirectives.DeprecationReasonArgument,
+                        enumValue.DeprecationReason)));
+            }
+
             return new EnumValueDefinitionNode
             (
                 null,
@@ -371,6 +380,15 @@ namespace HotChocolate
             var directives = field.Directives
                 .Select(t => SerializeDirective(t, referenced))
                 .ToList();
+
+            if(field.IsDeprecated)
+            {
+                directives.Add(new DirectiveNode(
+                    WellKnownDirectives.Deprecated,
+                    new ArgumentNode(
+                        WellKnownDirectives.DeprecationReasonArgument,
+                        field.DeprecationReason)));
+            }
 
             return new FieldDefinitionNode
             (

--- a/src/Core/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
@@ -161,5 +161,34 @@ namespace HotChocolate.Types.Descriptors
 
             return description;
         }
+
+        public string GetDeprecationReason(MemberInfo member)
+        {
+            if (member == null)
+            {
+                throw new ArgumentNullException(nameof(member));
+            }
+
+            return member.GetGraphQLDeprecationReason();
+        }
+
+        public string GetDeprecationReason(object value)
+        {
+            Type enumType = value.GetType();
+
+            if (enumType.IsEnum)
+            {
+                MemberInfo enumMember = enumType
+                    .GetMember(value.ToString())
+                    .FirstOrDefault();
+
+                if (enumMember != null)
+                {
+                    return enumMember.GetGraphQLDeprecationReason();
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Core/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
@@ -146,7 +146,7 @@ namespace HotChocolate.Types.Descriptors
             return name;
         }
 
-        public string GetTypeDescription(Type type, TypeKind kind)
+        public virtual string GetTypeDescription(Type type, TypeKind kind)
         {
             if (type == null)
             {
@@ -162,7 +162,7 @@ namespace HotChocolate.Types.Descriptors
             return description;
         }
 
-        public string GetDeprecationReason(MemberInfo member)
+        public virtual string GetDeprecationReason(MemberInfo member)
         {
             if (member == null)
             {
@@ -172,7 +172,7 @@ namespace HotChocolate.Types.Descriptors
             return member.GetGraphQLDeprecationReason();
         }
 
-        public string GetDeprecationReason(object value)
+        public virtual string GetDeprecationReason(object value)
         {
             Type enumType = value.GetType();
 

--- a/src/Core/Types/Types/Descriptors/Conventions/INamingConventions.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/INamingConventions.cs
@@ -22,5 +22,9 @@ namespace HotChocolate.Types.Descriptors
         NameString GetEnumValueName(object value);
 
         string GetEnumValueDescription(object value);
+
+        string GetDeprecationReason(MemberInfo member);
+
+        string GetDeprecationReason(object value);
     }
 }

--- a/src/Core/Types/Types/Descriptors/Conventions/ITypeInspector.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/ITypeInspector.cs
@@ -7,6 +7,7 @@ namespace HotChocolate.Types.Descriptors
     public interface ITypeInspector
     {
         IEnumerable<Type> GetResolverTypes(Type sourceType);
+
         IEnumerable<MemberInfo> GetMembers(Type type);
 
         /// <summary>
@@ -35,7 +36,9 @@ namespace HotChocolate.Types.Descriptors
         ITypeReference GetArgumentType(ParameterInfo parameter);
 
         IEnumerable<object> GetEnumValues(Type enumType);
+
         Type ExtractType(Type type);
+
         bool IsSchemaType(Type type);
     }
 }

--- a/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
@@ -18,8 +18,10 @@ namespace HotChocolate.Types.Descriptors
 
             Definition.Name = context.Naming.GetEnumValueName(value);
             Definition.Value = value;
-            Definition.Description = context.Naming
-                .GetEnumValueDescription(value);
+            Definition.Description =
+                context.Naming.GetEnumValueDescription(value);
+            Definition.DeprecationReason =
+                context.Naming.GetDeprecationReason(value);
         }
 
         protected override EnumValueDefinition Definition { get; } =

--- a/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -33,6 +33,8 @@ namespace HotChocolate.Types.Descriptors
             Definition.Description = context.Naming.GetMemberDescription(
                 member, MemberKind.InputObjectField);
             Definition.Type = context.Inspector.GetOutputReturnType(member);
+            Definition.DeprecationReason =
+                context.Naming.GetDeprecationReason(member);
 
             if (member is MethodInfo m)
             {

--- a/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -43,6 +43,8 @@ namespace HotChocolate.Types.Descriptors
                 member, MemberKind.ObjectField);
             Definition.Type = context.Inspector.GetOutputReturnType(member);
             Definition.ResolverType = resolverType;
+            Definition.DeprecationReason =
+                context.Naming.GetDeprecationReason(member);
 
             if (member is MethodInfo m)
             {


### PR DESCRIPTION
This PR adds support to infer deprecation from field members and enum value members.
The default implementation will use the `ObsoleteAttribute` to infer if a member is deprecated. 