### PR TITLE
DataLoader Dependency Injection Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for batching over HTTP [#933](https://github.com/ChilliCream/hotchocolate/pull/933)
 - Added support for persisted queries and added a middleware to enable the active persisted query flow. [#858](https://github.com/ChilliCream/hotchocolate/pull/858)
 - Provide access to variables through IResolverContext. [#958](https://github.com/ChilliCream/hotchocolate/pull/958)
+- Added ability to control when the schem stitching will pull in the remote schemas. [#964](https://github.com/ChilliCream/hotchocolate/pull/964)
+- Added support to register class DataLoader with the standard dependency injection. [#966](https://github.com/ChilliCream/hotchocolate/pull/966)
 
 ### Changed
 

--- a/src/Core/Core.Tests/Extensions/DataLoaderServiceCollectionExtensionsTests.cs
+++ b/src/Core/Core.Tests/Extensions/DataLoaderServiceCollectionExtensionsTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using HotChocolate.Integration.DataLoader;
+using HotChocolate.Utilities;
+using Snapshooter.Xunit;
+
+namespace HotChocolate
+{
+    public class DataLoaderServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddDataLoader_Services_ServicesIsNull()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddDataLoader_Services()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(services);
+
+            // assert
+            services
+                .Select(t => t.ServiceType.GetTypeName())
+                .OrderBy(t => t)
+                .ToArray()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDataLoader_Services_MultipleTimes()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(services);
+            DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(services);
+            DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(services);
+
+            // assert
+            services
+                .Select(t => t.ServiceType.GetTypeName())
+                .OrderBy(t => t)
+                .ToArray()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDataLoader_ServicesFactory_ServicesIsNull()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(
+                    null, s => null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddDataLoader_ServicesFactory_FactoryIsNull()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            Action action = () =>
+                DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(
+                    services, null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddDataLoader_ServicesFactory()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(
+                services, s => null);
+
+            // assert
+            services
+                .Select(t => t.ServiceType.GetTypeName())
+                .OrderBy(t => t)
+                .ToArray()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDataLoader_ServicesFactory_MultipleTimes()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(
+                services, s => null);
+            DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(
+                services, s => null);
+            DataLoaderServiceCollectionExtensions.AddDataLoader<TestDataLoader>(
+                services, s => null);
+
+            // assert
+            services
+                .Select(t => t.ServiceType.GetTypeName())
+                .OrderBy(t => t)
+                .ToArray()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDataLoader_ServicesFactory_ServiceToImplementation_ServicesIsNull()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                DataLoaderServiceCollectionExtensions
+                    .AddDataLoader<ITestDataLoader, TestDataLoader>(null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddDataLoader_ServicesFactory_ServiceToImplementation()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            DataLoaderServiceCollectionExtensions
+                .AddDataLoader<ITestDataLoader, TestDataLoader>(services);
+
+            // assert
+            services
+                .Select(t => t.ServiceType.GetTypeName())
+                .OrderBy(t => t)
+                .ToArray()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDataLoader_ServicesFactory_ServiceToImplementation_MultipleTimes()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            DataLoaderServiceCollectionExtensions
+                .AddDataLoader<ITestDataLoader, TestDataLoader>(services);
+            DataLoaderServiceCollectionExtensions
+                .AddDataLoader<ITestDataLoader, TestDataLoader>(services);
+            DataLoaderServiceCollectionExtensions
+                .AddDataLoader<ITestDataLoader, TestDataLoader>(services);
+
+            // assert
+            services
+                .Select(t => t.ServiceType.GetTypeName())
+                .OrderBy(t => t)
+                .ToArray()
+                .MatchSnapshot();
+        }
+
+        public void AddDataLoaderRegistry_ServicesIsNull()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                DataLoaderServiceCollectionExtensions
+                    .AddDataLoaderRegistry(null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddDataLoaderRegistry()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            DataLoaderServiceCollectionExtensions.AddDataLoaderRegistry(services);
+
+            // assert
+            services
+                .Select(t => t.ServiceType.GetTypeName())
+                .OrderBy(t => t)
+                .ToArray()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddDataLoaderRegistry_MultipleTimes()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            // act
+            DataLoaderServiceCollectionExtensions.AddDataLoaderRegistry(services);
+            DataLoaderServiceCollectionExtensions.AddDataLoaderRegistry(services);
+            DataLoaderServiceCollectionExtensions.AddDataLoaderRegistry(services);
+
+            // assert
+            services
+                .Select(t => t.ServiceType.GetTypeName())
+                .OrderBy(t => t)
+                .ToArray()
+                .MatchSnapshot();
+        }
+    }
+}

--- a/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoaderRegistry.snap
+++ b/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoaderRegistry.snap
@@ -1,0 +1,4 @@
+﻿[
+  "HotChocolate.DataLoader.IDataLoaderRegistry",
+  "HotChocolate.Execution.IBatchOperation"
+]

--- a/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoaderRegistry_MultipleTimes.snap
+++ b/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoaderRegistry_MultipleTimes.snap
@@ -1,0 +1,4 @@
+﻿[
+  "HotChocolate.DataLoader.IDataLoaderRegistry",
+  "HotChocolate.Execution.IBatchOperation"
+]

--- a/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_Services.snap
+++ b/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_Services.snap
@@ -1,0 +1,5 @@
+﻿[
+  "HotChocolate.DataLoader.IDataLoaderRegistry",
+  "HotChocolate.Execution.IBatchOperation",
+  "HotChocolate.Integration.DataLoader.TestDataLoader"
+]

--- a/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_ServicesFactory.snap
+++ b/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_ServicesFactory.snap
@@ -1,0 +1,5 @@
+﻿[
+  "HotChocolate.DataLoader.IDataLoaderRegistry",
+  "HotChocolate.Execution.IBatchOperation",
+  "HotChocolate.Integration.DataLoader.TestDataLoader"
+]

--- a/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_ServicesFactory_MultipleTimes.snap
+++ b/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_ServicesFactory_MultipleTimes.snap
@@ -1,0 +1,5 @@
+﻿[
+  "HotChocolate.DataLoader.IDataLoaderRegistry",
+  "HotChocolate.Execution.IBatchOperation",
+  "HotChocolate.Integration.DataLoader.TestDataLoader"
+]

--- a/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_ServicesFactory_ServiceToImplementation.snap
+++ b/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_ServicesFactory_ServiceToImplementation.snap
@@ -1,0 +1,5 @@
+﻿[
+  "HotChocolate.DataLoader.IDataLoaderRegistry",
+  "HotChocolate.Execution.IBatchOperation",
+  "HotChocolate.Integration.DataLoader.ITestDataLoader"
+]

--- a/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_ServicesFactory_ServiceToImplementation_MultipleTimes.snap
+++ b/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_ServicesFactory_ServiceToImplementation_MultipleTimes.snap
@@ -1,0 +1,5 @@
+﻿[
+  "HotChocolate.DataLoader.IDataLoaderRegistry",
+  "HotChocolate.Execution.IBatchOperation",
+  "HotChocolate.Integration.DataLoader.ITestDataLoader"
+]

--- a/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_Services_MultipleTimes.snap
+++ b/src/Core/Core.Tests/Extensions/__snapshots__/DataLoaderServiceCollectionExtensionsTests.AddDataLoader_Services_MultipleTimes.snap
@@ -1,0 +1,5 @@
+﻿[
+  "HotChocolate.DataLoader.IDataLoaderRegistry",
+  "HotChocolate.Execution.IBatchOperation",
+  "HotChocolate.Integration.DataLoader.TestDataLoader"
+]

--- a/src/Core/Core.Tests/Integration/DataLoader/ITestDataLoader.cs
+++ b/src/Core/Core.Tests/Integration/DataLoader/ITestDataLoader.cs
@@ -1,0 +1,10 @@
+using GreenDonut;
+
+namespace HotChocolate.Integration.DataLoader
+{
+    public interface ITestDataLoader
+        : IDataLoader<string, string>
+    {
+
+    }
+}

--- a/src/Core/Core.Tests/Integration/DataLoader/Query.cs
+++ b/src/Core/Core.Tests/Integration/DataLoader/Query.cs
@@ -25,6 +25,15 @@ namespace HotChocolate.Integration.DataLoader
             return testDataLoader.LoadAsync(key, cancellationToken);
         }
 
+        public Task<string> GetDataLoaderWithInterface(
+            string key,
+            FieldNode fieldSelection,
+            [DataLoader]ITestDataLoader testDataLoader,
+            CancellationToken cancellationToken)
+        {
+            return testDataLoader.LoadAsync(key, cancellationToken);
+        }
+
         public async Task<string> GetWithStackedDataLoader(
             string key,
             FieldNode fieldSelection,
@@ -59,6 +68,19 @@ namespace HotChocolate.Integration.DataLoader
             var list = new List<string>();
 
             foreach (IReadOnlyList<string> request in testDataLoader.Loads)
+            {
+                list.Add(string.Join(", ", request));
+            }
+
+            return list;
+        }
+
+        public List<string> GetLoads3(
+            [DataLoader]ITestDataLoader testDataLoader)
+        {
+            var list = new List<string>();
+
+            foreach (IReadOnlyList<string> request in ((TestDataLoader)testDataLoader).Loads)
             {
                 list.Add(string.Join(", ", request));
             }

--- a/src/Core/Core.Tests/Integration/DataLoader/Query.cs
+++ b/src/Core/Core.Tests/Integration/DataLoader/Query.cs
@@ -28,7 +28,7 @@ namespace HotChocolate.Integration.DataLoader
         public Task<string> GetDataLoaderWithInterface(
             string key,
             FieldNode fieldSelection,
-            [DataLoader]ITestDataLoader testDataLoader,
+            ITestDataLoader testDataLoader,
             CancellationToken cancellationToken)
         {
             return testDataLoader.LoadAsync(key, cancellationToken);
@@ -75,8 +75,7 @@ namespace HotChocolate.Integration.DataLoader
             return list;
         }
 
-        public List<string> GetLoads3(
-            [DataLoader]ITestDataLoader testDataLoader)
+        public List<string> GetLoads3(ITestDataLoader testDataLoader)
         {
             var list = new List<string>();
 

--- a/src/Core/Core.Tests/Integration/DataLoader/TestDataLoader.cs
+++ b/src/Core/Core.Tests/Integration/DataLoader/TestDataLoader.cs
@@ -8,6 +8,7 @@ namespace HotChocolate.Integration.DataLoader
 {
     public class TestDataLoader
         : DataLoaderBase<string, string>
+        , ITestDataLoader
     {
         public TestDataLoader()
             : base(new DataLoaderOptions<string>())

--- a/src/Core/Core.Tests/Integration/DataLoader/__snapshots__/DataLoaderTests.ClassDataLoader_Resolve_From_DependencyInjection.snap
+++ b/src/Core/Core.Tests/Integration/DataLoader/__snapshots__/DataLoaderTests.ClassDataLoader_Resolve_From_DependencyInjection.snap
@@ -1,0 +1,40 @@
+﻿[
+  {
+    "Data": {
+      "a": "a",
+      "b": "b"
+    },
+    "Extensions": {},
+    "Errors": [],
+    "ContextData": {}
+  },
+  {
+    "Data": {
+      "a": "a"
+    },
+    "Extensions": {},
+    "Errors": [],
+    "ContextData": {}
+  },
+  {
+    "Data": {
+      "c": "c"
+    },
+    "Extensions": {},
+    "Errors": [],
+    "ContextData": {}
+  },
+  {
+    "Data": {
+      "loads": [],
+      "loads2": [],
+      "loads3": [
+        "a, b",
+        "c"
+      ]
+    },
+    "Extensions": {},
+    "Errors": [],
+    "ContextData": {}
+  }
+]

--- a/src/Core/Core/Extensions/DataLoaderServiceCollectionExtensions.cs
+++ b/src/Core/Core/Extensions/DataLoaderServiceCollectionExtensions.cs
@@ -13,9 +13,16 @@ namespace HotChocolate
             this IServiceCollection services)
             where T : class, IDataLoader
         {
-            return services
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services
                 .AddDataLoaderRegistry()
-                .AddTransient<T>();
+                .TryAddTransient<T>();
+
+            return services;
         }
 
         public static IServiceCollection AddDataLoader<TService>(
@@ -23,9 +30,21 @@ namespace HotChocolate
             Func<IServiceProvider, TService> factory)
             where TService : class, IDataLoader
         {
-            return services
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (factory is null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            services
                 .AddDataLoaderRegistry()
-                .AddTransient<TService>(factory);
+                .TryAddTransient<TService>(factory);
+
+            return services;
         }
 
         public static IServiceCollection AddDataLoader<TService, TImplementation>(
@@ -33,14 +52,26 @@ namespace HotChocolate
             where TService : class, IDataLoader
             where TImplementation : class, TService
         {
-            return services
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services
                 .AddDataLoaderRegistry()
-                .AddTransient<TService, TImplementation>();
+                .TryAddTransient<TService, TImplementation>();
+
+            return services;
         }
 
         public static IServiceCollection AddDataLoaderRegistry(
             this IServiceCollection services)
         {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             services.TryAddScoped<IDataLoaderRegistry, DataLoaderRegistry>();
             services.TryAddScoped<IBatchOperation>(sp =>
             {

--- a/src/Core/Core/Extensions/DataLoaderServiceCollectionExtensions.cs
+++ b/src/Core/Core/Extensions/DataLoaderServiceCollectionExtensions.cs
@@ -1,28 +1,60 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using HotChocolate.DataLoader;
 using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using GreenDonut;
 
 namespace HotChocolate
 {
     public static class DataLoaderServiceCollectionExtensions
     {
+        public static IServiceCollection AddDataLoader<T>(
+            this IServiceCollection services)
+            where T : class, IDataLoader
+        {
+            return services
+                .AddDataLoaderRegistry()
+                .AddTransient<T>();
+        }
+
+        public static IServiceCollection AddDataLoader<TService>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TService> factory)
+            where TService : class, IDataLoader
+        {
+            return services
+                .AddDataLoaderRegistry()
+                .AddTransient<TService>(factory);
+        }
+
+        public static IServiceCollection AddDataLoader<TService, TImplementation>(
+            this IServiceCollection services)
+            where TService : class, IDataLoader
+            where TImplementation : class, TService
+        {
+            return services
+                .AddDataLoaderRegistry()
+                .AddTransient<TService, TImplementation>();
+        }
+
         public static IServiceCollection AddDataLoaderRegistry(
             this IServiceCollection services)
         {
-            return services
-                .AddScoped<IDataLoaderRegistry, DataLoaderRegistry>()
-                .AddScoped<IBatchOperation>(sp =>
+            services.TryAddScoped<IDataLoaderRegistry, DataLoaderRegistry>();
+            services.TryAddScoped<IBatchOperation>(sp =>
+            {
+                var batchOperation = new DataLoaderBatchOperation();
+
+                foreach (IDataLoaderRegistry registry in
+                    sp.GetServices<IDataLoaderRegistry>())
                 {
-                    var batchOperation = new DataLoaderBatchOperation();
+                    registry.Subscribe(batchOperation);
+                }
 
-                    foreach (IDataLoaderRegistry registry in
-                        sp.GetServices<IDataLoaderRegistry>())
-                    {
-                        registry.Subscribe(batchOperation);
-                    }
-
-                    return batchOperation;
-                });
+                return batchOperation;
+            });
+            return services;
         }
     }
 }

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetCancellationTokenCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetCancellationTokenCompiler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
 {

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetContextCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetContextCompiler.cs
@@ -12,7 +12,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
         public override bool CanHandle(
             ParameterInfo parameter,
             Type sourceType) =>
-            typeof(TContext) == parameter.ParameterType;
+            parameter.ParameterType.IsAssignableFrom(typeof(TContext));
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetCustomContextCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetCustomContextCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using HotChocolate.Resolvers.CodeGeneration;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
 {
@@ -28,7 +29,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
         public override bool CanHandle(
             ParameterInfo parameter,
             Type sourceType) =>
-            parameter.IsDefined(typeof(StateAttribute));
+            ArgumentHelper.IsState(parameter);
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetDataLoaderCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetDataLoaderCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using GreenDonut;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
 {
@@ -29,8 +30,11 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
 
         public override bool CanHandle(
             ParameterInfo parameter,
-            Type sourceType) =>
-            parameter.IsDefined(typeof(DataLoaderAttribute));
+            Type sourceType)
+        {
+            return typeof(IDataLoader).IsAssignableFrom(parameter.ParameterType)
+                || parameter.IsDefined(typeof(DataLoaderAttribute));
+        }
 
         public override Expression Compile(
             Expression context,
@@ -40,7 +44,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
             var attribute =
                 parameter.GetCustomAttribute<DataLoaderAttribute>();
 
-            return string.IsNullOrEmpty(attribute.Key)
+            return string.IsNullOrEmpty(attribute?.Key)
                 ? Expression.Call(
                     _dataLoader.MakeGenericMethod(
                         parameter.ParameterType),

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetDataLoaderCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetDataLoaderCompiler.cs
@@ -15,13 +15,16 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
         {
             _dataLoaderWithKey = typeof(DataLoaderResolverContextExtensions)
                 .GetTypeInfo()
-                .GetDeclaredMethod("DataLoader",
+                .GetDeclaredMethod(
+                    "DataLoader",
                     typeof(IResolverContext),
                     typeof(string));
 
             _dataLoader = typeof(DataLoaderResolverContextExtensions)
                 .GetTypeInfo()
-                .GetDeclaredMethod("DataLoader", typeof(IResolverContext));
+                .GetDeclaredMethod(
+                    "DataLoader",
+                    typeof(IResolverContext));
         }
 
         public override bool CanHandle(

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetDataLoaderCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetDataLoaderCompiler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using GreenDonut;
+using HotChocolate.Resolvers.CodeGeneration;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
 {
@@ -30,11 +31,8 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
 
         public override bool CanHandle(
             ParameterInfo parameter,
-            Type sourceType)
-        {
-            return typeof(IDataLoader).IsAssignableFrom(parameter.ParameterType)
-                || parameter.IsDefined(typeof(DataLoaderAttribute));
-        }
+            Type sourceType) =>
+            ArgumentHelper.IsDataLoader(parameter);
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetEventMessageCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetEventMessageCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using HotChocolate.Resolvers.CodeGeneration;
 using HotChocolate.Subscriptions;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
@@ -20,7 +21,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
         public override bool CanHandle(
             ParameterInfo parameter,
             Type sourceType) =>
-            typeof(IEventMessage).IsAssignableFrom(parameter.ParameterType);
+            ArgumentHelper.IsEventMessage(parameter);
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetObjectTypeCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetObjectTypeCompiler.cs
@@ -19,7 +19,8 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
 
         public override bool CanHandle(
             ParameterInfo parameter,
-            Type sourceType) => typeof(ObjectType) == parameter.ParameterType;
+            Type sourceType) =>
+            typeof(ObjectType) == parameter.ParameterType;
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetOutputFieldCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetOutputFieldCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using HotChocolate.Resolvers.CodeGeneration;
 using HotChocolate.Types;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
@@ -20,7 +21,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
         public override bool CanHandle(
             ParameterInfo parameter,
             Type sourceType) =>
-            typeof(IOutputField).IsAssignableFrom(parameter.ParameterType);
+            ArgumentHelper.IsOutputField(parameter);
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetParentCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetParentCompiler.cs
@@ -17,7 +17,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
             ParameterInfo parameter,
             Type sourceType)
         {
-            return sourceType == parameter.ParameterType
+            return parameter.ParameterType.IsAssignableFrom(sourceType)
                 || parameter.IsDefined(typeof(ParentAttribute));
         }
     }

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetParentCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetParentCompiler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using HotChocolate.Resolvers.CodeGeneration;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
 {
@@ -15,10 +16,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
 
         public override bool CanHandle(
             ParameterInfo parameter,
-            Type sourceType)
-        {
-            return parameter.ParameterType.IsAssignableFrom(sourceType)
-                || parameter.IsDefined(typeof(ParentAttribute));
-        }
+            Type sourceType) =>
+            ArgumentHelper.IsParent(parameter, sourceType);
     }
 }

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetQueryCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetQueryCompiler.cs
@@ -19,7 +19,8 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
 
         public override bool CanHandle(
             ParameterInfo parameter,
-            Type sourceType) => typeof(DocumentNode) == parameter.ParameterType;
+            Type sourceType) =>
+            typeof(DocumentNode) == parameter.ParameterType;
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetSchemaCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetSchemaCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using HotChocolate.Resolvers.CodeGeneration;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
 {
@@ -19,7 +20,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
         public override bool CanHandle(
             ParameterInfo parameter,
             Type sourceType) =>
-            typeof(ISchema).IsAssignableFrom(parameter.ParameterType);
+            ArgumentHelper.IsSchema(parameter);
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetSchemaCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetSchemaCompiler.cs
@@ -18,7 +18,8 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
 
         public override bool CanHandle(
             ParameterInfo parameter,
-            Type sourceType) => typeof(ISchema) == parameter.ParameterType;
+            Type sourceType) =>
+            typeof(ISchema).IsAssignableFrom(parameter.ParameterType);
 
         public override Expression Compile(
             Expression context,

--- a/src/Core/Types/Resolvers/Expressions/Arguments/GetServiceCompiler.cs
+++ b/src/Core/Types/Resolvers/Expressions/Arguments/GetServiceCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using HotChocolate.Resolvers.CodeGeneration;
 
 namespace HotChocolate.Resolvers.Expressions.Parameters
 {
@@ -17,9 +18,7 @@ namespace HotChocolate.Resolvers.Expressions.Parameters
 
         public override bool CanHandle(
             ParameterInfo parameter,
-            Type sourceType)
-        {
-            return parameter.IsDefined(typeof(ServiceAttribute));
-        }
+            Type sourceType) =>
+            ArgumentHelper.IsService(parameter);
     }
 }

--- a/src/Core/Utilities/ActivatorHelper.cs
+++ b/src/Core/Utilities/ActivatorHelper.cs
@@ -22,24 +22,13 @@ namespace HotChocolate.Utilities
 
             Func<IServiceProvider, object> factory;
 
-            if (typeInfo.IsClass)
-            {
-                if (!_factories.TryGetValue(typeInfo, out factory))
-                {
-                    ParameterExpression services =
-                        Expression.Parameter(typeof(IServiceProvider));
-                    NewExpression newInstance = CreateNewInstance(typeInfo, services);
-                    factory = Expression.Lambda<Func<IServiceProvider, object>>(
-                        newInstance, services).Compile();
-                    _factories.TryAdd(typeInfo, factory);
-                }
-                return factory;
-            }
-
             if (!_factories.TryGetValue(typeInfo, out factory))
             {
-                Type type = typeInfo.AsType();
-                factory = s => s.GetService(type);
+                ParameterExpression services =
+                    Expression.Parameter(typeof(IServiceProvider));
+                NewExpression newInstance = CreateNewInstance(typeInfo, services);
+                factory = Expression.Lambda<Func<IServiceProvider, object>>(
+                    newInstance, services).Compile();
                 _factories.TryAdd(typeInfo, factory);
             }
 


### PR DESCRIPTION
The DataLoader could already resolve dependencies from the dependency injection container. With this change it is now possible to register a DataLoader with the standard dependency injection container. This enables referencing DataLoaders through interfaces. 

Here is how we can now register a DataLoader:

```charp
services.AddDataLoader<IMyDataLoader, MyDataLoader>();
```

```charp
services.AddDataLoader<MyDataLoader>();
```

```charp
services.AddDataLoader<IMyDataLoader>(s => ....);
```

The DataLoaderRegistry is automatically registered when using this.

On the resolver side I can now resolve my DataLoader through an interface:

```charp
public async Task<string> ResolveSomething(IMyDataLoader dataLoader) 
{

}
```

I also do not need to use the `[DataLoader]` attribute I the interface implements `IDataLoader`.

Fixes #926