### PR TITLE
Fixed deprecation handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The parent method on the resolver context now uses the converters if the source object type does not align with the requested type.
+- Aligned the deprecation handling with the GraphQL spec. [#876](https://github.com/ChilliCream/hotchocolate/pull/876)
 
 ## [9.0.4] - 2019-06-16
 

--- a/src/Core/Abstractions/AttributeExtensions.cs
+++ b/src/Core/Abstractions/AttributeExtensions.cs
@@ -114,16 +114,18 @@ namespace HotChocolate
             return null;
         }
 
-        public static string GetGraphQLDeprecationReason(
-            this ICustomAttributeProvider attributeProvider)
+        public static bool IsDeprecated(
+            this ICustomAttributeProvider attributeProvider,
+            out string reason)
         {
-            var deprecatedAttribute = GetAttributeIfDefined<GraphQLDeprecatedAttribute>(
-                attributeProvider
-            );
+            var deprecatedAttribute =
+                GetAttributeIfDefined<GraphQLDeprecatedAttribute>(
+                    attributeProvider);
 
             if (deprecatedAttribute != null)
             {
-                return deprecatedAttribute.DeprecationReason;
+                reason = deprecatedAttribute.DeprecationReason;
+                return true;
             }
 
             var obsoleteAttribute = GetAttributeIfDefined<ObsoleteAttribute>(
@@ -131,12 +133,12 @@ namespace HotChocolate
 
             if (obsoleteAttribute != null)
             {
-                return string.IsNullOrEmpty(obsoleteAttribute.Message)
-                    ? WellKnownDirectives.DeprecationDefaultReason
-                    : obsoleteAttribute.Message;
+                reason = obsoleteAttribute.Message;
+                return true;
             }
 
-            return null;
+            reason = null;
+            return false;
         }
 
         private static string GetFromType(Type type)

--- a/src/Core/Abstractions/AttributeExtensions.cs
+++ b/src/Core/Abstractions/AttributeExtensions.cs
@@ -127,20 +127,13 @@ namespace HotChocolate
             }
 
             var obsoleteAttribute = GetAttributeIfDefined<ObsoleteAttribute>(
-                attributeProvider
-            );
+                attributeProvider);
 
             if (obsoleteAttribute != null)
             {
-                if (string.IsNullOrEmpty(obsoleteAttribute.Message))
-                {
-                    // TODO : resources
-                    return "This field is no longer supported.";
-                }
-                else
-                {
-                    return obsoleteAttribute.Message;
-                }
+                return string.IsNullOrEmpty(obsoleteAttribute.Message)
+                    ? WellKnownDirectives.DeprecationDefaultReason
+                    : obsoleteAttribute.Message;
             }
 
             return null;
@@ -179,7 +172,7 @@ namespace HotChocolate
             where TAttribute : Attribute
         {
             Type attributeType = typeof(TAttribute);
-            
+
             if (attributeProvider.IsDefined(attributeType, false))
             {
                 return (TAttribute)attributeProvider

--- a/src/Core/Abstractions/InternalsVisibleTo.cs
+++ b/src/Core/Abstractions/InternalsVisibleTo.cs
@@ -1,7 +1,8 @@
 ﻿using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("HotChocolate.Types")]
 [assembly: InternalsVisibleTo("HotChocolate.Core")]
+[assembly: InternalsVisibleTo("HotChocolate.Types")]
 [assembly: InternalsVisibleTo("HotChocolate.Stitching")]
 [assembly: InternalsVisibleTo("HotChocolate.Abstractions.Tests")]
 [assembly: InternalsVisibleTo("HotChocolate.Core.Tests")]
+[assembly: InternalsVisibleTo("HotChocolate.Types.Tests")]

--- a/src/Core/Abstractions/WellKnownDirectives.cs
+++ b/src/Core/Abstractions/WellKnownDirectives.cs
@@ -7,5 +7,6 @@
         public const string IfArgument = "if";
         public const string Deprecated = "deprecated";
         public const string DeprecationReasonArgument = "reason";
+        public const string DeprecationDefaultReason = "No longer supported";
     }
 }

