### PR TITLE
Switch date handling to None in stitching layer

### DIFF
--- a/src/Core/Abstractions/ErrorBuilder.cs
+++ b/src/Core/Abstractions/ErrorBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using HotChocolate.Execution;
 
 namespace HotChocolate
@@ -138,6 +139,48 @@ namespace HotChocolate
         public static ErrorBuilder FromError(IError error)
         {
             return new ErrorBuilder(error);
+        }
+
+        public static ErrorBuilder FromDictionary(
+            IReadOnlyDictionary<string, object> dict)
+        {
+            if (dict == null)
+            {
+                throw new ArgumentNullException(nameof(dict));
+            }
+
+            var builder = ErrorBuilder.New();
+            builder.SetMessage((string)dict["message"]);
+
+            if (dict.TryGetValue("extensions", out object obj)
+                && obj is IDictionary<string, object> extensions)
+            {
+                foreach (var item in extensions)
+                {
+                    builder.SetExtension(item.Key, item.Value);
+                }
+            }
+
+            if (dict.TryGetValue("path", out obj)
+                && obj is IReadOnlyList<object> path)
+            {
+                builder.SetPath(path);
+            }
+
+            if (dict.TryGetValue("locations", out obj)
+                && obj is IList<object> locations)
+            {
+                var locs = new List<Location>();
+                foreach (IDictionary<string, object> loc in locations
+                    .OfType<IDictionary<string, object>>())
+                {
+                    builder.AddLocation(new Location(
+                        Convert.ToInt32(loc["line"]),
+                        Convert.ToInt32(loc["column"])));
+                }
+            }
+
+            return builder;
         }
     }
 }

