### PR TITLE
Changed IHttpContext.User from object to strongly typed property

### DIFF
--- a/src/Server/AspNetCore.Tests/Subscriptions/HttpContextMock.cs
+++ b/src/Server/AspNetCore.Tests/Subscriptions/HttpContextMock.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Claims;
+using System.Security.Principal;
 using System.Threading;
 
 namespace HotChocolate.AspNetCore.Subscriptions
@@ -7,7 +8,7 @@ namespace HotChocolate.AspNetCore.Subscriptions
     internal class HttpContextMock
         : IHttpContext
     {
-        public object User { get; set; }
+        public IPrincipal User { get; set; }
 
         public CancellationToken RequestAborted { get; }
 

--- a/src/Server/AspNetCore/Subscriptions/HttpContextWrapper.cs
+++ b/src/Server/AspNetCore/Subscriptions/HttpContextWrapper.cs
@@ -21,7 +21,7 @@ namespace HotChocolate.AspNetCore.Subscriptions
             _context = context;
         }
 
-        public object User
+        public ClaimsPrincipal User
         {
             get
             {

--- a/src/Server/AspNetCore/Subscriptions/HttpContextWrapper.cs
+++ b/src/Server/AspNetCore/Subscriptions/HttpContextWrapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Claims;
+using System.Security.Principal;
 using System.Threading;
 #if ASPNETCLASSIC
 using HotChocolate.AspNetClassic;
@@ -13,7 +14,7 @@ namespace HotChocolate.AspNetCore.Subscriptions
         : IHttpContext
     {
         private readonly HttpContext _context;
-        private object _user;
+        private IPrincipal _user;
 
         public HttpContextWrapper(
             HttpContext context)
@@ -21,7 +22,7 @@ namespace HotChocolate.AspNetCore.Subscriptions
             _context = context;
         }
 
-        public ClaimsPrincipal User
+        public IPrincipal User
         {
             get
             {

--- a/src/Server/AspNetCore/Subscriptions/IHttpContext.cs
+++ b/src/Server/AspNetCore/Subscriptions/IHttpContext.cs
@@ -6,7 +6,7 @@ namespace HotChocolate.AspNetCore.Subscriptions
 {
     public interface IHttpContext
     {
-        object User { get; set; }
+        ClaimsPrincipal User { get; set; }
 
         CancellationToken RequestAborted { get; }
 

--- a/src/Server/AspNetCore/Subscriptions/IHttpContext.cs
+++ b/src/Server/AspNetCore/Subscriptions/IHttpContext.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Security.Claims;
+using System.Security.Principal;
 using System.Threading;
 
 namespace HotChocolate.AspNetCore.Subscriptions
 {
     public interface IHttpContext
     {
-        ClaimsPrincipal User { get; set; }
+        IPrincipal User { get; set; }
 
         CancellationToken RequestAborted { get; }
 


### PR DESCRIPTION
Changed the `IHttpContext.User` property from an `object` type to a `ClaimsPrincipal` type. It introduces a needless level of boxing since the assumption is going to be that it's a `ClaimsPrincipal`. Making the `User` property an `object` type also makes it more tedious if you need to use the property because you get no intellisense unless you do a `httpContext.User is ClaimsPrincipal principal`. Plus, this is supposed to be an abstraction for the `IHttpContext` (from what I can tell); why not keep consistent with what someone would expect on an instance of `HttpContext`?