--- a/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs
+++ b/src/Core/Core.Tests/Execution/Errors/ErrorBehaviourTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace HotChocolate.Execution
 {
-    public class ErrorbehaviorTests
+    public class ErrorBehaviourTests
     {
         [Fact]
         public async Task SyntaxError()

--- a/src/Core/Core.Tests/Execution/__snapshots__/IntrospectionTests.DefaultValueIsInputObject.snap
+++ b/src/Core/Core.Tests/Execution/__snapshots__/IntrospectionTests.DefaultValueIsInputObject.snap
@@ -1053,6 +1053,25 @@
           "onOperation": false,
           "onFragment": false,
           "onField": false
+        },
+        {
+          "name": "deprecated",
+          "description": "The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values.",
+          "args": [
+            {
+              "name": "reason",
+              "description": "Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
         }
       ]
     }

--- a/src/Core/Core.Tests/Execution/__snapshots__/IntrospectionTests.ExecuteGraphiQLIntrospectionQuery.snap
+++ b/src/Core/Core.Tests/Execution/__snapshots__/IntrospectionTests.ExecuteGraphiQLIntrospectionQuery.snap
@@ -1136,6 +1136,25 @@
           "onOperation": false,
           "onFragment": false,
           "onField": false
+        },
+        {
+          "name": "deprecated",
+          "description": "The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values.",
+          "args": [
+            {
+              "name": "reason",
+              "description": "Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
         }
       ]
     }

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
@@ -8,7 +8,7 @@ type Query {
 
 input FooFilter {
   AND: [FooFilter!]
-  bar: Boolean @Bar(qux: null)
+  bar: Boolean @Bar
   OR: [FooFilter!]
 }
 

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
@@ -8,7 +8,7 @@ type Query {
 
 input FooFilter {
   AND: [FooFilter!]
-  bar: Boolean @Bar(qux: null)
+  bar: Boolean @Bar
   OR: [FooFilter!]
 }
 

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
@@ -44,7 +44,7 @@ input FooFilter {
   barFloat_not_in: [Float!]
   barFloat_not_lt: Float
   barFloat_not_lte: Float
-  barInt: Int @Bar(baz: null)
+  barInt: Int @Bar
   barLong: Long
   barLong_gt: Long
   barLong_gte: Long

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
@@ -44,7 +44,7 @@ input FooFilter {
   barFloat_not_in: [Float!]
   barFloat_not_lt: Float
   barFloat_not_lte: Float
-  barInt: Int @Bar(baz: null)
+  barInt: Int @Bar
   barLong: Long
   barLong_gt: Long
   barLong_gte: Long

--- a/src/Core/Types.Filters.Tests/__snapshots__/StringFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/StringFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
@@ -8,7 +8,7 @@ type Query {
 
 input FooFilter {
   AND: [FooFilter!]
-  bar: String @Bar(baz: null)
+  bar: String @Bar
   OR: [FooFilter!]
 }
 

--- a/src/Core/Types.Filters.Tests/__snapshots__/StringFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/StringFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
@@ -8,7 +8,7 @@ type Query {
 
 input FooFilter {
   AND: [FooFilter!]
-  bar: String @Bar(baz: null)
+  bar: String @Bar
   OR: [FooFilter!]
 }
 

--- a/src/Core/Types.Tests/Configuration/__snapshots__/TypeRegistrarTests.Register_ClrType_InferSchemaTypes_clr.snap
+++ b/src/Core/Types.Tests/Configuration/__snapshots__/TypeRegistrarTests.Register_ClrType_InferSchemaTypes_clr.snap
@@ -9,6 +9,7 @@
   "None: HotChocolate.Types.CostDirective": "None: HotChocolate.Types.CostDirectiveType",
   "None: System.String": "None: HotChocolate.Types.StringType",
   "None: System.Boolean": "None: HotChocolate.Types.BooleanType",
+  "None: HotChocolate.Types.DeprecatedDirective": "None: HotChocolate.Types.DeprecatedDirectiveType",
   "None: System.Int32": "None: HotChocolate.Types.IntType",
   "None: HotChocolate.Types.MultiplierPathString": "None: HotChocolate.Types.MultiplierPathType",
   "Output: HotChocolate.TypeRegistrarTests.Foo": "Output: HotChocolate.Types.ObjectType<HotChocolate.TypeRegistrarTests.Foo>",

--- a/src/Core/Types.Tests/Configuration/__snapshots__/TypeRegistrarTests.Register_ClrType_InferSchemaTypes_registered.snap
+++ b/src/Core/Types.Tests/Configuration/__snapshots__/TypeRegistrarTests.Register_ClrType_InferSchemaTypes_registered.snap
@@ -12,6 +12,7 @@
   "HotChocolate.Types.CostDirectiveType": "HotChocolate.Types.CostDirective",
   "HotChocolate.Types.StringType": "System.String",
   "HotChocolate.Types.BooleanType": "System.Boolean",
+  "HotChocolate.Types.DeprecatedDirectiveType": "HotChocolate.Types.DeprecatedDirective",
   "HotChocolate.Types.IntType": "System.Int32",
   "HotChocolate.Types.MultiplierPathType": "HotChocolate.Types.MultiplierPathString",
   "HotChocolate.Types.ObjectType<HotChocolate.TypeRegistrarTests.Foo>": "HotChocolate.TypeRegistrarTests.Foo",

--- a/src/Core/Types.Tests/Configuration/__snapshots__/TypeRegistrarTests.Register_SchemaType_ClrTypeExists_clr.snap
+++ b/src/Core/Types.Tests/Configuration/__snapshots__/TypeRegistrarTests.Register_SchemaType_ClrTypeExists_clr.snap
@@ -10,6 +10,7 @@
   "Output: HotChocolate.TypeRegistrarTests.Foo": "Output: HotChocolate.TypeRegistrarTests.FooType",
   "None: System.String": "None: HotChocolate.Types.StringType",
   "None: System.Boolean": "None: HotChocolate.Types.BooleanType",
+  "None: HotChocolate.Types.DeprecatedDirective": "None: HotChocolate.Types.DeprecatedDirectiveType",
   "None: System.Int32": "None: HotChocolate.Types.IntType",
   "None: HotChocolate.Types.MultiplierPathString": "None: HotChocolate.Types.MultiplierPathType",
   "Output: HotChocolate.TypeRegistrarTests.Bar": "Output: HotChocolate.TypeRegistrarTests.BarType"

--- a/src/Core/Types.Tests/Configuration/__snapshots__/TypeRegistrarTests.Register_SchemaType_ClrTypeExists_registered.snap
+++ b/src/Core/Types.Tests/Configuration/__snapshots__/TypeRegistrarTests.Register_SchemaType_ClrTypeExists_registered.snap
@@ -13,6 +13,7 @@
   "HotChocolate.TypeRegistrarTests.FooType": "HotChocolate.TypeRegistrarTests.Foo",
   "HotChocolate.Types.StringType": "System.String",
   "HotChocolate.Types.BooleanType": "System.Boolean",
+  "HotChocolate.Types.DeprecatedDirectiveType": "HotChocolate.Types.DeprecatedDirective",
   "HotChocolate.Types.IntType": "System.Int32",
   "HotChocolate.Types.MultiplierPathType": "HotChocolate.Types.MultiplierPathString",
   "HotChocolate.TypeRegistrarTests.BarType": "HotChocolate.TypeRegistrarTests.Bar"

--- a/src/Core/Types.Tests/Types/InterfaceTypeExtensionTests.cs
+++ b/src/Core/Types.Tests/Types/InterfaceTypeExtensionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -29,6 +30,7 @@ namespace HotChocolate.Types
             Assert.True(type.Fields.ContainsField("test"));
         }
 
+        [Obsolete]
         [Fact]
         public void InterfaceTypeExtension_DepricateField()
         {
@@ -51,6 +53,78 @@ namespace HotChocolate.Types
             InterfaceType type = schema.GetType<InterfaceType>("Foo");
             Assert.True(type.Fields["description"].IsDeprecated);
             Assert.Equal("Foo", type.Fields["description"].DeprecationReason);
+        }
+
+        [Fact]
+        public void InterfaceTypeExtension_Deprecate_With_Reason()
+        {
+            // arrange
+            FieldResolverDelegate resolver =
+                ctx => Task.FromResult<object>(null);
+
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType<DummyQuery>()
+                .AddType<FooType>()
+                .AddType(new InterfaceTypeExtension(d => d
+                    .Name("Foo")
+                    .Field("description")
+                    .Type<StringType>()
+                    .Deprecated("Foo")))
+                .Create();
+
+            // assert
+            InterfaceType type = schema.GetType<InterfaceType>("Foo");
+            Assert.True(type.Fields["description"].IsDeprecated);
+            Assert.Equal("Foo", type.Fields["description"].DeprecationReason);
+        }
+
+        [Fact]
+        public void InterfaceTypeExtension_Deprecate_Without_Reason()
+        {
+            // arrange
+            FieldResolverDelegate resolver =
+                ctx => Task.FromResult<object>(null);
+
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType<DummyQuery>()
+                .AddType<FooType>()
+                .AddType(new InterfaceTypeExtension(d => d
+                    .Name("Foo")
+                    .Field("description")
+                    .Type<StringType>()
+                    .Deprecated()))
+                .Create();
+
+            // assert
+            InterfaceType type = schema.GetType<InterfaceType>("Foo");
+            Assert.True(type.Fields["description"].IsDeprecated);
+            Assert.Equal(
+                WellKnownDirectives.DeprecationDefaultReason,
+                type.Fields["description"].DeprecationReason);
+        }
+
+        [Fact]
+        public void InterfaceTypeExtension_Deprecated_Directive_Is_Serialized()
+        {
+            // arrange
+            FieldResolverDelegate resolver =
+                ctx => Task.FromResult<object>(null);
+
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType<DummyQuery>()
+                .AddType<FooType>()
+                .AddType(new InterfaceTypeExtension(d => d
+                    .Name("Foo")
+                    .Field("description")
+                    .Type<StringType>()
+                    .Deprecated()))
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
         }
 
         [Fact]

--- a/src/Core/Types.Tests/Types/ObjectTypeExtensionTests.cs
+++ b/src/Core/Types.Tests/Types/ObjectTypeExtensionTests.cs
@@ -99,8 +99,9 @@ namespace HotChocolate.Types
             executor.Execute("{ description }").MatchSnapshot();
         }
 
+        [Obsolete]
         [Fact]
-        public void ObjectTypeExtension_DepricateField()
+        public void ObjectTypeExtension_DeprecateField_Obsolete()
         {
             // arrange
             FieldResolverDelegate resolver =
@@ -120,6 +121,56 @@ namespace HotChocolate.Types
             ObjectType type = schema.GetType<ObjectType>("Foo");
             Assert.True(type.Fields["description"].IsDeprecated);
             Assert.Equal("Foo", type.Fields["description"].DeprecationReason);
+        }
+
+        [Fact]
+        public void ObjectTypeExtension_DepricateField_With_Reason()
+        {
+            // arrange
+            FieldResolverDelegate resolver =
+                ctx => Task.FromResult<object>(null);
+
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType<FooType>()
+                .AddType(new ObjectTypeExtension(d => d
+                    .Name("Foo")
+                    .Field("description")
+                    .Type<StringType>()
+                    .Deprecated("Foo")))
+                .Create();
+
+            // assert
+            ObjectType type = schema.GetType<ObjectType>("Foo");
+            Assert.True(type.Fields["description"].IsDeprecated);
+            Assert.Equal("Foo", type.Fields["description"].DeprecationReason);
+            schema.ToString().MatchSnapshot();
+        }
+
+        [Fact]
+        public void ObjectTypeExtension_DepricateField_Without_Reason()
+        {
+            // arrange
+            FieldResolverDelegate resolver =
+                ctx => Task.FromResult<object>(null);
+
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType<FooType>()
+                .AddType(new ObjectTypeExtension(d => d
+                    .Name("Foo")
+                    .Field("description")
+                    .Type<StringType>()
+                    .Deprecated()))
+                .Create();
+
+            // assert
+            ObjectType type = schema.GetType<ObjectType>("Foo");
+            Assert.True(type.Fields["description"].IsDeprecated);
+            Assert.Equal(
+                WellKnownDirectives.DeprecationDefaultReason,
+                type.Fields["description"].DeprecationReason);
+            schema.ToString().MatchSnapshot();
         }
 
         [Fact]

--- a/src/Core/Types.Tests/Types/ObjectTypeTests.cs
+++ b/src/Core/Types.Tests/Types/ObjectTypeTests.cs
@@ -149,8 +149,9 @@ namespace HotChocolate.Types
             Assert.Equal("BAZ", resolverContext.Object.Result);
         }
 
+        [Obsolete]
         [Fact]
-        public void FieldIsDepricated()
+        public void DeprecationReasion_Obsolete()
         {
             // arrange
             var resolverContext = new Mock<IMiddlewareContext>();
@@ -166,6 +167,82 @@ namespace HotChocolate.Types
             // assert
             Assert.Equal("fooBar", fooType.Fields["bar"].DeprecationReason);
             Assert.True(fooType.Fields["bar"].IsDeprecated);
+        }
+
+        [Fact]
+        public void Deprecated_Field_With_Reason()
+        {
+            // arrange
+            var resolverContext = new Mock<IMiddlewareContext>();
+            resolverContext.SetupAllProperties();
+
+            // act
+            ObjectType fooType = CreateType(new ObjectType(c => c
+                .Name("Foo")
+                .Field("bar")
+                .Deprecated("fooBar")
+                .Resolver(() => "baz")));
+
+            // assert
+            Assert.Equal("fooBar", fooType.Fields["bar"].DeprecationReason);
+            Assert.True(fooType.Fields["bar"].IsDeprecated);
+        }
+
+        [Fact]
+        public void Deprecated_Field_With_Reason_Is_Serialized()
+        {
+            // arrange
+            var resolverContext = new Mock<IMiddlewareContext>();
+            resolverContext.SetupAllProperties();
+
+            // act
+            ISchema schema = CreateSchema(new ObjectType(c => c
+                .Name("Foo")
+                .Field("bar")
+                .Deprecated("fooBar")
+                .Resolver(() => "baz")));
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
+        [Fact]
+        public void Deprecated_Field_Without_Reason()
+        {
+            // arrange
+            var resolverContext = new Mock<IMiddlewareContext>();
+            resolverContext.SetupAllProperties();
+
+            // act
+            ObjectType fooType = CreateType(new ObjectType(c => c
+                .Name("Foo")
+                .Field("bar")
+                .Deprecated()
+                .Resolver(() => "baz")));
+
+            // assert
+            Assert.Equal(
+                WellKnownDirectives.DeprecationDefaultReason,
+                fooType.Fields["bar"].DeprecationReason);
+            Assert.True(fooType.Fields["bar"].IsDeprecated);
+        }
+
+        [Fact]
+        public void Deprecated_Field_Without_Reason_Is_Serialized()
+        {
+            // arrange
+            var resolverContext = new Mock<IMiddlewareContext>();
+            resolverContext.SetupAllProperties();
+
+            // act
+            ISchema schema = CreateSchema(new ObjectType(c => c
+                .Name("Foo")
+                .Field("bar")
+                .Deprecated()
+                .Resolver(() => "baz")));
+
+            // assert
+            schema.ToString().MatchSnapshot();
         }
 
         [Fact]

--- a/src/Core/Types.Tests/Types/TypeFactoryTests.cs
+++ b/src/Core/Types.Tests/Types/TypeFactoryTests.cs
@@ -135,6 +135,32 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public void InterfaceFieldDeprecationWithoutReason()
+        {
+            // arrange
+            string source = @"
+                interface Simple {
+                    a: String @deprecated
+                }";
+
+            // act
+            var schema = Schema.Create(source, c =>
+            {
+                c.RegisterQueryType<DummyQuery>();
+            });
+
+            // assert
+            InterfaceType type = schema.GetType<InterfaceType>("Simple");
+
+            Assert.True(type.Fields["a"].IsDeprecated);
+            Assert.Equal(
+                WellKnownDirectives.DeprecationDefaultReason,
+                type.Fields["a"].DeprecationReason);
+
+            schema.ToString().MatchSnapshot();
+        }
+
+        [Fact]
         public void CreateUnion()
         {
             // arrange

--- a/src/Core/Types.Tests/Types/__snapshots__/EnumTypeTests.Deprecate_Obsolete_Values.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/EnumTypeTests.Deprecate_Obsolete_Values.snap
@@ -8,7 +8,7 @@ type Query {
 
 enum FooObsolete {
   BAR1
-  BAR2 @deprecated(reason: "This field is no longer supported.")
+  BAR2 @deprecated(reason: "No longer supported")
 }
 
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."

--- a/src/Core/Types.Tests/Types/__snapshots__/EnumTypeTests.Deprecate_Obsolete_Values.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/EnumTypeTests.Deprecate_Obsolete_Values.snap
@@ -8,8 +8,11 @@ type Query {
 
 enum FooObsolete {
   BAR1
-  BAR2 @deprecated(reason: "No longer supported")
+  BAR2 @deprecated
 }
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
 
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
 scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeExtensionTests.InterfaceTypeExtension_Deprecated_Directive_Is_Serialized.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeExtensionTests.InterfaceTypeExtension_Deprecated_Directive_Is_Serialized.snap
@@ -1,0 +1,18 @@
+﻿schema {
+  query: DummyQuery
+}
+
+interface Foo {
+  description: String @deprecated(reason: "No longer supported") @deprecated(reason: "No longer supported")
+  name(a: String): String
+}
+
+type DummyQuery {
+  foo: String
+}
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeExtensionTests.InterfaceTypeExtension_Deprecated_Directive_Is_Serialized.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeExtensionTests.InterfaceTypeExtension_Deprecated_Directive_Is_Serialized.snap
@@ -3,7 +3,7 @@
 }
 
 interface Foo {
-  description: String @deprecated(reason: "No longer supported") @deprecated(reason: "No longer supported")
+  description: String @deprecated
   name(a: String): String
 }
 

--- a/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
@@ -11,5 +11,8 @@ type Query {
   foo: String
 }
 
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
 scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Deprecate_Obsolete_Fields.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Deprecate_Obsolete_Fields.snap
@@ -10,5 +10,8 @@ type Query {
   foo: String
 }
 
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
 scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_DepricateField_With_Reason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_DepricateField_With_Reason.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: Foo
+}
+
+type Foo {
+  description: String @deprecated(reason: "Foo")
+  name(a: String): String
+}
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_DepricateField_Without_Reason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_DepricateField_Without_Reason.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: Foo
+}
+
+type Foo {
+  description: String @deprecated
+  name(a: String): String
+}
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecate_Fields_With_Deprecated_Attribute.snap
@@ -11,5 +11,8 @@ type Query {
   foo: String
 }
 
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
 scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecate_Obsolete_Fields.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecate_Obsolete_Fields.snap
@@ -10,5 +10,8 @@ type Query {
   foo: String
 }
 
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
 scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecated_Field_With_Reason_Is_Serialized.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecated_Field_With_Reason_Is_Serialized.snap
@@ -1,0 +1,17 @@
+﻿schema {
+  query: Query
+}
+
+type Foo {
+  bar: String @deprecated(reason: "fooBar")
+}
+
+type Query {
+  foo: String
+}
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecated_Field_Without_Reason_Is_Serialized.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Deprecated_Field_Without_Reason_Is_Serialized.snap
@@ -1,0 +1,17 @@
+﻿schema {
+  query: Query
+}
+
+type Foo {
+  bar: String @deprecated
+}
+
+type Query {
+  foo: String
+}
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.InterfaceFieldDeprecationReason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.InterfaceFieldDeprecationReason.snap
@@ -3,12 +3,15 @@
 }
 
 interface Simple {
-  a: String @deprecated(reason: "reason123")
+  a: String @deprecated(reason: "reason123") @deprecated(reason: "reason123")
 }
 
 type DummyQuery {
   bar: String
 }
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
 
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
 scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.InterfaceFieldDeprecationReason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.InterfaceFieldDeprecationReason.snap
@@ -3,7 +3,7 @@
 }
 
 interface Simple {
-  a: String @deprecated(reason: "reason123") @deprecated(reason: "reason123")
+  a: String @deprecated(reason: "reason123")
 }
 
 type DummyQuery {

--- a/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.InterfaceFieldDeprecationWithoutReason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.InterfaceFieldDeprecationWithoutReason.snap
@@ -1,14 +1,13 @@
 ﻿schema {
-  query: Query
+  query: DummyQuery
 }
 
-type Query {
-  foo: String
+interface Simple {
+  a: String @deprecated(reason: "No longer supported")
 }
 
-enum FooDeprecated {
-  BAR1
-  BAR2 @deprecated(reason: "Baz.")
+type DummyQuery {
+  bar: String
 }
 
 "The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."

--- a/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.ObjectFieldDeprecationReason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.ObjectFieldDeprecationReason.snap
@@ -3,8 +3,11 @@
 }
 
 type Simple {
-  a: String @deprecated(reason: "reason123")
+  a: String @deprecated(reason: "reason123") @deprecated(reason: "reason123")
 }
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
 
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
 scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.ObjectFieldDeprecationReason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/TypeFactoryTests.ObjectFieldDeprecationReason.snap
@@ -3,7 +3,7 @@
 }
 
 type Simple {
-  a: String @deprecated(reason: "reason123") @deprecated(reason: "reason123")
+  a: String @deprecated(reason: "reason123")
 }
 
 "The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."

--- a/src/Core/Types.Tests/__snapshots__/SchemaFirstTests.DescriptionsAreCorrectlyRead.snap
+++ b/src/Core/Types.Tests/__snapshots__/SchemaFirstTests.DescriptionsAreCorrectlyRead.snap
@@ -1223,6 +1223,25 @@
           "onOperation": false,
           "onFragment": false,
           "onField": false
+        },
+        {
+          "name": "deprecated",
+          "description": "The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values.",
+          "args": [
+            {
+              "name": "reason",
+              "description": "Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
         }
       ]
     }

--- a/src/Core/Types/Configuration/Contracts/IInitializationContext.cs
+++ b/src/Core/Types/Configuration/Contracts/IInitializationContext.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using HotChocolate.Types.Descriptors;
+using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Configuration
 {
@@ -12,9 +13,15 @@ namespace HotChocolate.Configuration
             ITypeReference reference,
             TypeDependencyKind kind);
 
+        void RegisterDependency(
+            TypeDependency dependency);
+
         void RegisterDependencyRange(
             IEnumerable<ITypeReference> references,
             TypeDependencyKind kind);
+
+        void RegisterDependencyRange(
+            IEnumerable<TypeDependency> dependencies);
 
         void RegisterDependency(IDirectiveReference reference);
 

--- a/src/Core/Types/Configuration/InitializationContext.cs
+++ b/src/Core/Types/Configuration/InitializationContext.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using HotChocolate.Resolvers;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
+using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Configuration
 {
@@ -84,6 +85,16 @@ namespace HotChocolate.Configuration
             _typeDependencies.Add(new TypeDependency(reference, kind));
         }
 
+        public void RegisterDependency(TypeDependency dependency)
+        {
+            if (dependency is null)
+            {
+                throw new ArgumentNullException(nameof(dependency));
+            }
+
+            _typeDependencies.Add(dependency);
+        }
+
         public void RegisterDependencyRange(
             IEnumerable<ITypeReference> references,
             TypeDependencyKind kind)
@@ -97,6 +108,12 @@ namespace HotChocolate.Configuration
             {
                 _typeDependencies.Add(new TypeDependency(reference, kind));
             }
+        }
+
+        public void RegisterDependencyRange(
+            IEnumerable<TypeDependency> dependencies)
+        {
+            _typeDependencies.AddRange(dependencies);
         }
 
         public void RegisterDependency(IDirectiveReference reference)

--- a/src/Core/Types/Configuration/RegisteredType.cs
+++ b/src/Core/Types/Configuration/RegisteredType.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
+using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Configuration
 {

--- a/src/Core/Types/Configuration/TypeInitializer.cs
+++ b/src/Core/Types/Configuration/TypeInitializer.cs
@@ -10,6 +10,7 @@ using HotChocolate.Configuration.Validation;
 using System.Reflection;
 using System.Globalization;
 using HotChocolate.Properties;
+using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Configuration
 {

--- a/src/Core/Types/SchemaSerializer.cs
+++ b/src/Core/Types/SchemaSerializer.cs
@@ -71,13 +71,15 @@ namespace HotChocolate
                     SerializeSchemaTypeDefinition(schema, referenced));
             }
 
-            IEnumerable<DirectiveDefinitionNode> directiveTypeDefinitions = schema.DirectiveTypes
+            IEnumerable<DirectiveDefinitionNode> directiveTypeDefinitions =
+                schema.DirectiveTypes
                 .Where(t => referenced.DirectiveNames.Contains(t.Name))
                 .Select(t => SerializeDirectiveTypeDefinition(t, referenced));
 
             typeDefinitions.AddRange(directiveTypeDefinitions);
 
-            IEnumerable<ScalarTypeDefinitionNode> scalarTypeDefinitions = schema.Types
+            IEnumerable<ScalarTypeDefinitionNode> scalarTypeDefinitions =
+                schema.Types
                 .OfType<ScalarType>()
                 .Where(t => referenced.TypeNames.Contains(t.Name))
                 .Select(t => SerializeScalarType(t));

--- a/src/Core/Types/SchemaSerializer.cs
+++ b/src/Core/Types/SchemaSerializer.cs
@@ -339,15 +339,6 @@ namespace HotChocolate
                 .Select(t => SerializeDirective(t, referenced))
                 .ToList();
 
-            if(enumValue.IsDeprecated)
-            {
-                directives.Add(new DirectiveNode(
-                    WellKnownDirectives.Deprecated,
-                    new ArgumentNode(
-                        WellKnownDirectives.DeprecationReasonArgument,
-                        enumValue.DeprecationReason)));
-            }
-
             return new EnumValueDefinitionNode
             (
                 null,
@@ -380,15 +371,6 @@ namespace HotChocolate
             var directives = field.Directives
                 .Select(t => SerializeDirective(t, referenced))
                 .ToList();
-
-            if(field.IsDeprecated)
-            {
-                directives.Add(new DirectiveNode(
-                    WellKnownDirectives.Deprecated,
-                    new ArgumentNode(
-                        WellKnownDirectives.DeprecationReasonArgument,
-                        field.DeprecationReason)));
-            }
 
             return new FieldDefinitionNode
             (
@@ -455,7 +437,7 @@ namespace HotChocolate
             ReferencedTypes referenced)
         {
             referenced.DirectiveNames.Add(directiveType.Name);
-            return directiveType.ToNode();
+            return directiveType.ToNode(true);
         }
 
         private static StringValueNode SerializeDescription(string description)

--- a/src/Core/Types/Types/Contracts/IDirective.cs
+++ b/src/Core/Types/Types/Contracts/IDirective.cs
@@ -22,6 +22,8 @@ namespace HotChocolate.Types
 
         DirectiveNode ToNode();
 
+        DirectiveNode ToNode(bool removeNullArguments);
+
         T GetArgument<T>(string argumentName);
     }
 }