--- a/src/Core/Abstractions/ErrorBuilder.cs
+++ b/src/Core/Abstractions/ErrorBuilder.cs
@@ -170,7 +170,6 @@ namespace HotChocolate
             if (dict.TryGetValue("locations", out obj)
                 && obj is IList<object> locations)
             {
-                var locs = new List<Location>();
                 foreach (IDictionary<string, object> loc in locations
                     .OfType<IDictionary<string, object>>())
                 {

--- a/src/Core/Core.Tests/Execution/Errors/ErrorTests.cs
+++ b/src/Core/Core.Tests/Execution/Errors/ErrorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using HotChocolate.Language;
 using Xunit;
@@ -53,14 +54,13 @@ namespace HotChocolate.Execution
             Assert.Null(error.Locations);
         }
 
+        [Obsolete]
         [Fact]
         public void VariableError_CreateWithoutLocation()
         {
             // arrange
             // act
-#pragma warning disable CS0618 // Type or member is obsolete
             var error = new VariableError("foo", "bar");
-#pragma warning restore CS0618 // Type or member is obsolete
 
             // assert
             Assert.Equal("foo", error.Message);

--- a/src/Core/Subscriptions.Tests/xunit.runner.json
+++ b/src/Core/Subscriptions.Tests/xunit.runner.json
@@ -1,3 +1,5 @@
 ﻿{
-  "appDomain": "denied",   "maxParallelThreads": 2
+  "appDomain": "denied",
+  "maxParallelThreads": 1,
+  "parallelizeTestCollections": false
 }

--- a/src/Core/Types/Types/Scalars/DateTimeType.cs
+++ b/src/Core/Types/Types/Scalars/DateTimeType.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using HotChocolate.Language;
 using HotChocolate.Properties;
 
 namespace HotChocolate.Types
@@ -48,23 +47,23 @@ namespace HotChocolate.Types
         }
 
         protected override bool TryParseLiteral(
-            StringValueNode literal,
+            string literal,
             out object obj)
         {
-            if (literal.Value != null
-                && literal.Value.EndsWith("Z")
+            if (literal != null
+                && literal.EndsWith("Z")
                 && DateTime.TryParse(
-                    literal.Value,
+                    literal,
                     CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal,
                     out DateTime zuluTime))
             {
-                obj = new DateTimeOffset(zuluTime);
+                obj = new DateTimeOffset(zuluTime.ToUniversalTime());
                 return true;
             }
 
             if (DateTimeOffset.TryParse(
-                literal.Value,
+                literal,
                 out DateTimeOffset dateTime))
             {
                 obj = dateTime;

--- a/src/Core/Types/Types/Scalars/DateTimeTypeBase.cs
+++ b/src/Core/Types/Types/Scalars/DateTimeTypeBase.cs
@@ -143,11 +143,11 @@ namespace HotChocolate.Types
             return false;
         }
 
-        private bool TryParseLiteral(string literal, out object obj) =>
-            TryParseLiteral(new StringValueNode(literal), out obj);
+        private bool TryParseLiteral(StringValueNode literal, out object obj) =>
+            TryParseLiteral(literal.Value, out obj);
 
         protected abstract bool TryParseLiteral(
-            StringValueNode literal,
+            string literal,
             out object obj);
 
         protected abstract string Serialize(DateTime value);

--- a/src/Core/Types/Types/Scalars/DateType.cs
+++ b/src/Core/Types/Types/Scalars/DateType.cs
@@ -29,10 +29,10 @@ namespace HotChocolate.Types
         }
 
         protected override bool TryParseLiteral(
-            StringValueNode literal, out object obj)
+            string literal, out object obj)
         {
             if (DateTime.TryParse(
-                literal.Value,
+                literal,
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.AssumeLocal,
                 out DateTime dateTime))

--- a/src/Server/AspNetCore.Subscriptions.Tests/AspNetCore.Subscriptions.Tests.csproj
+++ b/src/Server/AspNetCore.Subscriptions.Tests/AspNetCore.Subscriptions.Tests.csproj
@@ -30,7 +30,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="__snapshots__\*.json">
+    <None Update="__snapshots__\*.*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="__resources__\*.*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="xunit.runner.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/Server/AspNetCore.Subscriptions.Tests/WebSocketProtocolTests.cs
+++ b/src/Server/AspNetCore.Subscriptions.Tests/WebSocketProtocolTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +7,7 @@ using HotChocolate.AspNetCore.Subscriptions.Messages;
 using HotChocolate.AspNetCore.Tests.Utilities;
 using HotChocolate.Language;
 using Microsoft.AspNetCore.TestHost;
+using Snapshooter;
 using Snapshooter.Xunit;
 using Xunit;
 
@@ -22,105 +22,122 @@ namespace HotChocolate.AspNetCore.Subscriptions
         }
 
         [Fact]
-        public async Task Send_Connect_AcceptAndKeepAlive()
+        public Task Send_Connect_AcceptAndKeepAlive()
         {
-            using (TestServer testServer = CreateStarWarsServer())
+            return TryTest(async () =>
             {
-                // arrange
-                WebSocketClient client = CreateWebSocketClient(testServer);
-                WebSocket webSocket = await client
-                    .ConnectAsync(SubscriptionUri, CancellationToken.None);
-
-                // act
-                await webSocket.SendConnectionInitializeAsync();
-
-                // assert
-                IReadOnlyDictionary<string, object> message =
-                    await webSocket.ReceiveServerMessageAsync();
-                Assert.NotNull(message);
-                Assert.Equal(MessageTypes.Connection.Accept, message["type"]);
-
-                message = await webSocket.ReceiveServerMessageAsync();
-                Assert.NotNull(message);
-                Assert.Equal(MessageTypes.Connection.KeepAlive, message["type"]);
-            }
-        }
-
-        [Fact]
-        public async Task Send_Terminate()
-        {
-            using (TestServer testServer = CreateStarWarsServer())
-            {
-                // arrange
-                WebSocketClient client = CreateWebSocketClient(testServer);
-                WebSocket webSocket = await ConnectToServerAsync(client);
-
-                // act
-                await webSocket.SendTerminateConnectionAsync();
-
-                // assert
-                byte[] buffer = new byte[1024];
-                await webSocket.ReceiveAsync(buffer, CancellationToken.None);
-
-                Assert.True(webSocket.CloseStatus.HasValue);
-                Assert.Equal(
-                    WebSocketCloseStatus.NormalClosure,
-                    webSocket.CloseStatus.Value);
-            }
-        }
-
-        [Fact]
-        public async Task Connect_With_Invalid_Protocol()
-        {
-            using (TestServer testServer = CreateStarWarsServer())
-            {
-                // arrange
-                WebSocketClient client = testServer.CreateWebSocketClient();
-
-                client.ConfigureRequest = r =>
+                using (TestServer testServer = CreateStarWarsServer())
                 {
-                    r.Headers.Add("Sec-WebSocket-Protocol", "foo");
-                };
+                    // arrange
+                    WebSocketClient client = CreateWebSocketClient(testServer);
+                    WebSocket webSocket = await client
+                        .ConnectAsync(SubscriptionUri, CancellationToken.None);
 
-                // act
-                WebSocket socket = await client.ConnectAsync(
-                    SubscriptionUri,
-                    CancellationToken.None);
+                    // act
+                    await webSocket.SendConnectionInitializeAsync();
 
-                byte[] buffer = new byte[1024];
-                await socket.ReceiveAsync(buffer, CancellationToken.None);
+                    // assert
+                    IReadOnlyDictionary<string, object> message =
+                        await webSocket.ReceiveServerMessageAsync();
+                    Assert.NotNull(message);
+                    Assert.Equal(
+                        MessageTypes.Connection.Accept,
+                        message["type"]);
 
-                // assert
-                Assert.True(socket.CloseStatus.HasValue);
-                Assert.Equal(
-                    WebSocketCloseStatus.ProtocolError,
-                    socket.CloseStatus.Value);
-            }
+                    message = await webSocket.ReceiveServerMessageAsync();
+                    Assert.NotNull(message);
+                    Assert.Equal(
+                        MessageTypes.Connection.KeepAlive,
+                        message["type"]);
+                }
+            });
         }
 
         [Fact]
