### PR TITLE
Respect UseXmlDocumentation with Schema.Create

### DIFF
--- a/src/Core/Types.Tests/Types/ObjectTypeTests.cs
+++ b/src/Core/Types.Tests/Types/ObjectTypeTests.cs
@@ -1323,6 +1323,21 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public void CreateObjectTypeWithXmlDocumentation_IgnoreXmlDocs_SchemaCreate()
+        {
+            // arrange
+            // act
+            ISchema schema = Schema.Create(c =>
+            {
+                c.RegisterQueryType<QueryWithDocumentation>();
+                c.Options.UseXmlDocumentation = false;
+            });
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
+        [Fact]
         public void Field_Is_Missing_Type_Throws_SchemaException()
         {
             // arrange

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.CreateObjectTypeWithXmlDocumentation_IgnoreXmlDocs_SchemaCreate.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.CreateObjectTypeWithXmlDocumentation_IgnoreXmlDocs_SchemaCreate.snap
@@ -1,0 +1,10 @@
+﻿schema {
+  query: QueryWithDocumentation
+}
+
+type QueryWithDocumentation {
+  foo(bar: String): String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types/Configuration/SchemaOptions.cs
+++ b/src/Core/Types/Configuration/SchemaOptions.cs
@@ -20,7 +20,8 @@ namespace HotChocolate.Configuration
                 QueryTypeName = options.QueryTypeName,
                 MutationTypeName = options.MutationTypeName,
                 SubscriptionTypeName = options.SubscriptionTypeName,
-                StrictValidation = options.StrictValidation
+                StrictValidation = options.StrictValidation,
+                UseXmlDocumentation = options.UseXmlDocumentation
             };
         }
     }


### PR DESCRIPTION
Fixes a bug in `SchemaOptions.FromOptions` to correctly copy the `UseXmlDocumentation` setting.

Resolves #895