--- a/src/Core/Types/Types/Descriptors/Contracts/IEnumValueDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/Contracts/IEnumValueDescriptor.cs
@@ -1,4 +1,5 @@
-﻿using HotChocolate.Language;
+﻿using System;
+using HotChocolate.Language;
 using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Types
@@ -14,7 +15,13 @@ namespace HotChocolate.Types
 
         IEnumValueDescriptor Description(string value);
 
-        IEnumValueDescriptor DeprecationReason(string reason);
+        [Obsolete("Use `Deprecated`.")]
+        IEnumValueDescriptor DeprecationReason(
+            string reason);
+
+        IEnumValueDescriptor Deprecated(string reason);
+
+        IEnumValueDescriptor Deprecated();
 
         IEnumValueDescriptor Directive<T>(
             T directiveInstance)

--- a/src/Core/Types/Types/Descriptors/Contracts/IInterfaceFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/Contracts/IInterfaceFieldDescriptor.cs
@@ -15,7 +15,13 @@ namespace HotChocolate.Types
 
         IInterfaceFieldDescriptor Description(string value);
 
-        IInterfaceFieldDescriptor DeprecationReason(string reason);
+        [Obsolete("Use `Deprecated`.")]
+        IInterfaceFieldDescriptor DeprecationReason(
+            string reason);
+
+        IInterfaceFieldDescriptor Deprecated(string reason);
+
+        IInterfaceFieldDescriptor Deprecated();
 
         IInterfaceFieldDescriptor Type<TOutputType>()
             where TOutputType : IOutputType;