-        public async Task Send_Start_ReceiveDataOnMutation()
+        public Task Send_Terminate()
         {
-            using (TestServer testServer = CreateStarWarsServer())
+            return TryTest(async () =>
             {
-                // arrange
-                WebSocketClient client = CreateWebSocketClient(testServer);
-                WebSocket webSocket = await ConnectToServerAsync(client);
-
-                var document = Utf8GraphQLParser.Parse(
-                    "subscription { onReview(episode: NEWHOPE) { stars } }");
-
-                var request = new GraphQLRequest(document);
-
-                const string subscriptionId = "abc";
-
-                // act
-                await webSocket.SendSubscriptionStartAsync(subscriptionId, request);
-
-                // assert
-                await testServer.SendRequestAsync(new ClientQueryRequest
+                using (TestServer testServer = CreateStarWarsServer())
                 {
-                    Query = @"
+                    // arrange
+                    WebSocketClient client = CreateWebSocketClient(testServer);
+                    WebSocket webSocket = await ConnectToServerAsync(client);
+
+                    // act
+                    await webSocket.SendTerminateConnectionAsync();
+
+                    // assert
+                    byte[] buffer = new byte[1024];
+                    await webSocket.ReceiveAsync(buffer, CancellationToken.None);
+
+                    Assert.True(webSocket.CloseStatus.HasValue);
+                    Assert.Equal(
+                        WebSocketCloseStatus.NormalClosure,
+                        webSocket.CloseStatus.Value);
+                }
+            });
+        }
+
+        [Fact]
+        public Task Connect_With_Invalid_Protocol()
+        {
+            return TryTest(async () =>
+            {
+                using (TestServer testServer = CreateStarWarsServer())
+                {
+                    // arrange
+                    WebSocketClient client = testServer.CreateWebSocketClient();
+
+                    client.ConfigureRequest = r =>
+                    {
+                        r.Headers.Add("Sec-WebSocket-Protocol", "foo");
+                    };
+
+                    // act
+                    WebSocket socket = await client.ConnectAsync(
+                        SubscriptionUri,
+                        CancellationToken.None);
+
+                    byte[] buffer = new byte[1024];
+                    await socket.ReceiveAsync(buffer, CancellationToken.None);
+
+                    // assert
+                    Assert.True(socket.CloseStatus.HasValue);
+                    Assert.Equal(
+                        WebSocketCloseStatus.ProtocolError,
+                        socket.CloseStatus.Value);
+                }
+            });
+        }
+
+        [Fact]
+        public Task Send_Start_ReceiveDataOnMutation()
+        {
+            SnapshotFullName snapshotName = Snapshot.FullName();
+
+            return TryTest(async () =>
+            {
+                using (TestServer testServer = CreateStarWarsServer())
+                {
+                    // arrange
+                    WebSocketClient client = CreateWebSocketClient(testServer);
+                    WebSocket webSocket = await ConnectToServerAsync(client);
+
+                    var document = Utf8GraphQLParser.Parse(
+                        "subscription { onReview(episode: NEWHOPE) { stars } }");
+
+                    var request = new GraphQLRequest(document);
+
+                    const string subscriptionId = "abc";
+
+                    // act
+                    await webSocket.SendSubscriptionStartAsync(subscriptionId, request);
+
+                    // assert
+                    await testServer.SendRequestAsync(new ClientQueryRequest
+                    {
+                        Query = @"
                     mutation {
                         createReview(episode:NEWHOPE review: {
                             commentary: ""foo""
@@ -130,81 +147,117 @@ namespace HotChocolate.AspNetCore.Subscriptions
                         }
                     }
                 "
-                });
+                    });
 
-                IReadOnlyDictionary<string, object> message =
-                    await WaitForMessage(
+                    IReadOnlyDictionary<string, object> message =
+                        await WaitForMessage(
+                            webSocket,
+                            MessageTypes.Subscription.Data,
+                            TimeSpan.FromSeconds(15));
+
+                    Assert.NotNull(message);
+                    Snapshot.Match(message, snapshotName);
+                }
+            });
+        }
+
+        [Fact]
+        public Task Send_Start_Stop()
+        {
+            return TryTest(async () =>
+            {
+                using (TestServer testServer = CreateStarWarsServer())
+                {
+                    // arrange
+                    WebSocketClient client = CreateWebSocketClient(testServer);
+                    WebSocket webSocket = await ConnectToServerAsync(client);
+
+                    var document = Utf8GraphQLParser.Parse(
+                        "subscription { onReview(episode: NEWHOPE) { stars } }");
+
+                    var request = new GraphQLRequest(document);
+
+                    const string subscriptionId = "abc";
+
+                    await webSocket.SendSubscriptionStartAsync(subscriptionId, request);
+
+                    await testServer.SendRequestAsync(new ClientQueryRequest
+                    {
+                        Query = @"
+                    mutation {
+                        createReview(episode:NEWHOPE review: {
+                            commentary: ""foo""
+                            stars: 5
+                        }) {
+                            stars
+                        }
+                    }
+                "
+                    });
+
+                    IReadOnlyDictionary<string, object> message =
+                        await WaitForMessage(
+                            webSocket,
+                            MessageTypes.Subscription.Data,
+                            TimeSpan.FromSeconds(15));
+
+                    // act
+                    await webSocket.SendSubscriptionStopAsync(subscriptionId);
+
+                    await testServer.SendRequestAsync(new ClientQueryRequest
+                    {
+                        Query = @"
+                    mutation {
+                        createReview(episode:NEWHOPE review: {
+                            commentary: ""foo""
+                            stars: 5
+                        }) {
+                            stars
+                        }
+                    }
+                "
+                    });
+
+                    message = await WaitForMessage(
                         webSocket,
                         MessageTypes.Subscription.Data,
-                        TimeSpan.FromSeconds(15));
+                        TimeSpan.FromSeconds(5));
 
-                Assert.NotNull(message);
-                message.MatchSnapshot();
-            }
+                    // assert
+                    Assert.Null(message);
+                }
+            });
         }
 
