### PR TITLE
Created GraphQLDeprecatedAttribute

### DIFF
--- a/src/Core/Abstractions/AttributeExtensions.cs
+++ b/src/Core/Abstractions/AttributeExtensions.cs
@@ -117,23 +117,29 @@ namespace HotChocolate
         public static string GetGraphQLDeprecationReason(
             this ICustomAttributeProvider attributeProvider)
         {
-            if (attributeProvider.IsDefined(
-                typeof(ObsoleteAttribute),
-                false))
-            {
-                ObsoleteAttribute attribute =
-                    (ObsoleteAttribute)attributeProvider.GetCustomAttributes(
-                        typeof(ObsoleteAttribute),
-                        false)[0];
+            var deprecatedAttribute = GetAttributeIfDefined<GraphQLDeprecatedAttribute>(
+                attributeProvider
+            );
 
-                if (string.IsNullOrEmpty(attribute.Message))
+            if (deprecatedAttribute != null)
+            {
+                return deprecatedAttribute.DeprecationReason;
+            }
+
+            var obsoleteAttribute = GetAttributeIfDefined<ObsoleteAttribute>(
+                attributeProvider
+            );
+
+            if (obsoleteAttribute != null)
+            {
+                if (string.IsNullOrEmpty(obsoleteAttribute.Message))
                 {
                     // TODO : resources
                     return "This field is no longer supported.";
                 }
                 else
                 {
-                    return attribute.Message;
+                    return obsoleteAttribute.Message;
                 }
             }
 
@@ -167,6 +173,20 @@ namespace HotChocolate
                     name.Substring(1);
             }
             return name.ToLowerInvariant();
+        }
+
+        private static TAttribute GetAttributeIfDefined<TAttribute>(ICustomAttributeProvider attributeProvider)
+            where TAttribute : Attribute
+        {
+            Type attributeType = typeof(TAttribute);
+            
+            if (attributeProvider.IsDefined(attributeType, false))
+            {
+                return (TAttribute)attributeProvider
+                    .GetCustomAttributes(attributeType, false)[0];
+            }
+
+            return null;
         }
     }
 }

--- a/src/Core/Abstractions/GraphQLDeprecatedAttribute.cs
+++ b/src/Core/Abstractions/GraphQLDeprecatedAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace HotChocolate
+{
+    /// <summary>
+    /// Denotes a deprecated field on a GraphQL type or a
+    /// deprecated value on a GraphQL enum.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field // Required for enum values
+        | AttributeTargets.Property
+        | AttributeTargets.Method)]
+    public sealed class GraphQLDeprecatedAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GraphQLDeprecatedAttribute"/>
+        /// with a specific deprecation reason.
+        /// </summary>
+        /// <param name="deprecationReason">The deprecation reason.</param>
+        public GraphQLDeprecatedAttribute(string deprecationReason)
+        {
+            DeprecationReason = deprecationReason;
+        }
+        
+        /// <summary>
+        /// The reason the field or enum value was deprecated.
+        /// </summary>
+        public string DeprecationReason { get; }
+    }
+}

--- a/src/Core/Abstractions/GraphQLDeprecatedAttribute.cs
+++ b/src/Core/Abstractions/GraphQLDeprecatedAttribute.cs
@@ -18,6 +18,11 @@ namespace HotChocolate
         /// <param name="deprecationReason">The deprecation reason.</param>
         public GraphQLDeprecatedAttribute(string deprecationReason)
         {
+            if (string.IsNullOrEmpty(deprecationReason))
+            {
+                throw new ArgumentNullException(nameof(deprecationReason));
+            }
+            
             DeprecationReason = deprecationReason;
         }
         

--- a/src/Core/Types.Tests/Types/EnumTypeTests.cs
+++ b/src/Core/Types.Tests/Types/EnumTypeTests.cs
@@ -449,6 +449,23 @@ namespace HotChocolate.Types
             schema.ToString().MatchSnapshot();
         }
 