--- a/src/Core/Types/Types/Descriptors/Contracts/IObjectFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/Contracts/IObjectFieldDescriptor.cs
@@ -18,8 +18,13 @@ namespace HotChocolate.Types
         IObjectFieldDescriptor Description(
             string value);
 
+        [Obsolete("Use `Deprecated`.")]
         IObjectFieldDescriptor DeprecationReason(
-            string value);
+            string reason);
+
+        IObjectFieldDescriptor Deprecated(string reason);
+
+        IObjectFieldDescriptor Deprecated();
 
         IObjectFieldDescriptor Type<TOutputType>()
             where TOutputType : IOutputType;

--- a/src/Core/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
@@ -162,17 +162,17 @@ namespace HotChocolate.Types.Descriptors
             return description;
         }
 
-        public virtual string GetDeprecationReason(MemberInfo member)
+        public virtual bool IsDeprecated(MemberInfo member, out string reason)
         {
             if (member == null)
             {
                 throw new ArgumentNullException(nameof(member));
             }
 
-            return member.GetGraphQLDeprecationReason();
+            return member.IsDeprecated(out reason);
         }
 
-        public virtual string GetDeprecationReason(object value)
+        public virtual bool IsDeprecated(object value, out string reason)
         {
             Type enumType = value.GetType();
 
@@ -184,11 +184,12 @@ namespace HotChocolate.Types.Descriptors
 
                 if (enumMember != null)
                 {
-                    return enumMember.GetGraphQLDeprecationReason();
+                    return enumMember.IsDeprecated(out reason);
                 }
             }
 