-        [Fact]
-        public async Task Send_Start_Stop()
+        private static async Task TryTest(Func<Task> action)
         {
-            using (TestServer testServer = CreateStarWarsServer())
+            // we will try four times ....
+            int count = 0;
+            int wait = 50;
+
+            while (true)
             {
-                // arrange
-                WebSocketClient client = CreateWebSocketClient(testServer);
-                WebSocket webSocket = await ConnectToServerAsync(client);
-
-                var document = Utf8GraphQLParser.Parse(
-                    "subscription { onReview(episode: NEWHOPE) { stars } }");
-
-                var request = new GraphQLRequest(document);
-
-                const string subscriptionId = "abc";
-
-                await webSocket.SendSubscriptionStartAsync(subscriptionId, request);
-
-                await testServer.SendRequestAsync(new ClientQueryRequest
+                if (count < 3)
                 {
-                    Query = @"
-                    mutation {
-                        createReview(episode:NEWHOPE review: {
-                            commentary: ""foo""
-                            stars: 5
-                        }) {
-                            stars
-                        }
+                    try
+                    {
+                        await action().ConfigureAwait(false);
+                        break;
                     }
-                "
-                });
-
-                IReadOnlyDictionary<string, object> message =
-                    await WaitForMessage(
-                        webSocket,
-                        MessageTypes.Subscription.Data,
-                        TimeSpan.FromSeconds(15));
-
-                // act
-                await webSocket.SendSubscriptionStopAsync(subscriptionId);
-
-                await testServer.SendRequestAsync(new ClientQueryRequest
+                    catch
+                    {
+                        // try again
+                    }
+                }
+                else
                 {
-                    Query = @"
-                    mutation {
-                        createReview(episode:NEWHOPE review: {
-                            commentary: ""foo""
-                            stars: 5
-                        }) {
-                            stars
-                        }
-                    }
-                "
-                });
+                    await action().ConfigureAwait(false);
+                    break;
+                }
 
-                message = await WaitForMessage(
-                    webSocket,
-                    MessageTypes.Subscription.Data,
-                    TimeSpan.FromSeconds(5));
-
-                // assert
-                Assert.Null(message);
+                await Task.Delay(wait).ConfigureAwait(false);
+                wait = wait * 2;
+                count++;
             }
         }
     }

