### PR TITLE
Adding Using for HotChocolate

### DIFF
--- a/src/Templates/Server/content/Startup.cs
+++ b/src/Templates/Server/content/Startup.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using HotChocolate.AspNetCore;
+using HotChocolate;
 
 namespace HotChocolate.Server
 {


### PR DESCRIPTION
The services.AddDataLoaderRegistry and services.AddGraphQL calls don't function without the using HotChocolate statement.