### PR TITLE
Fixed source object conversion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support to infer if a field or enum value is deprecated. [#826](https://github.com/ChilliCream/hotchocolate/pull/826)
+- Added prisma filter types. [#861](https://github.com/ChilliCream/hotchocolate/pull/861)
 
 ### Changed
 
 - Subscription now uses pipeline API to abstract sockets. [#807](https://github.com/ChilliCream/hotchocolate/pull/807)
 - Improved parser performance. [#806](https://github.com/ChilliCream/hotchocolate/pull/806)
+- Roles collection on authorization directive is now interpreted as OR.
+
+### Fixed
+
+- The parent method on the resolver context now uses the converters if the source object type does not align with the requested type.
 
 ## [9.0.4] - 2019-06-16
 

--- a/src/Core/Core.Tests/Execution/SourceObjectConversionTests.cs
+++ b/src/Core/Core.Tests/Execution/SourceObjectConversionTests.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using HotChocolate;
-using HotChocolate.Execution;
 using HotChocolate.Types;
 using HotChocolate.Utilities;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Core/Core.Tests/Execution/SourceObjectConversionTests.cs
+++ b/src/Core/Core.Tests/Execution/SourceObjectConversionTests.cs
@@ -48,6 +48,29 @@ namespace HotChocolate.Execution
             result.MatchSnapshot();
         }
 
+        [Fact]
+        public async Task NoConverter_Specified()
+        {
+            // arrange
+            ISchema schema =
+                SchemaBuilder.New()
+                    .AddQueryType<QueryType>()
+                    .Create();
+
+            // act
+            IReadOnlyQueryRequest request =
+                QueryRequestBuilder.New()
+                    .SetQuery("{ foo { qux } }")
+                    .Create();
+
+            IExecutionResult result =
+                await schema.MakeExecutable().ExecuteAsync(request);
+
+            // assert
+            result.MatchSnapshot(options =>
+                options.IgnoreField("Errors[0].Exception"));
+        }
+
         public class Query
         {
             public Foo Foo { get; } = new Foo { Bar = "bar" };

--- a/src/Core/Core.Tests/Execution/SourceObjectConversionTests.cs
+++ b/src/Core/Core.Tests/Execution/SourceObjectConversionTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading.Tasks;
+using HotChocolate;
+using HotChocolate.Execution;
+using HotChocolate.Types;
+using HotChocolate.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace HotChocolate.Execution
+{
+    public class SourceObjectConversionTests
+    {
+        [Fact]
+        public async Task ConvertSourceObject()
+        {
+            // arrange
+            bool conversionTriggered = false;
+            var conversion = new TypeConversion();
+            conversion.Register<Foo, Baz>(source =>
+            {
+                conversionTriggered = true;
+                return new Baz { Qux = source.Bar };
+            });
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<ITypeConversion>(conversion);
+            IServiceProvider services =
+                serviceCollection.BuildServiceProvider();
+
+            ISchema schema =
+                SchemaBuilder.New()
+                    .AddQueryType<QueryType>()
+                    .AddServices(services)
+                    .Create();
+
+            // act
+            IReadOnlyQueryRequest request =
+                QueryRequestBuilder.New()
+                    .SetQuery("{ foo { qux } }")
+                    .SetServices(services)
+                    .Create();
+
+            IExecutionResult result =
+                await schema.MakeExecutable().ExecuteAsync(request);
+
+            // assert
+            Assert.True(conversionTriggered);
+            result.MatchSnapshot();
+        }
+
+        public class Query
+        {
+            public Foo Foo { get; } = new Foo { Bar = "bar" };
+        }
+
+        public class QueryType
+            : ObjectType<Query>
+        {
+            protected override void Configure(
+                IObjectTypeDescriptor<Query> descriptor)
+            {
+                descriptor.Field(t => t.Foo).Type<BazType>();
+            }
+        }
+
+        public class Foo
+        {
+            public string Bar { get; set; }
+        }
+
+        public class Baz
+        {
+            public string Qux { get; set; }
+        }
+
+        public class BazType
+            : ObjectType<Baz>
+        {
+        }
+    }
+}

--- a/src/Core/Core.Tests/Execution/__snapshots__/SourceObjectConversionTests.ConvertSourceObject.snap
+++ b/src/Core/Core.Tests/Execution/__snapshots__/SourceObjectConversionTests.ConvertSourceObject.snap
@@ -1,0 +1,10 @@
+﻿{
+  "Data": {
+    "foo": {
+      "qux": "bar"
+    }
+  },
+  "Extensions": {},
+  "Errors": [],
+  "ContextData": {}
+}

--- a/src/Core/Core.Tests/Execution/__snapshots__/SourceObjectConversionTests.NoConverter_Specified.snap
+++ b/src/Core/Core.Tests/Execution/__snapshots__/SourceObjectConversionTests.NoConverter_Specified.snap
@@ -1,0 +1,40 @@
+﻿{
+  "Data": {
+    "foo": {
+      "qux": null
+    }
+  },
+  "Extensions": {},
+  "Errors": [
+    {
+      "Message": "Unexpected Execution Error",
+      "Code": null,
+      "Path": [
+        "foo",
+        "qux"
+      ],
+      "Locations": [
+        {
+          "line": 1,
+          "column": 9
+        }
+      ],
+      "Exception": {
+        "ClassName": "System.InvalidCastException",
+        "Message": "Could not cast the source object to `HotChocolate.Execution.SourceObjectConversionTests+Baz`.",
+        "Data": null,
+        "InnerException": null,
+        "HelpURL": null,
+        "StackTraceString": "   at HotChocolate.Execution.ResolverContext.Parent[T]() in /Users/michael/Local/hotchocolate/src/Core/Core/Execution/Utilities/ResolverContext.cs:line 126\n   at lambda_method(Closure , IResolverContext )\n   at HotChocolate.Types.FieldMiddlewareCompiler.<>c__DisplayClass3_0.<<CreateResolverMiddleware>b__0>d.MoveNext() in /Users/michael/Local/hotchocolate/src/Core/Types/Types/Helpers/FieldMiddlewareCompiler.cs:line 74\n--- End of stack trace from previous location where exception was thrown ---\n   at HotChocolate.Execution.ExecutionStrategyBase.ExecuteMiddlewareAsync(ResolverContext resolverContext, IErrorHandler errorHandler) in /Users/michael/Local/hotchocolate/src/Core/Core/Execution/ExecutionStrategyBase.Resolver.cs:line 41",
+        "RemoteStackTraceString": null,
+        "RemoteStackIndex": 0,
+        "ExceptionMethod": null,
+        "HResult": -2147467262,
+        "Source": "HotChocolate.Core",
+        "WatsonBuckets": null
+      },
+      "Extensions": {}
+    }
+  ],
+  "ContextData": {}
+}

--- a/src/Core/Core/Execution/Utilities/ResolverContext.cs
+++ b/src/Core/Core/Execution/Utilities/ResolverContext.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -100,7 +101,23 @@ namespace HotChocolate.Execution
 
         public T Parent<T>()
         {
-            return (T)SourceObject;
+            if (SourceObject is T parent)
+            {
+                return parent;
+            }
+
+            if (_executionContext.Converter
+                .TryConvert<object, T>(SourceObject, out parent))
+            {
+                return parent;
+            }
+
+            // TODO : resources
+            throw new InvalidCastException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Could not cast the source object to `{0}`.",
+                    typeof(T).FullName));
         }
 
         public T CustomProperty<T>(string key)

--- a/src/Core/Core/Execution/Utilities/ResolverContext.cs
+++ b/src/Core/Core/Execution/Utilities/ResolverContext.cs
@@ -101,6 +101,11 @@ namespace HotChocolate.Execution
 
         public T Parent<T>()
         {
+            if (SourceObject is null)
+            {
+                return default;
+            }
+
             if (SourceObject is T parent)
             {
                 return parent;


### PR DESCRIPTION
The resolver context parent method `context.Parent<Foo>()` now correctly calls the type converters if the requests type does not match the internal source object type.