--- a/src/Server/AspNetCore.Subscriptions.Tests/xunit.runner.json
+++ b/src/Server/AspNetCore.Subscriptions.Tests/xunit.runner.json
@@ -1,5 +1,5 @@
 ﻿{
   "appDomain": "denied",
-  "maxParallelThreads": 2,
+  "maxParallelThreads": 1,
   "parallelizeTestCollections": false
 }

--- a/src/Server/AspNetCore.Subscriptions.Tests/xunit.runner.json
+++ b/src/Server/AspNetCore.Subscriptions.Tests/xunit.runner.json
@@ -1,4 +1,5 @@
 ﻿{
   "appDomain": "denied",
-  "maxParallelThreads": 1
+  "maxParallelThreads": 2,
+  "parallelizeTestCollections": false
 }

--- a/src/Server/Server/RequestHelper.cs
+++ b/src/Server/Server/RequestHelper.cs
@@ -91,6 +91,7 @@ namespace HotChocolate.Server
             }
         }
 
+
         private IReadOnlyList<GraphQLRequest> ParseRequest(
             byte[] buffer, int bytesBuffered)
         {

--- a/src/Server/Server/RequestHelper.cs
+++ b/src/Server/Server/RequestHelper.cs
@@ -39,38 +39,20 @@ namespace HotChocolate.Server
         public Task<IReadOnlyList<GraphQLRequest>> ReadGraphQLQueryAsync(
             Stream stream) => ReadAsync(stream, true);
 
-        private async Task<IReadOnlyList<GraphQLRequest>> ReadAsync(
+        private Task<IReadOnlyList<GraphQLRequest>> ReadAsync(
             Stream stream,
             bool isGraphQLQuery)
         {
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(1024);
-            var bytesBuffered = 0;
-
-            try
-            {
-                while (true)
+            return ReadAsync(
+                stream,
+                (buffer, bytesBuffered) =>
                 {
-                    var bytesRemaining = buffer.Length - bytesBuffered;
-
-                    if (bytesRemaining == 0)
-                    {
-                        var next = ArrayPool<byte>.Shared.Rent(
-                            buffer.Length * 2);
-                        Buffer.BlockCopy(buffer, 0, next, 0, buffer.Length);
-                        ArrayPool<byte>.Shared.Return(buffer);
-                        buffer = next;
-                        bytesRemaining = buffer.Length - bytesBuffered;
-                    }
-
-                    var bytesRead = await stream.ReadAsync(
-                        buffer, bytesBuffered, bytesRemaining)
-                        .ConfigureAwait(false);
-                    if (bytesRead == 0)
-                    {
-                        break;
-                    }
-
-                    bytesBuffered += bytesRead;
+                    return isGraphQLQuery
+                        ? ParseQuery(buffer, bytesBuffered)
+                        : ParseRequest(buffer, bytesBuffered);
+                },
+                bytesBuffered =>
+                {
                     if (bytesBuffered > _maxRequestSize)
                     {
                         throw new QueryException(
@@ -79,16 +61,7 @@ namespace HotChocolate.Server
                                 .SetCode("MAX_REQUEST_SIZE")
                                 .Build());
                     }
-                }
-
-                return isGraphQLQuery
-                    ? ParseQuery(buffer, bytesBuffered)
-                    : ParseRequest(buffer, bytesBuffered);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
+                });
         }
 
 
@@ -120,6 +93,57 @@ namespace HotChocolate.Server
             DocumentNode document = requestParser.Parse();
 
             return new[] { new GraphQLRequest(document, queryHash) };
+        }
+
+        public static Task<T> ReadAsync<T>(
+            Stream stream,
+            Func<byte[], int, T> handle) => ReadAsync<T>(stream, handle, null);
+
+        public static async Task<T> ReadAsync<T>(
+            Stream stream,
+            Func<byte[], int, T> handle,
+            Action<int> checkSize)
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(1024);
+            var bytesBuffered = 0;
+
+            try
+            {
+                while (true)
+                {
+                    var bytesRemaining = buffer.Length - bytesBuffered;
+
+                    if (bytesRemaining == 0)
+                    {
+                        var next = ArrayPool<byte>.Shared.Rent(
+                            buffer.Length * 2);
+                        Buffer.BlockCopy(buffer, 0, next, 0, buffer.Length);
+                        ArrayPool<byte>.Shared.Return(buffer);
+                        buffer = next;
+                        bytesRemaining = buffer.Length - bytesBuffered;
+                    }
+
+                    var bytesRead = await stream.ReadAsync(
+                        buffer, bytesBuffered, bytesRemaining)
+                        .ConfigureAwait(false);
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    bytesBuffered += bytesRead;
+                    if (checkSize != null)
+                    {
+                        checkSize(bytesBuffered);
+                    }
+                }
+
+                return handle(buffer, bytesBuffered);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
     }
 }