-            return null;
+            reason = null;
+            return false;
         }
     }
 }

--- a/src/Core/Types/Types/Descriptors/Conventions/INamingConventions.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/INamingConventions.cs
@@ -23,8 +23,8 @@ namespace HotChocolate.Types.Descriptors
 
         string GetEnumValueDescription(object value);
 
-        string GetDeprecationReason(MemberInfo member);
+        bool IsDeprecated(MemberInfo member, out string reason);
 
-        string GetDeprecationReason(object value);
+        bool IsDeprecated(object value, out string reason);
     }
 }

--- a/src/Core/Types/Types/Descriptors/Definitions/DefinitionBase.cs
+++ b/src/Core/Types/Types/Descriptors/Definitions/DefinitionBase.cs
@@ -23,6 +23,12 @@ namespace HotChocolate.Types.Descriptors.Definitions
         public IDictionary<string, object> ContextData { get; } =
             new Dictionary<string, object>();
 
+        /// <summary>
+        /// Gets access to additional type dependencies.
+        /// </summary>
+        public ICollection<TypeDependency> Dependencies { get; } =
+            new List<TypeDependency>();
+
         internal ICollection<ITypeConfigration> Configurations { get; } =
             new List<ITypeConfigration>();
 

--- a/src/Core/Types/Types/Descriptors/Definitions/ITypeConfigration.cs
+++ b/src/Core/Types/Types/Descriptors/Definitions/ITypeConfigration.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using HotChocolate.Configuration;
 
