### PR TITLE
Order of types in a serialized schema is consistent

### DIFF
--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Bind_Filter_Implicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Bind_Filter_Implicitly.snap
@@ -13,8 +13,8 @@ input FooFilter {
   OR: [FooFilter!]
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Create_Filter_Declare_Operators_Explicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Create_Filter_Declare_Operators_Explicitly.snap
@@ -13,8 +13,8 @@ input FooFilter {
   OR: [FooFilter!]
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Create_Filter_Discover_Everything_Implicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Create_Filter_Discover_Everything_Implicitly.snap
@@ -13,8 +13,8 @@ input FooFilter {
   OR: [FooFilter!]
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Create_Filter_Discover_Operators_Implicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Create_Filter_Discover_Operators_Implicitly.snap
@@ -13,8 +13,8 @@ input FooFilter {
   OR: [FooFilter!]
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Description_Explicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Description_Explicitly.snap
@@ -13,8 +13,8 @@ input FooFilter {
   OR: [FooFilter!]
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_By_Name.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_By_Name.snap
@@ -14,8 +14,8 @@ input FooFilter {
 
 directive @bar on INPUT_FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_By_Name_With_Argument.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_By_Name_With_Argument.snap
@@ -14,8 +14,8 @@ input FooFilter {
 
 directive @bar(qux: String) on INPUT_FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
@@ -14,8 +14,8 @@ input FooFilter {
 
 directive @Bar(qux: String) on INPUT_FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
@@ -14,8 +14,8 @@ input FooFilter {
 
 directive @Bar(qux: String) on INPUT_FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Name_Explicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/BooleanFilterInputTypeTests.Declare_Name_Explicitly.snap
@@ -12,8 +12,8 @@ input FooFilter {
   OR: [FooFilter!]
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Bind_Filter_Implicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Bind_Filter_Implicitly.snap
@@ -23,8 +23,8 @@ input FooFilter {
   OR: [FooFilter!]
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 scalar Int
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Create_Filter_Declare_Operators_Explicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Create_Filter_Declare_Operators_Explicitly.snap
@@ -23,8 +23,8 @@ input FooFilter {
   OR: [FooFilter!]
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
 scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Create_Filter_Discover_Everything_Implicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Create_Filter_Discover_Everything_Implicitly.snap
@@ -100,20 +100,20 @@ enum FooBar {
   BAR
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
-"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
-scalar Int
-
-"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
-scalar Short
-
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
-scalar Long
+"The built-in `Decimal` scalar type."
+scalar Decimal
 
 "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
 scalar Float
 
-"The built-in `Decimal` scalar type."
-scalar Decimal
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Create_Filter_Discover_Operators_Implicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Create_Filter_Discover_Operators_Implicitly.snap
@@ -100,20 +100,20 @@ enum FooBar {
   BAR
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
-"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
-scalar Int
-
-"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
-scalar Short
-
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
-scalar Long
+"The built-in `Decimal` scalar type."
+scalar Decimal
 
 "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
 scalar Float
 
-"The built-in `Decimal` scalar type."
-scalar Decimal
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Description_Explicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Description_Explicitly.snap
@@ -90,20 +90,20 @@ enum FooBar {
   BAR
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
-"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
-scalar Int
-
-"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
-scalar Short
-
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
-scalar Long
+"The built-in `Decimal` scalar type."
+scalar Decimal
 
 "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
 scalar Float
 
-"The built-in `Decimal` scalar type."
-scalar Decimal
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_By_Name.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_By_Name.snap
@@ -91,20 +91,20 @@ enum FooBar {
 
 directive @bar on INPUT_FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
-"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
-scalar Int
-
-"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
-scalar Short
-
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
-scalar Long
+"The built-in `Decimal` scalar type."
+scalar Decimal
 
 "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
 scalar Float
 
-"The built-in `Decimal` scalar type."
-scalar Decimal
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_By_Name_With_Argument.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_By_Name_With_Argument.snap
@@ -91,20 +91,20 @@ enum FooBar {
 
 directive @bar(qux: String) on INPUT_FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
-"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
-scalar Int
-
-"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
-scalar Short
-
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
-scalar Long
+"The built-in `Decimal` scalar type."
+scalar Decimal
 
 "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
 scalar Float
 
-"The built-in `Decimal` scalar type."
-scalar Decimal
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_With_Clr_Instance.snap
@@ -91,20 +91,20 @@ enum FooBar {
 
 directive @Bar(baz: String) on INPUT_FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
-"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
-scalar Int
-
-"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
-scalar Short
-
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
-scalar Long
+"The built-in `Decimal` scalar type."
+scalar Decimal
 
 "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
 scalar Float
 
-"The built-in `Decimal` scalar type."
-scalar Decimal
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Directive_With_Clr_Type.snap
@@ -91,20 +91,20 @@ enum FooBar {
 
 directive @Bar(baz: String) on INPUT_FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
-"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
-scalar Int
-
-"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
-scalar Short
-
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
-scalar Long
+"The built-in `Decimal` scalar type."
+scalar Decimal
 
 "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
 scalar Float
 
-"The built-in `Decimal` scalar type."
-scalar Decimal
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Name_Explicitly.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Declare_Name_Explicitly.snap
@@ -89,20 +89,20 @@ enum FooBar {
   BAR
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
-"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
-scalar Int
-
-"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
-scalar Short
-
-"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
-scalar Long
+"The built-in `Decimal` scalar type."
+scalar Decimal
 
 "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
 scalar Float
 
-"The built-in `Decimal` scalar type."
-scalar Decimal
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Ignore_Bar_Property.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Ignore_Bar_Property.snap
@@ -11,8 +11,8 @@ type Query {
   foo: String
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 scalar Int
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Argument_Type_IsInfered_From_Parameter.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Argument_Type_IsInfered_From_Parameter.snap
@@ -6,8 +6,8 @@ type QueryWithIntArg {
   bar(foo: Int!): String
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 scalar Int
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/__snapshots__/SchemaBuilderTests.InferMutationType.snap
+++ b/src/Core/Types.Tests/__snapshots__/SchemaBuilderTests.InferMutationType.snap
@@ -1,4 +1,4 @@
-schema {
+﻿schema {
   query: Query
   mutation: Mutation
 }
@@ -11,8 +11,8 @@ type Query {
   foo: String
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 scalar Int
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/__snapshots__/SchemaBuilderTests.InferSubscriptionType.snap
+++ b/src/Core/Types.Tests/__snapshots__/SchemaBuilderTests.InferSubscriptionType.snap
@@ -1,4 +1,4 @@
-schema {
+﻿schema {
   query: Query
   subscription: Subscription
 }
@@ -11,8 +11,8 @@ type Subscription {
   onFoo: Int
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 scalar Int
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/__snapshots__/SchemaFirstTests.BuiltInScalarsAreRecognized.snap
+++ b/src/Core/Types.Tests/__snapshots__/SchemaFirstTests.BuiltInScalarsAreRecognized.snap
@@ -13,14 +13,14 @@ type Query {
   string_non_null_field: String!
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
+scalar Float
 
 "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 scalar Int
 
-"The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
-scalar Float
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/__snapshots__/SchemaFirstTests.BuiltInScalarsAreRecognized2.snap
+++ b/src/Core/Types.Tests/__snapshots__/SchemaFirstTests.BuiltInScalarsAreRecognized2.snap
@@ -17,14 +17,14 @@ type Query {
   foo: Foo
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `Boolean` scalar type represents `true` or `false`."
 scalar Boolean
+
+"The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
+scalar Float
 
 "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 scalar Int
 
-"The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http:\/\/en.wikipedia.org\/wiki\/IEEE_floating_point)."
-scalar Float
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/__snapshots__/SchemaSerializerTests.SerializeSchemaWithDirective.snap
+++ b/src/Core/Types.Tests/__snapshots__/SchemaSerializerTests.SerializeSchemaWithDirective.snap
@@ -1,4 +1,4 @@
-schema {
+﻿schema {
   query: Query
 }
 
@@ -26,8 +26,8 @@ input BazInput {
 
 directive @upper on FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID."
 scalar ID
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/__snapshots__/SchemaSerializerTests.SerializeSchemaWithMutationWithoutSubscription.snap
+++ b/src/Core/Types.Tests/__snapshots__/SchemaSerializerTests.SerializeSchemaWithMutationWithoutSubscription.snap
@@ -1,4 +1,4 @@
-schema {
+﻿schema {
   query: Query
   mutation: Mutation
 }
@@ -29,8 +29,8 @@ input BazInput {
   name: String
 }
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID."
 scalar ID
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types/SchemaSerializer.cs
+++ b/src/Core/Types/SchemaSerializer.cs
@@ -74,6 +74,7 @@ namespace HotChocolate
             IEnumerable<DirectiveDefinitionNode> directiveTypeDefinitions =
                 schema.DirectiveTypes
                 .Where(t => referenced.DirectiveNames.Contains(t.Name))
+                .OrderBy(t => t.Name.ToString(), StringComparer.Ordinal)
                 .Select(t => SerializeDirectiveTypeDefinition(t, referenced));
 
             typeDefinitions.AddRange(directiveTypeDefinitions);
@@ -82,6 +83,7 @@ namespace HotChocolate
                 schema.Types
                 .OfType<ScalarType>()
                 .Where(t => referenced.TypeNames.Contains(t.Name))
+                .OrderBy(t => t.Name.ToString(), StringComparer.Ordinal)
                 .Select(t => SerializeScalarType(t));
 
             typeDefinitions.AddRange(scalarTypeDefinitions);
@@ -94,7 +96,7 @@ namespace HotChocolate
         {
             return schema.Types
                .Where(t => IsPublicAndNoScalar(t))
-               .OrderBy(t => t.Name.ToString())
+               .OrderBy(t => t.Name.ToString(), StringComparer.Ordinal)
                .GroupBy(t => (int)t.Kind)
                .OrderBy(t => t.Key)
                .SelectMany(t => t);

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/InputObjectDelegationTests.AllowInputObjectTypesAsArguments_schema.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/InputObjectDelegationTests.AllowInputObjectTypesAsArguments_schema.snap
@@ -16,8 +16,8 @@ directive @delegate(path: String "The name of the schema to which this field sha
 "Annotates the original name of a type."
 directive @source("The original name of the annotated type." name: Name! "The name of the schema to which this type belongs to." schema: Name!) repeatable on ENUM | OBJECT | INTERFACE | UNION | INPUT_OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The name scalar represents a valid GraphQL name as specified in the spec and can be used to refer to fields or types."
 scalar Name
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/TypeRewriterTests.CustomRewriterTakesPriority_schema.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/TypeRewriterTests.CustomRewriterTakesPriority_schema.snap
@@ -8,8 +8,8 @@ type Query {
 
 directive @delegate(path: String "The name of the schema to which this field shall be delegated to." schema: Name!) on FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The name scalar represents a valid GraphQL name as specified in the spec and can be used to refer to fields or types."
 scalar Name
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/TypeSystemDirectivesTests.SourceSchemaHasTypeSystemDirectives_schema.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/TypeSystemDirectivesTests.SourceSchemaHasTypeSystemDirectives_schema.snap
@@ -8,8 +8,8 @@ type Query {
 
 directive @delegate(path: String "The name of the schema to which this field shall be delegated to." schema: Name!) on FIELD_DEFINITION
 
-"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
-scalar String
-
 "The name scalar represents a valid GraphQL name as specified in the spec and can be used to refer to fields or types."
 scalar Name
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String


### PR DESCRIPTION
Updates the schema serializer to sort all types and specifies a comparer in order to handle different default sorting on different platforms (see dotnet/corefx#15825 for more details).

Resolves #890 