+        [Fact]
+        public void Deprecate_Fields_With_Deprecated_Attribute()
+        {
+            // act
+            var schema = SchemaBuilder.New()
+                .AddQueryType(c => c
+                    .Name("Query")
+                    .Field("foo")
+                    .Type<StringType>()
+                    .Resolver("bar"))
+                .AddType<FooDeprecated>()
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public enum Foo
         {
             Bar1,
@@ -462,6 +479,13 @@ namespace HotChocolate.Types
             Bar1,
 
             [Obsolete]
+            Bar2
+        }
+
+        public enum FooDeprecated
+        {
+            Bar1,
+            [GraphQLDeprecated("Baz.")]
             Bar2
         }
     }

--- a/src/Core/Types.Tests/Types/InterfaceTypeTests.cs
+++ b/src/Core/Types.Tests/Types/InterfaceTypeTests.cs
@@ -454,6 +454,20 @@ namespace HotChocolate.Types
             schema.ToString().MatchSnapshot();
         }
 
+        [Fact]
+        public void Deprecate_Fields_With_Deprecated_Attribute()
+        {
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType(c => c.Name("Query")
+                    .Field("foo")
+                    .Type<StringType>()
+                    .Resolver("bar"))
+                .AddType(new InterfaceType<FooDeprecated>())
+                .Create();
+
+            schema.ToString().MatchSnapshot();
+        }
+
         public interface IFoo
         {
             bool Bar { get; }
@@ -495,6 +509,14 @@ namespace HotChocolate.Types
         {
             [Obsolete("Baz")]
             public string Bar() => "foo";
+        }
+
+        public class FooDeprecated
+        {
+            [GraphQLDeprecated("Use Bar2.")]
+            public string Bar() => "foo";
+
+            public string Bar2() => "Foo 2: Electric foo-galoo";
         }
     }
 }

--- a/src/Core/Types.Tests/Types/ObjectTypeTests.cs
+++ b/src/Core/Types.Tests/Types/ObjectTypeTests.cs
@@ -1280,6 +1280,24 @@ namespace HotChocolate.Types
             schema.ToString().MatchSnapshot();
         }
 
+        [Fact]
+        public void Deprecate_Fields_With_Deprecated_Attribute()
+        {
+            // arrange
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType(c => c
+                    .Name("Query")
+                    .Field("foo")
+                    .Type<StringType>()
+                    .Resolver("bar"))
+                .AddType(new ObjectType<FooDeprecated>())
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public class GenericFoo<T>
         {
             public T Value { get; }
@@ -1343,6 +1361,14 @@ namespace HotChocolate.Types
         {
             [Obsolete("Baz")]
             public string Bar() => "foo";
+        }
+
+        public class FooDeprecated
+        {
+            [GraphQLDeprecated("Use Bar2.")]
+            public string Bar() => "foo";
+
+            public string Bar2() => "Foo 2: Electric foo-galoo";
         }
     }
 }

--- a/src/Core/Types.Tests/Types/__snapshots__/EnumTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/EnumTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
@@ -1,0 +1,15 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  foo: String
+}
+
+enum FooDeprecated {
+  BAR1
+  BAR2 @deprecated(reason: "Baz.")
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
@@ -1,0 +1,15 @@
+﻿schema {
+  query: Query
+}
+
+interface FooDeprecated {
+  bar: String @deprecated(reason: "Use Bar2.")
+  bar2: String
+}
+
+type Query {
+  foo: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
@@ -1,0 +1,15 @@
+﻿schema {
+  query: Query
+}
+
+type FooDeprecated {
+  bar: String @deprecated(reason: "Use Bar2.")
+  bar2: String
+}
+
+type Query {
+  foo: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String


### PR DESCRIPTION
Created a `GraphQLDeprecatedAttribute` to provide a HotChocolate specific tool for denoting fields and enum values that are deprecated.

- Created `GraphQLDeprecatedAttribute` that requires a deprecation reason.
- Updated the `GetGraphQLDeprecationReason()` method to look for the new attribute before checking for `ObsoleteAttribute`

Addresses #747 