-namespace HotChocolate.Types
+namespace HotChocolate.Types.Descriptors.Definitions
 {
     internal interface ITypeConfigration
     {

--- a/src/Core/Types/Types/Descriptors/Definitions/TypeDependency.cs
+++ b/src/Core/Types/Types/Descriptors/Definitions/TypeDependency.cs
@@ -1,10 +1,8 @@
 using System;
 using HotChocolate.Properties;
-using HotChocolate.Types;
-using HotChocolate.Types.Descriptors;
 using HotChocolate.Utilities;
 
-namespace HotChocolate.Configuration
+namespace HotChocolate.Types.Descriptors.Definitions
 {
     public sealed class TypeDependency
     {

--- a/src/Core/Types/Types/Descriptors/Definitions/TypeDependencyKind.cs
+++ b/src/Core/Types/Types/Descriptors/Definitions/TypeDependencyKind.cs
@@ -1,4 +1,4 @@
-namespace HotChocolate.Configuration
+namespace HotChocolate.Types.Descriptors.Definitions
 {
     public enum TypeDependencyKind
     {

--- a/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
@@ -8,6 +8,9 @@ namespace HotChocolate.Types.Descriptors
         : DescriptorBase<EnumValueDefinition>
         , IEnumValueDescriptor
     {
+        private bool _deprecatedDependecySet;
+        private DirectiveDefinition _deprecatedDirective;
+
         public EnumValueDescriptor(IDescriptorContext context, object value)
             : base(context)
         {
@@ -46,10 +49,52 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
-        public IEnumValueDescriptor DeprecationReason(string reason)
+        [Obsolete("Use `Deprecated`.")]
+        public IEnumValueDescriptor DeprecationReason(string reason) =>
+            Deprecated(reason);
+
+        public IEnumValueDescriptor Deprecated(string reason)
         {
-            Definition.DeprecationReason = reason;
+            if (string.IsNullOrEmpty(reason))
+            {
+                return Deprecated();
+            }
+            else
+            {
+                Definition.DeprecationReason = reason;
+                AddDeprectedDirective(reason);
+                return this;
+            }
+        }
+
+        public IEnumValueDescriptor Deprecated()
+        {
+            Definition.DeprecationReason =
+                WellKnownDirectives.DeprecationDefaultReason;
+            AddDeprectedDirective(Definition.DeprecationReason);
             return this;
+        }
+
+        private void AddDeprectedDirective(string reason)
+        {
+            if (_deprecatedDirective != null)
+            {
+                Definition.Directives.Remove(_deprecatedDirective);
+            }
+
+            _deprecatedDirective = new DirectiveDefinition(
+                new DeprecatedDirective(reason));
+            Definition.Directives.Add(_deprecatedDirective);
+
+            if (!_deprecatedDependecySet)
+            {
+                Definition.Dependencies.Add(new TypeDependency(
+                    new ClrTypeReference(
+                        typeof(DeprecatedDirectiveType),
+                        TypeContext.None),
+                    TypeDependencyKind.Completed));
+                _deprecatedDependecySet = true;
+            }
         }
 
         public IEnumValueDescriptor Directive<T>(T directiveInstance)

--- a/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
@@ -23,8 +23,11 @@ namespace HotChocolate.Types.Descriptors
             Definition.Value = value;
             Definition.Description =
                 context.Naming.GetEnumValueDescription(value);
-            Definition.DeprecationReason =
-                context.Naming.GetDeprecationReason(value);
+
+            if (context.Naming.IsDeprecated(value, out string reason))
+            {
+                Deprecated(reason);
+            }
         }
 
         protected override EnumValueDefinition Definition { get; } =
@@ -71,7 +74,7 @@ namespace HotChocolate.Types.Descriptors
         {
             Definition.DeprecationReason =
                 WellKnownDirectives.DeprecationDefaultReason;
-            AddDeprectedDirective(Definition.DeprecationReason);
+            AddDeprectedDirective(null);
             return this;
         }
 

--- a/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -33,8 +33,11 @@ namespace HotChocolate.Types.Descriptors
             Definition.Description = context.Naming.GetMemberDescription(
                 member, MemberKind.InputObjectField);
             Definition.Type = context.Inspector.GetOutputReturnType(member);
-            Definition.DeprecationReason =
-                context.Naming.GetDeprecationReason(member);
+
+            if (context.Naming.IsDeprecated(member, out string reason))
+            {
+                Deprecated(reason);
+            }
 
             if (member is MethodInfo m)
             {

--- a/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -85,10 +85,19 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
-        public new IInterfaceFieldDescriptor DeprecationReason(
-            string deprecationReason)
+        [Obsolete("Use `Deprecated`.")]
+        public IInterfaceFieldDescriptor DeprecationReason(string reason) =>
+            Deprecated(reason);
+
+        public new IInterfaceFieldDescriptor Deprecated(string reason)
         {
-            base.DeprecationReason(deprecationReason);
+            base.Deprecated(reason);
+            return this;
+        }
+
+        public new IInterfaceFieldDescriptor Deprecated()
+        {
+            base.Deprecated();
             return this;
         }
 

--- a/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -94,10 +94,19 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
-        public new IObjectFieldDescriptor DeprecationReason(
-            string value)
+        [Obsolete("Use `Deprecated`.")]
+        public IObjectFieldDescriptor DeprecationReason(string reason) =>
+           Deprecated(reason);
+
+        public new IObjectFieldDescriptor Deprecated(string reason)
         {
-            base.DeprecationReason(value);
+            base.Deprecated(reason);
+            return this;
+        }
+
+        public new IObjectFieldDescriptor Deprecated()
+        {
+            base.Deprecated();
             return this;
         }
 

--- a/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -43,8 +43,11 @@ namespace HotChocolate.Types.Descriptors
                 member, MemberKind.ObjectField);
             Definition.Type = context.Inspector.GetOutputReturnType(member);
             Definition.ResolverType = resolverType;
-            Definition.DeprecationReason =
-                context.Naming.GetDeprecationReason(member);
+
+            if (context.Naming.IsDeprecated(member, out string reason))
+            {
+                Deprecated(reason);
+            }
 
             if (member is MethodInfo m)
             {

--- a/src/Core/Types/Types/Descriptors/OutputFieldDescriptorBase.cs
+++ b/src/Core/Types/Types/Descriptors/OutputFieldDescriptorBase.cs
@@ -121,7 +121,7 @@ namespace HotChocolate.Types.Descriptors
         {
             Definition.DeprecationReason =
                 WellKnownDirectives.DeprecationDefaultReason;
-            AddDeprectedDirective(Definition.DeprecationReason);
+            AddDeprectedDirective(null);
         }
 
         private void AddDeprectedDirective(string reason)

--- a/src/Core/Types/Types/Descriptors/OutputFieldDescriptorBase.cs
+++ b/src/Core/Types/Types/Descriptors/OutputFieldDescriptorBase.cs
@@ -12,6 +12,9 @@ namespace HotChocolate.Types.Descriptors
         : DescriptorBase<TDefinition>
         where TDefinition : OutputFieldDefinitionBase
     {
+        private bool _deprecatedDependecySet;
+        private DirectiveDefinition _deprecatedDirective;
+
         protected OutputFieldDescriptorBase(IDescriptorContext context)
             : base(context)
         {
@@ -101,9 +104,46 @@ namespace HotChocolate.Types.Descriptors
             Definition.Arguments.Add(definition);
         }
 
-        protected void DeprecationReason(string reason)
+        public void Deprecated(string reason)
         {
-            Definition.DeprecationReason = reason;
+            if (string.IsNullOrEmpty(reason))
+            {
+                Deprecated();
+            }
+            else
+            {
+                Definition.DeprecationReason = reason;
+                AddDeprectedDirective(reason);
+            }
+        }
+
+        public void Deprecated()
+        {
+            Definition.DeprecationReason =
+                WellKnownDirectives.DeprecationDefaultReason;
+            AddDeprectedDirective(Definition.DeprecationReason);
+        }
+
+        private void AddDeprectedDirective(string reason)
+        {
+            if (_deprecatedDirective != null)
+            {
+                Definition.Directives.Remove(_deprecatedDirective);
+            }
+
+            _deprecatedDirective = new DirectiveDefinition(
+                new DeprecatedDirective(reason));
+            Definition.Directives.Add(_deprecatedDirective);
+
+            if (!_deprecatedDependecySet)
+            {
+                Definition.Dependencies.Add(new TypeDependency(
+                    new ClrTypeReference(
+                        typeof(DeprecatedDirectiveType),
+                        TypeContext.None),
+                    TypeDependencyKind.Completed));
+                _deprecatedDependecySet = true;
+            }
         }
 
         protected void Ignore()

--- a/src/Core/Types/Types/Directive.cs
+++ b/src/Core/Types/Types/Directive.cs
@@ -72,7 +72,9 @@ namespace HotChocolate.Types
             return CreateCustomDirective<T>();
         }
 
-        public DirectiveNode ToNode()
+        public DirectiveNode ToNode() => ToNode(false);
+
+        public DirectiveNode ToNode(bool removeNullArguments)
         {
             if (_parsedDirective is null)
             {
@@ -92,6 +94,21 @@ namespace HotChocolate.Types
                 }
 
                 _parsedDirective = new DirectiveNode(Name, arguments);
+            }
+
+            if (removeNullArguments
+                && _parsedDirective.Arguments.Count != 0
+                && _parsedDirective.Arguments.Any(t => t.Value.IsNull()))
+            {
+                var arguments = new List<ArgumentNode>();
+                foreach (ArgumentNode argument in _parsedDirective.Arguments)
+                {
+                    if (!argument.Value.IsNull())
+                    {
+                        arguments.Add(argument);
+                    }
+                }
+                return _parsedDirective.WithArguments(arguments);
             }
 
             return _parsedDirective;

--- a/src/Core/Types/Types/Directives/DeprecatedDirective.cs
+++ b/src/Core/Types/Types/Directives/DeprecatedDirective.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace HotChocolate.Types
+{
+    [Serializable]
+    public sealed class DeprecatedDirective
+    {
+        public DeprecatedDirective()
+        {
+            Reason = WellKnownDirectives.DeprecationDefaultReason;
+        }
+
+        public DeprecatedDirective(string reason)
+        {
+            // TODO : resources
+            if (string.IsNullOrEmpty(reason))
+            {
+                throw new ArgumentException(
+                    "The deprecation reason cannot be null or empty.",
+                    nameof(reason));
+            }
+
+            Reason = reason;
+        }
+
+        public string Reason { get; }
+    }
+}

--- a/src/Core/Types/Types/Directives/DeprecatedDirective.cs
+++ b/src/Core/Types/Types/Directives/DeprecatedDirective.cs
@@ -7,19 +7,10 @@ namespace HotChocolate.Types
     {
         public DeprecatedDirective()
         {
-            Reason = WellKnownDirectives.DeprecationDefaultReason;
         }
 
         public DeprecatedDirective(string reason)
         {
-            // TODO : resources
-            if (string.IsNullOrEmpty(reason))
-            {
-                throw new ArgumentException(
-                    "The deprecation reason cannot be null or empty.",
-                    nameof(reason));
-            }
-
             Reason = reason;
         }
 

--- a/src/Core/Types/Types/Directives/DeprecatedDirectiveType.cs
+++ b/src/Core/Types/Types/Directives/DeprecatedDirectiveType.cs
@@ -1,0 +1,38 @@
+namespace HotChocolate.Types
+{
+    /// <summary>
+    /// The @deprecated directive is used within the type system definition
+    /// language to indicate deprecated portions of a GraphQL service’s schema,
+    /// such as deprecated fields on a type or deprecated enum values.
+    ///
+    /// Deprecations include a reason for why it is deprecated,
+    /// which is formatted using Markdown syntax (as specified by CommonMark).
+    /// </summary>
+    public sealed class DeprecatedDirectiveType
+        : DirectiveType<DeprecatedDirective>
+    {
+        protected override void Configure(
+            IDirectiveTypeDescriptor<DeprecatedDirective> descriptor)
+        {
+            // TODO : resources
+            descriptor
+                .Name("deprecated")
+                .Description(
+                    "The @deprecated directive is used within the " +
+                    "type system definition language to indicate " +
+                    "deprecated portions of a GraphQL service’s schema," +
+                    "such as deprecated fields on a type or deprecated " +
+                    "enum values.")
+                .Location(DirectiveLocation.FieldDefinition)
+                .Location(DirectiveLocation.EnumValue)
+                .Argument(t => t.Reason)
+                .Name("reason")
+                .Description(
+                    "Deprecations include a reason for why it is deprecated, " +
+                    "which is formatted using Markdown syntax " +
+                    "(as specified by CommonMark).")
+                .Type<StringType>()
+                .DefaultValue(WellKnownDirectives.DeprecationDefaultReason);
+        }
+    }
+}

--- a/src/Core/Types/Types/Directives/Directives.cs
+++ b/src/Core/Types/Types/Directives/Directives.cs
@@ -10,6 +10,7 @@ namespace HotChocolate.Types
             {
                 WellKnownDirectives.Skip,
                 WellKnownDirectives.Include,
+                WellKnownDirectives.Deprecated,
                 "cost"
             };
 

--- a/src/Core/Types/Types/Factories/EnumTypeFactory.cs
+++ b/src/Core/Types/Types/Factories/EnumTypeFactory.cs
@@ -39,7 +39,10 @@ namespace HotChocolate.Types.Factories
 
                 foreach (DirectiveNode directive in node.Directives)
                 {
-                    d.Directive(directive);
+                    if (!directive.IsDeprecationReason())
+                    {
+                        d.Directive(directive);
+                    }
                 }
 
                 DeclareValues(d, node.Values);

--- a/src/Core/Types/Types/Factories/EnumTypeFactory.cs
+++ b/src/Core/Types/Types/Factories/EnumTypeFactory.cs
@@ -59,7 +59,7 @@ namespace HotChocolate.Types.Factories
                 string deprecactionReason = value.DeprecationReason();
                 if (!string.IsNullOrEmpty(deprecactionReason))
                 {
-                    valueDescriptor.DeprecationReason(deprecactionReason);
+                    valueDescriptor.Deprecated(deprecactionReason);
                 }
             }
         }

--- a/src/Core/Types/Types/Factories/InterfaceTypeFactory.cs
+++ b/src/Core/Types/Types/Factories/InterfaceTypeFactory.cs
@@ -69,7 +69,7 @@ namespace HotChocolate.Types.Factories
                 string deprecactionReason = fieldDefinition.DeprecationReason();
                 if (!string.IsNullOrEmpty(deprecactionReason))
                 {
-                    fieldDescriptor.DeprecationReason(deprecactionReason);
+                    fieldDescriptor.Deprecated(deprecactionReason);
                 }
 
                 DeclareFieldArguments(fieldDescriptor, fieldDefinition);

--- a/src/Core/Types/Types/Factories/ObjectTypeFactory.cs
+++ b/src/Core/Types/Types/Factories/ObjectTypeFactory.cs
@@ -94,7 +94,7 @@ namespace HotChocolate.Types.Factories
                 string deprecactionReason = fieldDefinition.DeprecationReason();
                 if (!string.IsNullOrEmpty(deprecactionReason))
                 {
-                    fieldDescriptor.DeprecationReason(deprecactionReason);
+                    fieldDescriptor.Deprecated(deprecactionReason);
                 }
 
                 DeclareFieldArguments(fieldDescriptor, fieldDefinition);

--- a/src/Core/Types/Types/Factories/SyntaxNodeExtensions.cs
+++ b/src/Core/Types/Types/Factories/SyntaxNodeExtensions.cs
@@ -11,24 +11,22 @@ namespace HotChocolate.Types.Factories
         {
             DirectiveNode directive = syntaxNode.Directives.FirstOrDefault(t =>
                 t.Name.Value == WellKnownDirectives.Deprecated);
+
             if (directive == null)
             {
                 return null;
             }
 
-            ArgumentNode argument = directive.Arguments.FirstOrDefault(t =>
-                t.Name.Value == WellKnownDirectives.DeprecationReasonArgument);
-            if (argument == null)
-            {
-                return null;
-            }
-
-            if (argument.Value is StringValueNode s)
+            if (directive.Arguments.Count != 0
+                && directive.Arguments[0].Name.Value ==
+                    WellKnownDirectives.DeprecationReasonArgument
+                && directive.Arguments[0].Value is StringValueNode s
+                && !string.IsNullOrEmpty(s.Value))
             {
                 return s.Value;
             }
 
-            return null;
+            return WellKnownDirectives.DeprecationDefaultReason;
         }
 
         public static bool IsDeprecationReason(this DirectiveNode directiveNode)

--- a/src/Core/Types/Types/Helpers/TypeDependencyHelper.cs
+++ b/src/Core/Types/Types/Helpers/TypeDependencyHelper.cs
@@ -27,6 +27,7 @@ namespace HotChocolate.Types
                 definition.Interfaces,
                 TypeDependencyKind.Default);
 
+            RegisterAdditionalDependencies(context, definition);
             RegisterDirectiveDependencies(context, definition);
             RegisterFieldDependencies(context, definition.Fields);
 
@@ -57,6 +58,7 @@ namespace HotChocolate.Types
                 throw new ArgumentNullException(nameof(definition));
             }
 
+            RegisterAdditionalDependencies(context, definition);
             RegisterDirectiveDependencies(context, definition);
             RegisterFieldDependencies(context, definition.Fields);
         }
@@ -75,6 +77,7 @@ namespace HotChocolate.Types
                 throw new ArgumentNullException(nameof(definition));
             }
 
+            RegisterAdditionalDependencies(context, definition);
             RegisterDirectiveDependencies(context, definition);
         }
 
@@ -92,10 +95,13 @@ namespace HotChocolate.Types
                 throw new ArgumentNullException(nameof(definition));
             }
 
+            RegisterAdditionalDependencies(context, definition);
             RegisterDirectiveDependencies(context, definition);
 
             foreach (InputFieldDefinition field in definition.Fields)
             {
+                RegisterAdditionalDependencies(context, field);
+
                 if (field.Type != null)
                 {
                     context.RegisterDependency(field.Type,
@@ -118,12 +124,22 @@ namespace HotChocolate.Types
                 TypeDependencyKind.Completed);
         }
 
+        private static void RegisterAdditionalDependencies(
+            this IInitializationContext context,
+            DefinitionBase definition)
+        {
+            context.RegisterDependencyRange(
+                definition.Dependencies);
+        }
+
         private static void RegisterFieldDependencies(
             this IInitializationContext context,
             IEnumerable<OutputFieldDefinitionBase> fields)
         {
             foreach (OutputFieldDefinitionBase field in fields)
             {
+                RegisterAdditionalDependencies(context, field);
+
                 if (field.Type != null)
                 {
                     context.RegisterDependency(field.Type,
@@ -145,6 +161,8 @@ namespace HotChocolate.Types
         {
             foreach (ArgumentDefinition field in fields)
             {
+                RegisterAdditionalDependencies(context, field);
+
                 if (field.Type != null)
                 {
                     context.RegisterDependency(field.Type,

--- a/src/Core/Types/Types/Helpers/TypeDependencyHelper.cs
+++ b/src/Core/Types/Types/Helpers/TypeDependencyHelper.cs
@@ -79,6 +79,7 @@ namespace HotChocolate.Types
 
             RegisterAdditionalDependencies(context, definition);
             RegisterDirectiveDependencies(context, definition);
+            RegisterEnumValueDependencies(context, definition.Values);
         }
 
         public static void RegisterDependencies(
@@ -171,6 +172,20 @@ namespace HotChocolate.Types
 
                 context.RegisterDependencyRange(
                     field.Directives.Select(t => t.TypeReference),
+                    TypeDependencyKind.Completed);
+            }
+        }
+
+        private static void RegisterEnumValueDependencies(
+            this IInitializationContext context,
+            IEnumerable<EnumValueDefinition> enumValues)
+        {
+            foreach (EnumValueDefinition enumValue in enumValues)
+            {
+                RegisterAdditionalDependencies(context, enumValue);
+
+                context.RegisterDependencyRange(
+                    enumValue.Directives.Select(t => t.TypeReference),
                     TypeDependencyKind.Completed);
             }
         }

--- a/src/Core/Types/Types/Introspection/__Directive.cs
+++ b/src/Core/Types/Types/Introspection/__Directive.cs
@@ -38,17 +38,17 @@ namespace HotChocolate.Types.Introspection
             descriptor.Field("onOperation")
                 .Type<NonNullType<BooleanType>>()
                 .Resolver(c => GetOnOperation(c))
-                .DeprecationReason(TypeResources.Directive_UseLocation);
+                .Deprecated(TypeResources.Directive_UseLocation);
 
             descriptor.Field("onFragment")
                 .Type<NonNullType<BooleanType>>()
                 .Resolver(c => GetOnFragment(c))
-                .DeprecationReason(TypeResources.Directive_UseLocation);
+                .Deprecated(TypeResources.Directive_UseLocation);
 
             descriptor.Field("onField")
                 .Type<NonNullType<BooleanType>>()
                 .Resolver(c => GetOnField(c))
-                .DeprecationReason(TypeResources.Directive_UseLocation);
+                .Deprecated(TypeResources.Directive_UseLocation);
         }
 
         private static bool GetOnOperation(IResolverContext context)

--- a/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizeDirectiveTests.FieldAuth_DefaultPolicy.snap
+++ b/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizeDirectiveTests.FieldAuth_DefaultPolicy.snap
@@ -3,7 +3,7 @@
 }
 
 type Query {
-  foo: String @authorize(policy: null, roles: [  ])
+  foo: String @authorize(roles: [  ])
 }
 
 directive @authorize(policy: String roles: [String]) repeatable on OBJECT | FIELD_DEFINITION

--- a/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizeDirectiveTests.FieldAuth_WithRoles.snap
+++ b/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizeDirectiveTests.FieldAuth_WithRoles.snap
@@ -3,7 +3,7 @@
 }
 
 type Query {
-  foo: String @authorize(policy: null, roles: [ "MyRole" ])
+  foo: String @authorize(roles: [ "MyRole" ])
 }
 
 directive @authorize(policy: String roles: [String]) repeatable on OBJECT | FIELD_DEFINITION

--- a/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizeDirectiveTests.TypeAuth_DefaultPolicy.snap
+++ b/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizeDirectiveTests.TypeAuth_DefaultPolicy.snap
@@ -2,7 +2,7 @@
   query: Query
 }
 
-type Query @authorize(policy: null, roles: [  ]) {
+type Query @authorize(roles: [  ]) {
   foo: String
 }
 

--- a/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizeDirectiveTests.TypeAuth_WithRoles.snap
+++ b/src/Server/AspNetCore.Tests/Authorization/__snapshots__/AuthorizeDirectiveTests.TypeAuth_WithRoles.snap
@@ -2,7 +2,7 @@
   query: Query
 }
 
-type Query @authorize(policy: null, roles: [ "MyRole" ]) {
+type Query @authorize(roles: [ "MyRole" ]) {
   foo: String
 }
 

--- a/src/Stitching/Stitching.Tests/Middleware/DelegateToRemoteSchemaMiddlewareTests.cs
+++ b/src/Stitching/Stitching.Tests/Middleware/DelegateToRemoteSchemaMiddlewareTests.cs
@@ -1,29 +1,15 @@
-using System.Text;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Net.Cache;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using Snapshooter.Xunit;
 using Xunit;
 using HotChocolate.AspNetCore;
 using HotChocolate.Execution;
-using HotChocolate.Stitching.Schemas.Contracts;
-using HotChocolate.Stitching.Schemas.Customers;
 using HotChocolate.Types;
 using HotChocolate.Resolvers;
-using HotChocolate.Stitching.Delegation;
 using FileResource = ChilliCream.Testing.FileResource;
-using HotChocolate.Language;
-using HotChocolate.Stitching.Utilities;
-using HotChocolate.Types.Relay;
 
 namespace HotChocolate.Stitching
 {

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/Errorbehavior.ConnectionLost.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/Errorbehavior.ConnectionLost.snap
@@ -1,0 +1,17 @@
+﻿{
+  "Data": {
+    "createCustomer": null
+  },
+  "Extensions": {},
+  "Errors": [
+    {
+      "Message": "System.Net.Http.HttpRequestException",
+      "Code": null,
+      "Path": null,
+      "Locations": [],
+      "Exception": null,
+      "Extensions": {}
+    }
+  ],
+  "ContextData": {}
+}

--- a/src/Stitching/Stitching/Merge/RemoveDirectivesRewriter.cs
+++ b/src/Stitching/Stitching/Merge/RemoveDirectivesRewriter.cs
@@ -1,9 +1,7 @@
+using System.Linq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using HotChocolate;
 using HotChocolate.Language;
-using HotChocolate.Resolvers;
 
 namespace HotChocolate.Stitching.Merge
 {


### PR DESCRIPTION
The deprecation directive was not implemented as specified in the spec. With this PR we have now aligned how deprecation works with HC.

https://graphql.github.io/graphql-spec/draft/#sec--deprecated

`DeprecationReason` is now obsolete. In order to be more explicit I have introduced `Deprecated` for the code-first variant.

`descriptor.Deprecated("reason")` or `descriptor.Deprecated()` can be used to deprecate a field or enum value.

With code first we now are able to use `@deprecated` without any arguments.