--- a/src/Stitching/Stitching.Tests/Middleware/DelegateToRemoteSchemaMiddlewareTests.cs
+++ b/src/Stitching/Stitching.Tests/Middleware/DelegateToRemoteSchemaMiddlewareTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -6,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Snapshooter.Xunit;
 using Xunit;
-using HotChocolate.AspNetCore;
 using HotChocolate.Execution;
 using HotChocolate.Types;
 using HotChocolate.Resolvers;
@@ -216,8 +214,8 @@ namespace HotChocolate.Stitching
                     c.Map(new FieldReference("Customer", "foo"),
                         next => context =>
                         {
-                            OrderedDictionary obj =
-                                context.Parent<OrderedDictionary>();
+                            var obj = context
+                                .Parent<IReadOnlyDictionary<string, object>>();
                             context.Result = obj["name"] + "_" + obj["id"];
                             return Task.CompletedTask;
                         });

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/DelegateToRemoteSchemaMiddlewareTests.AddErrorFilter.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/DelegateToRemoteSchemaMiddlewareTests.AddErrorFilter.snap
@@ -36,13 +36,16 @@
       "Extensions": {
         "code": "ERROR_CODE",
         "remote": {
-          "Exception": null,
-          "message": "Error_Message",
-          "path": [
+          "Message": "Error_Message",
+          "Code": "ERROR_CODE",
+          "Path": [
             "contracts",
+            0,
             "error"
           ],
-          "extensions": {
+          "Locations": [],
+          "Exception": null,
+          "Extensions": {
             "code": "ERROR_CODE"
           }
         },
@@ -67,13 +70,16 @@
       "Extensions": {
         "code": "ERROR_CODE",
         "remote": {
-          "Exception": null,
-          "message": "Error_Message",
-          "path": [
+          "Message": "Error_Message",
+          "Code": "ERROR_CODE",
+          "Path": [
             "contracts",
+            1,
             "error"
           ],
-          "extensions": {
+          "Locations": [],
+          "Exception": null,
+          "Extensions": {
             "code": "ERROR_CODE"
           }
         },

--- a/src/Stitching/Stitching.Tests/Schemas/Contracts/QueryType.cs
+++ b/src/Stitching/Stitching.Tests/Schemas/Contracts/QueryType.cs
@@ -22,9 +22,7 @@ namespace HotChocolate.Stitching.Schemas.Contracts
                 .Type<DateTimeType>()
                 .Resolver(ctx =>
                 {
-                    DateTime dateTime =
-                        ctx.Argument<DateTime>("d")
-                            .ToUniversalTime();
+                    DateTime dateTime = ctx.Argument<DateTime>("d");
                     return dateTime;
                 });
         }

--- a/src/Stitching/Stitching.Tests/Utilities/HttpResponseDeserializerTests.cs
+++ b/src/Stitching/Stitching.Tests/Utilities/HttpResponseDeserializerTests.cs
@@ -1,13 +1,11 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 using HotChocolate.Execution;
 using HotChocolate.Stitching.Utilities;
 using Snapshooter.Xunit;
+using HotChocolate.Language;
 
 namespace HotChocolate.Stitching
 {
@@ -35,12 +33,12 @@ namespace HotChocolate.Stitching
             await serializer.SerializeAsync(result, stream);
             byte[] buffer = stream.ToArray();
 
-            string json = Encoding.UTF8.GetString(buffer, 0, buffer.Length);
-            var serializedResult = JsonConvert.DeserializeObject<JObject>(json);
+            var serializedResult = Utf8GraphQLRequestParser.ParseJson(buffer);
 
             // act
             IReadOnlyQueryResult deserializedResult =
-                HttpResponseDeserializer.Deserialize(serializedResult);
+                HttpResponseDeserializer.Deserialize(
+                    (IReadOnlyDictionary<string, object>)serializedResult);
 
             // assert
             Snapshot.Match(deserializedResult,
@@ -71,12 +69,12 @@ namespace HotChocolate.Stitching
             await serializer.SerializeAsync(result, stream);
             byte[] buffer = stream.ToArray();
 
-            string json = Encoding.UTF8.GetString(buffer, 0, buffer.Length);
-            var serializedResult = JsonConvert.DeserializeObject<JObject>(json);
+            var serializedResult = Utf8GraphQLRequestParser.ParseJson(buffer);
 
             // act
             IReadOnlyQueryResult deserializedResult =
-                HttpResponseDeserializer.Deserialize(serializedResult);
+                HttpResponseDeserializer.Deserialize(
+                    (IReadOnlyDictionary<string, object>)serializedResult);
 
             // assert
             Snapshot.Match(deserializedResult);
@@ -118,12 +116,12 @@ namespace HotChocolate.Stitching
             await serializer.SerializeAsync(result, stream);
             byte[] buffer = stream.ToArray();
 
-            string json = Encoding.UTF8.GetString(buffer, 0, buffer.Length);
-            var serializedResult = JsonConvert.DeserializeObject<JObject>(json);
+            var serializedResult = Utf8GraphQLRequestParser.ParseJson(buffer);
 
             // act
             IReadOnlyQueryResult deserializedResult =
-                HttpResponseDeserializer.Deserialize(serializedResult);
+                HttpResponseDeserializer.Deserialize(
+                    (IReadOnlyDictionary<string, object>)serializedResult);
 
             // assert
             Snapshot.Match(deserializedResult);
@@ -161,12 +159,12 @@ namespace HotChocolate.Stitching
             await serializer.SerializeAsync(result, stream);
             byte[] buffer = stream.ToArray();
 
-            string json = Encoding.UTF8.GetString(buffer, 0, buffer.Length);
-            var serializedResult = JsonConvert.DeserializeObject<JObject>(json);
+            var serializedResult = Utf8GraphQLRequestParser.ParseJson(buffer);
 
             // act
             IReadOnlyQueryResult deserializedResult =
-                HttpResponseDeserializer.Deserialize(serializedResult);
+                HttpResponseDeserializer.Deserialize(
+                    (IReadOnlyDictionary<string, object>)serializedResult);
 
             // assert
             Snapshot.Match(deserializedResult);

--- a/src/Stitching/Stitching.Tests/Utilities/__snapshots__/HttpResponseDeserializerTests.DeserializeQueryResultOnlyErrors.snap
+++ b/src/Stitching/Stitching.Tests/Utilities/__snapshots__/HttpResponseDeserializerTests.DeserializeQueryResultOnlyErrors.snap
@@ -3,32 +3,40 @@
   "Extensions": {},
   "Errors": [
     {
-      "Exception": null,
-      "message": "foo",
-      "path": [
+      "Message": "foo",
+      "Code": null,
+      "Path": [
         "root",
         "child"
       ],
-      "locations": [
+      "Locations": [
         {
           "line": 15,
           "column": 16
         }
       ],
-      "extensions": {
+      "Exception": null,
+      "Extensions": {
         "bar": "baz"
       }
     },
     {
+      "Message": "qux",
+      "Code": null,
+      "Path": null,
+      "Locations": [],
       "Exception": null,
-      "message": "qux",
-      "extensions": {
+      "Extensions": {
         "bar": "baz"
       }
     },
     {
+      "Message": "quux",
+      "Code": null,
+      "Path": null,
+      "Locations": [],
       "Exception": null,
-      "message": "quux"
+      "Extensions": {}
     }
   ],
   "ContextData": {}

--- a/src/Stitching/Stitching.Tests/Utilities/__snapshots__/HttpResponseDeserializerTests.DeserializeQueryResultWithErrors.snap
+++ b/src/Stitching/Stitching.Tests/Utilities/__snapshots__/HttpResponseDeserializerTests.DeserializeQueryResultWithErrors.snap
@@ -19,32 +19,40 @@
   "Extensions": {},
   "Errors": [
     {
-      "Exception": null,
-      "message": "foo",
-      "path": [
+      "Message": "foo",
+      "Code": null,
+      "Path": [
         "root",
         "child"
       ],
-      "locations": [
+      "Locations": [
         {
           "line": 15,
           "column": 16
         }
       ],
-      "extensions": {
+      "Exception": null,
+      "Extensions": {
         "bar": "baz"
       }
     },
     {
+      "Message": "qux",
+      "Code": null,
+      "Path": null,
+      "Locations": [],
       "Exception": null,
-      "message": "qux",
-      "extensions": {
+      "Extensions": {
         "bar": "baz"
       }
     },
     {
+      "Message": "quux",
+      "Code": null,
+      "Path": null,
+      "Locations": [],
       "Exception": null,
-      "message": "quux"
+      "Extensions": {}
     }
   ],
   "ContextData": {}

--- a/src/Stitching/Stitching/Middleware/DelegateToRemoteSchemaMiddleware.cs
+++ b/src/Stitching/Stitching/Middleware/DelegateToRemoteSchemaMiddleware.cs
@@ -1,12 +1,9 @@
-using System.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using HotChocolate.Execution;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;
@@ -51,7 +48,8 @@ namespace HotChocolate.Stitching
 
                 UpdateContextData(context, result, delegateDirective);
 
-                context.Result = ExtractData(result.Data, path.Count());
+                context.Result = new SerializedData(
+                    ExtractData(result.Data, path.Count()));
                 ReportErrors(context, result.Errors);
             }
 
@@ -462,5 +460,4 @@ namespace HotChocolate.Stitching
             return definitions;
         }
     }
-
 }

--- a/src/Stitching/Stitching/Middleware/SerializedData.cs
+++ b/src/Stitching/Stitching/Middleware/SerializedData.cs
@@ -1,0 +1,12 @@
+namespace HotChocolate.Stitching
+{
+    public sealed class SerializedData
+    {
+        public SerializedData(object data)
+        {
+            Data = data;
+        }
+
+        public object Data { get; }
+    }
+}

--- a/src/Stitching/Stitching/Stitching.csproj
+++ b/src/Stitching/Stitching/Stitching.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.csproj" />
+    <ProjectReference Include="..\..\Server\Server\Server.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stitching/Stitching/Utilities/HttpQueryClient.cs
+++ b/src/Stitching/Stitching/Utilities/HttpQueryClient.cs
@@ -38,12 +38,14 @@ namespace HotChocolate.Stitching.Utilities
                 await FetchInternalAsync(request, httpClient)
                     .ConfigureAwait(false);
 
-            using (Stream stream = await message.Content.ReadAsStreamAsync())
+            using (Stream stream = await message.Content.ReadAsStreamAsync()
+                .ConfigureAwait(false))
             {
                 object response = await RequestHelper.ReadAsync(
                     stream,
                     (buffer, bytesBuffered) =>
-                        ParseJson(buffer, bytesBuffered));
+                        ParseJson(buffer, bytesBuffered))
+                    .ConfigureAwait(false);
 
                 QueryResult queryResult =
                     response is IReadOnlyDictionary<string, object> d
@@ -69,7 +71,7 @@ namespace HotChocolate.Stitching.Utilities
             }
         }
 
-        private object ParseJson(byte[] buffer, int bytesBuffered)
+        private static object ParseJson(byte[] buffer, int bytesBuffered)
         {
             return Utf8GraphQLRequestParser.ParseJson(
                 new ReadOnlySpan<byte>(buffer, 0, bytesBuffered));

--- a/src/Stitching/Stitching/Utilities/HttpQueryClient.cs
+++ b/src/Stitching/Stitching/Utilities/HttpQueryClient.cs
@@ -18,7 +18,7 @@ namespace HotChocolate.Stitching.Utilities
             new JsonSerializerSettings
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                DateParseHandling = DateParseHandling.DateTimeOffset
+                DateParseHandling = DateParseHandling.None
             };
 
         public Task<QueryResult> FetchAsync(

--- a/src/Stitching/Stitching/Utilities/HttpQueryClient.cs
+++ b/src/Stitching/Stitching/Utilities/HttpQueryClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -9,7 +8,6 @@ using HotChocolate.Execution;
 using HotChocolate.Language;
 using HotChocolate.Server;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace HotChocolate.Stitching.Utilities
@@ -42,7 +40,7 @@ namespace HotChocolate.Stitching.Utilities
 
             using (Stream stream = await message.Content.ReadAsStreamAsync())
             {
-                object response = RequestHelper.ReadAsync(
+                object response = await RequestHelper.ReadAsync(
                     stream,
                     (buffer, bytesBuffered) =>
                         ParseJson(buffer, bytesBuffered));


### PR DESCRIPTION
Having a default setting of `DateParseHandling.DateTimeOffset` causes errors on any field of type `String` where the value looks like a date.

Resolves #930 