### PR TITLE
Added support for middleware on introspection fields

### DIFF
--- a/src/Core/Core.Tests/Execution/__snapshots__/IntrospectionTests.FieldMiddlewareHasAnEffectOnIntrospectIfSwitchedOn.snap
+++ b/src/Core/Core.Tests/Execution/__snapshots__/IntrospectionTests.FieldMiddlewareHasAnEffectOnIntrospectIfSwitchedOn.snap
@@ -1,0 +1,9 @@
+﻿{
+  "Data": {
+    "__typename": "QUERY",
+    "a": "A"
+  },
+  "Extensions": {},
+  "Errors": [],
+  "ContextData": {}
+}

--- a/src/Core/Types/Configuration/Contracts/FieldMiddlewareApplication.cs
+++ b/src/Core/Types/Configuration/Contracts/FieldMiddlewareApplication.cs
@@ -1,0 +1,21 @@
+namespace HotChocolate.Configuration
+{
+    /// <summary>
+    /// This enum specified on which fields custom field
+    /// middleware is applied to.
+    /// </summary>
+    public enum FieldMiddlewareApplication : byte
+    {
+        /// <summary>
+        /// Custom field middleware is only applied to
+        /// user-defined fields and not to introspection fields.
+        /// </summary>
+        UserDefinedFields = 0,
+
+        /// <summary>
+        /// Custom field middleware is applied to all fields
+        /// (user-defined fields and introspection fields).
+        /// </summary>
+        AllFields = 1
+    }
+}

--- a/src/Core/Types/Configuration/Contracts/IReadOnlySchemaOptions.cs
+++ b/src/Core/Types/Configuration/Contracts/IReadOnlySchemaOptions.cs
@@ -11,5 +11,10 @@
         bool StrictValidation { get; }
 
         bool UseXmlDocumentation { get; }
+
+        /// <summary>
+        /// Defines on which fields a middleware pipeline can be applied on.
+        /// </summary>
+        FieldMiddlewareApplication FieldMiddleware { get; }
     }
 }

--- a/src/Core/Types/Configuration/Contracts/ISchemaOptions.cs
+++ b/src/Core/Types/Configuration/Contracts/ISchemaOptions.cs
@@ -12,5 +12,7 @@
         new bool StrictValidation { get; set; }
 
         new bool UseXmlDocumentation { get; set; }
+
+        new FieldMiddlewareApplication FieldMiddleware { get; set; }
     }
 }

--- a/src/Core/Types/Configuration/ReadOnlySchemaOptions.cs
+++ b/src/Core/Types/Configuration/ReadOnlySchemaOptions.cs
@@ -20,6 +20,7 @@ namespace HotChocolate.Configuration
                 ?? "Subscription";
             StrictValidation = options.StrictValidation;
             UseXmlDocumentation = options.UseXmlDocumentation;
+            FieldMiddleware = options.FieldMiddleware;
         }
 
         public string QueryTypeName { get; }
@@ -31,5 +32,7 @@ namespace HotChocolate.Configuration
         public bool StrictValidation { get; }
 
         public bool UseXmlDocumentation { get; }
+
+        public FieldMiddlewareApplication FieldMiddleware { get; }
     }
 }

--- a/src/Core/Types/Configuration/SchemaOptions.cs
+++ b/src/Core/Types/Configuration/SchemaOptions.cs
@@ -13,6 +13,12 @@ namespace HotChocolate.Configuration
 
         public bool UseXmlDocumentation { get; set; } = true;
 
+        public FieldMiddlewareApplication FieldMiddleware
+        {
+            get;
+            set;
+        } = FieldMiddlewareApplication.UserDefinedFields;
+
         public static SchemaOptions FromOptions(IReadOnlySchemaOptions options)
         {
             return new SchemaOptions
@@ -21,7 +27,8 @@ namespace HotChocolate.Configuration
                 MutationTypeName = options.MutationTypeName,
                 SubscriptionTypeName = options.SubscriptionTypeName,
                 StrictValidation = options.StrictValidation,
-                UseXmlDocumentation = options.UseXmlDocumentation
+                UseXmlDocumentation = options.UseXmlDocumentation,
+                FieldMiddleware = options.FieldMiddleware
             };
         }
     }

--- a/src/Core/Types/Types/Helpers/FieldMiddlewareCompiler.cs
+++ b/src/Core/Types/Types/Helpers/FieldMiddlewareCompiler.cs
@@ -11,7 +11,7 @@ namespace HotChocolate.Types
             IReadOnlyList<FieldMiddleware> globalComponents,
             IReadOnlyList<FieldMiddleware> fieldComponents,
             FieldResolverDelegate fieldResolver,
-            bool isIntrospection)
+            bool skipMiddleware)
         {
             if (globalComponents == null)
             {
@@ -23,7 +23,7 @@ namespace HotChocolate.Types
                 throw new ArgumentNullException(nameof(fieldComponents));
             }
 
-            if (isIntrospection
+            if (skipMiddleware
                 || (globalComponents.Count == 0
                     && fieldComponents.Count == 0))
             {

--- a/src/Core/Types/Types/ObjectField.cs
+++ b/src/Core/Types/Types/ObjectField.cs
@@ -110,11 +110,18 @@ namespace HotChocolate.Types
                     context.Type.Name, Resolver, resolver);
             }
 
+            IReadOnlySchemaOptions options = context.DescriptorContext.Options;
+
+            bool skipMiddleware =
+                options.FieldMiddleware == FieldMiddlewareApplication.AllFields
+                    ? false
+                    : isIntrospectionField;
+
             Middleware = FieldMiddlewareCompiler.Compile(
                 context.GlobalComponents,
                 definition.MiddlewareComponents.ToArray(),
                 Resolver,
-                isIntrospectionField);
+                skipMiddleware);
 
             if (Resolver == null && Middleware == null)
             {


### PR DESCRIPTION
This PR adds a new schema option which allows to apply a custom field middleware on a introspection field.

Fixes #853
