### PR TITLE
Fixed variable coercion.

### DIFF
--- a/src/Core/Core.Tests/Execution/Utilities/VariableValueBuilderTests.cs
+++ b/src/Core/Core.Tests/Execution/Utilities/VariableValueBuilderTests.cs
@@ -350,7 +350,7 @@ namespace HotChocolate.Execution
             Schema schema = CreateSchema();
             OperationDefinitionNode operation = CreateQuery(
                 "query test($test: Decimal) { a }");
-            var input = "1.000000E-004";
+            var input = 1.000000E-004;
 
             var variableValues = new Dictionary<string, object>();
             variableValues.Add("test", input);

--- a/src/Core/Core.Tests/Execution/Utilities/VariableValueBuilderTests.cs
+++ b/src/Core/Core.Tests/Execution/Utilities/VariableValueBuilderTests.cs
@@ -37,6 +37,77 @@ namespace HotChocolate.Execution
         }
 
         [Fact]
+        public void Coerce_Variable_Value_Int_To_String()
+        {
+            // arrange
+            Schema schema = CreateSchema();
+            OperationDefinitionNode operation = CreateQuery(
+                "query test($test: String! = \"foo\") { a }");
+            var variableValues = new Dictionary<string, object>
+            {
+                {
+                    "test",
+                    123
+                }
+            };
+
+            // act
+            var resolver = new VariableValueBuilder(schema, operation);
+            Action action = () => resolver.CreateValues(variableValues);
+
+            // assert
+            Assert.Throws<QueryException>(action).Errors.MatchSnapshot();
+        }
+
+        [Fact]
+        public void Coerce_Variable_Value_Float_To_Int()
+        {
+            // arrange
+            Schema schema = CreateSchema();
+            OperationDefinitionNode operation = CreateQuery(
+                "query test($test: Int!) { a }");
+            var variableValues = new Dictionary<string, object>
+            {
+                {
+                    "test",
+                    123.123
+                }
+            };
+
+            // act
+            var resolver = new VariableValueBuilder(schema, operation);
+            Action action = () => resolver.CreateValues(variableValues);
+
+            // assert
+            Assert.Throws<QueryException>(action).Errors.MatchSnapshot();
+        }
+
+         [Fact]
+        public void Coerce_Variable_Value_Int_To_Float()
+        {
+            // arrange
+            Schema schema = CreateSchema();
+            OperationDefinitionNode operation = CreateQuery(
+                "query test($test: Float!) { a }");
+            var variableValues = new Dictionary<string, object>
+            {
+                {
+                    "test",
+                    123
+                }
+            };
+
+            // act
+            var resolver = new VariableValueBuilder(schema, operation);
+            VariableValueCollection coercedVariableValues =
+                resolver.CreateValues(variableValues);
+
+            // assert
+            Assert.Equal((float)123,
+                coercedVariableValues.GetVariable<float>("test"));
+        }
+
+        [Fact]
         public void StringVariableIsObject()
         {
             // arrange
@@ -551,6 +622,7 @@ namespace HotChocolate.Execution
                     c.RegisterType<FooType>();
                     c.RegisterType<BazType>();
                     c.RegisterType<BarEnumType>();
+                    c.RegisterType<FloatType>();
                     c.RegisterExtendedScalarTypes();
                 });
         }

--- a/src/Core/Core.Tests/Execution/Utilities/__snapshots__/VariableValueBuilderTests.Coerce_Variable_Value_Float_To_Int.snap
+++ b/src/Core/Core.Tests/Execution/Utilities/__snapshots__/VariableValueBuilderTests.Coerce_Variable_Value_Float_To_Int.snap
@@ -1,0 +1,15 @@
+﻿[
+  {
+    "Message": "Variable `test` got invalid value.",
+    "Code": null,
+    "Path": null,
+    "Locations": [
+      {
+        "Line": 1,
+        "Column": 12
+      }
+    ],
+    "Exception": null,
+    "Extensions": {}
+  }
+]

--- a/src/Core/Core.Tests/Execution/Utilities/__snapshots__/VariableValueBuilderTests.Coerce_Variable_Value_Int_To_String.snap
+++ b/src/Core/Core.Tests/Execution/Utilities/__snapshots__/VariableValueBuilderTests.Coerce_Variable_Value_Int_To_String.snap
@@ -1,0 +1,15 @@
+﻿[
+  {
+    "Message": "Variable `test` got invalid value.",
+    "Code": null,
+    "Path": null,
+    "Locations": [
+      {
+        "Line": 1,
+        "Column": 12
+      }
+    ],
+    "Exception": null,
+    "Extensions": {}
+  }
+]

--- a/src/Core/Core/Execution/Utilities/VariableValueBuilder.cs
+++ b/src/Core/Core/Execution/Utilities/VariableValueBuilder.cs
@@ -155,17 +155,11 @@ namespace HotChocolate.Execution
                 value = variable.Type.ParseLiteral(literal);
             }
 
-            value = DeserializeValue(variable.Type, value);
-
-            return value;
-        }
-
-        private object DeserializeValue(IInputType type, object value)
-        {
-            if (type.TryDeserialize(value, out object d))
+            if (variable.Type.TryDeserialize(value, out object deserialized))
             {
-                return d;
+                return deserialized;
             }
+
             return value;
         }
 

--- a/src/Core/Core/Execution/Utilities/VariableValueBuilder.cs
+++ b/src/Core/Core/Execution/Utilities/VariableValueBuilder.cs
@@ -16,7 +16,6 @@ namespace HotChocolate.Execution
         private readonly ISchema _schema;
         private readonly OperationDefinitionNode _operation;
         private readonly ITypeConversion _converter;
-        private readonly DictionaryToInputObjectConverter _inputTypeConverter;
 
         public VariableValueBuilder(
             ISchema schema,
@@ -28,8 +27,6 @@ namespace HotChocolate.Execution
                 ?? throw new ArgumentNullException(nameof(operation));
 
             _converter = _schema.Services.GetTypeConversion();
-            _inputTypeConverter = new DictionaryToInputObjectConverter(
-                _converter);
         }
 
         /// <summary>
@@ -159,43 +156,15 @@ namespace HotChocolate.Execution
             }
 
             value = DeserializeValue(variable.Type, value);
-            value = EnsureClrTypeIsCorrect(variable.Type, value);
 
             return value;
         }
 
         private object DeserializeValue(IInputType type, object value)
         {
-            if (type.IsLeafType()
-                && type.NamedType() is ISerializableType serializable
-                && serializable.TryDeserialize(value, out object deserialized))
+            if (type.TryDeserialize(value, out object d))
             {
-                return deserialized;
-            }
-
-            if (type.IsListType() && value is IList<object>)
-            {
-                return _inputTypeConverter.Convert(value, type);
-            }
-
-            if (type.IsInputObjectType()
-                && value is IDictionary<string, object>)
-            {
-                return _inputTypeConverter.Convert(value, type);
-            }
-
-            return value;
-        }
-
-        private object EnsureClrTypeIsCorrect(IHasClrType type, object value)
-        {
-            if (type.ClrType != typeof(object)
-                && value.GetType() != type.ClrType
-                && _converter.TryConvert(value.GetType(),
-                    type.ClrType, value,
-                    out object converted))
-            {
-                return converted;
+                return d;
             }
             return value;
         }

--- a/src/Core/Core/Execution/Utilities/VariableValueBuilder.cs
+++ b/src/Core/Core/Execution/Utilities/VariableValueBuilder.cs
@@ -136,7 +136,7 @@ namespace HotChocolate.Execution
             return variable;
         }
 
-        private object Normalize(
+        private static object Normalize(
             VariableDefinitionNode variableDefinition,
             Variable variable,
             object rawValue)

--- a/src/Core/Subscriptions.Redis.Tests/RedisTests.cs
+++ b/src/Core/Subscriptions.Redis.Tests/RedisTests.cs
@@ -41,7 +41,7 @@ namespace HotChocolate.Subscriptions.Redis
         [Fact]
         public Task SubscribeOneConsumer_SendMessage_ConsumerReceivesMessage()
         {
-            return TryTest(async () =>
+            return TestHelper.TryTest(async () =>
             {
                 // arrange
                 var cts = new CancellationTokenSource(30000);
@@ -63,7 +63,7 @@ namespace HotChocolate.Subscriptions.Redis
         [Fact]
         public Task SubscribeOneConsumer_Complete_StreamIsCompleted()
         {
-            return TryTest(async () =>
+            return TestHelper.TryTest(async () =>
             {
                 // arrange
                 var eventDescription = new EventDescription(
@@ -82,7 +82,7 @@ namespace HotChocolate.Subscriptions.Redis
         [Fact]
         public Task SubscribeTwoConsumer_SendOneMessage_BothConsumerReceivesMessage()
         {
-            return TryTest(async () =>
+            return TestHelper.TryTest(async () =>
             {
                 // arrange
                 var cts = new CancellationTokenSource(30000);
@@ -110,7 +110,7 @@ namespace HotChocolate.Subscriptions.Redis
         [Fact]
         public Task SubscribeTwoConsumer_SendTwoMessage_BothConsumerReceivesIndependentMessage()
         {
-            return TryTest(async () =>
+            return TestHelper.TryTest(async () =>
             {
                 // arrange
                 var cts = new CancellationTokenSource(30000);
@@ -140,38 +140,6 @@ namespace HotChocolate.Subscriptions.Redis
                 Assert.Equal(outgoingTwo.Payload, incomingTwo.Payload);
                 Assert.NotEqual(incomingOne.Event, incomingTwo.Event);
             });
-        }
-
-        private static async Task TryTest(Func<Task> action)
-        {
-            // we will try four times ....
-            int count = 0;
-            int wait = 50;
-
-            while (true)
-            {
-                if (count < 3)
-                {
-                    try
-                    {
-                        await action().ConfigureAwait(false);
-                        break;
-                    }
-                    catch
-                    {
-                        // try again
-                    }
-                }
-                else
-                {
-                    await action().ConfigureAwait(false);
-                    break;
-                }
-
-                await Task.Delay(wait).ConfigureAwait(false);
-                wait = wait * 2;
-                count++;
-            }
         }
     }
 }

--- a/src/Core/Subscriptions.Redis.Tests/TestHelper.cs
+++ b/src/Core/Subscriptions.Redis.Tests/TestHelper.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+
+namespace HotChocolate.Subscriptions.Redis
+{
+    public static class TestHelper
+    {
+        public static async Task TryTest(Func<Task> action)
+        {
+            // we will try four times ....
+            int count = 0;
+            int wait = 50;
+
+            while (true)
+            {
+                if (count < 3)
+                {
+                    try
+                    {
+                        await action().ConfigureAwait(false);
+                        break;
+                    }
+                    catch
+                    {
+                        // try again
+                    }
+                }
+                else
+                {
+                    await action().ConfigureAwait(false);
+                    break;
+                }
+
+                await Task.Delay(wait).ConfigureAwait(false);
+                wait = wait * 2;
+                count++;
+            }
+        }
+    }
+}

--- a/src/Core/Types.Tests/Types/Scalars/ByteTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/ByteTypeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using HotChocolate.Language;
+using Xunit;
 
 namespace HotChocolate.Types
 {
@@ -26,5 +27,78 @@ namespace HotChocolate.Types
         protected override byte GetMinValue => byte.MinValue;
         protected override string GetAssertMinValue =>
             byte.MinValue.ToString("D", CultureInfo.InvariantCulture);
+
+        [Fact]
+        public void Deserialize_Int_To_Byte()
+        {
+            // arrange
+            var type = new ByteType();
+            int serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((byte)123, Assert.IsType<byte>(value));
+        }
+
+        [Fact]
+        public void Deserialize_NullableInt_To_Byte()
+        {
+            // arrange
+            var type = new ByteType();
+            int? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((byte)123, Assert.IsType<byte>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Byte_To_Byte()
+        {
+            // arrange
+            var type = new ByteType();
+            byte serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((byte)123, Assert.IsType<byte>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Null_To_Null()
+        {
+            // arrange
+            var type = new ByteType();
+
+            // act
+            bool success = type.TryDeserialize(null, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void Deserialize_Decimal_To_Byte()
+        {
+            // arrange
+            var type = new ByteType();
+            decimal serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.False(success);
+        }
     }
 }

--- a/src/Core/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
@@ -227,6 +227,52 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public void Deserialize_NullableDateTime_To_DateTimeOffset()
+        {
+            // arrange
+            var type = new DateTimeType();
+            DateTime? time =
+                new DateTime(2018, 6, 11, 8, 46, 14, DateTimeKind.Utc);
+
+            // act
+            bool success = type.TryDeserialize(time, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal(time,
+                Assert.IsType<DateTimeOffset>(deserialized).UtcDateTime);
+        }
+
+        [Fact]
+        public void Deserialize_NullableDateTime_To_DateTimeOffset_2()
+        {
+            // arrange
+            var type = new DateTimeType();
+            DateTime? time = null;
+
+            // act
+            bool success = type.TryDeserialize(time, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(deserialized);
+        }
+
+        [Fact]
+        public void Deserialize_Null_To_Null()
+        {
+            // arrange
+            var type = new DateTimeType();
+
+            // act
+            bool success = type.TryDeserialize(null, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(deserialized);
+        }
+
+        [Fact]
         public void ParseLiteral_NullValueNode()
         {
             // arrange

--- a/src/Core/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
@@ -182,6 +182,51 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public void Deserialize_InvalidString_To_DateTimeOffset()
+        {
+            // arrange
+            var type = new DateTimeType();
+
+            // act
+            bool success = type.TryDeserialize("abc", out object deserialized);
+
+            // assert
+            Assert.False(success);
+        }
+
+        [Fact]
+        public void Deserialize_DateTimeOffset_To_DateTimeOffset()
+        {
+            // arrange
+            var type = new DateTimeType();
+            var time = new DateTimeOffset(
+                new DateTime(2018, 6, 11, 8, 46, 14, DateTimeKind.Utc));
+
+            // act
+            bool success = type.TryDeserialize(time, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal(time, deserialized);
+        }
+
+        [Fact]
+        public void Deserialize_DateTime_To_DateTimeOffset()
+        {
+            // arrange
+            var type = new DateTimeType();
+            var time = new DateTime(2018, 6, 11, 8, 46, 14, DateTimeKind.Utc);
+
+            // act
+            bool success = type.TryDeserialize(time, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal(time,
+                Assert.IsType<DateTimeOffset>(deserialized).UtcDateTime);
+        }
+
+        [Fact]
         public void ParseLiteral_NullValueNode()
         {
             // arrange

--- a/src/Core/Types.Tests/Types/Scalars/DateTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/DateTypeTests.cs
@@ -82,6 +82,96 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public void Deserialize_InvalidString_To_DateTimeOffset()
+        {
+            // arrange
+            var type = new DateType();
+
+            // act
+            bool success = type.TryDeserialize("abc", out object deserialized);
+
+            // assert
+            Assert.False(success);
+        }
+
+        [Fact]
+        public void Deserialize_DateTimeOffset_To_DateTime()
+        {
+            // arrange
+            var type = new DateType();
+            var time = new DateTimeOffset(
+                new DateTime(2018, 6, 11, 8, 46, 14, DateTimeKind.Utc));
+
+            // act
+            bool success = type.TryDeserialize(time, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal(time.UtcDateTime,
+                Assert.IsType<DateTime>(deserialized));
+        }
+
+        [Fact]
+        public void Deserialize_DateTime_To_DateTime()
+        {
+            // arrange
+            var type = new DateType();
+            var time = new DateTime(2018, 6, 11, 8, 46, 14, DateTimeKind.Utc);
+
+            // act
+            bool success = type.TryDeserialize(time, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal(time, deserialized);
+        }
+
+        [Fact]
+        public void Deserialize_NullableDateTime_To_DateTime()
+        {
+            // arrange
+            var type = new DateType();
+            DateTime? time =
+                new DateTime(2018, 6, 11, 8, 46, 14, DateTimeKind.Utc);
+
+            // act
+            bool success = type.TryDeserialize(time, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal(time, Assert.IsType<DateTime>(deserialized));
+        }
+
+        [Fact]
+        public void Deserialize_NullableDateTime_To_DateTime_2()
+        {
+            // arrange
+            var type = new DateType();
+            DateTime? time = null;
+
+            // act
+            bool success = type.TryDeserialize(time, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(deserialized);
+        }
+
+        [Fact]
+        public void Deserialize_Null_To_Null()
+        {
+            // arrange
+            var type = new DateType();
+
+            // act
+            bool success = type.TryDeserialize(null, out object deserialized);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(deserialized);
+        }
+
+        [Fact]
         public void ParseLiteral_StringValueNode()
         {
             // arrange

--- a/src/Core/Types.Tests/Types/Scalars/DecimalTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/DecimalTypeTests.cs
@@ -53,5 +53,93 @@ namespace HotChocolate.Types
             Assert.Equal(123, Assert.IsType<decimal>(output));
         }
 
+        [Fact]
+        public void Deserialize_Int_To_Decimal()
+        {
+            // arrange
+            var type = new DecimalType();
+            int serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((decimal)123, Assert.IsType<decimal>(value));
+        }
+
+        [Fact]
+        public void Deserialize_NullableInt_To_Decimal()
+        {
+            // arrange
+            var type = new DecimalType();
+            int? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((decimal)123, Assert.IsType<decimal>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Float_To_Decimal()
+        {
+            // arrange
+            var type = new DecimalType();
+            float serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((decimal)123, Assert.IsType<decimal>(value));
+        }
+
+        [Fact]
+        public void Deserialize_NullableFloat_To_Decimal()
+        {
+            // arrange
+            var type = new DecimalType();
+            float? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((decimal)123, Assert.IsType<decimal>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Decimal_To_Decimal()
+        {
+            // arrange
+            var type = new DecimalType();
+            decimal serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((decimal)123, Assert.IsType<decimal>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Null_To_Null()
+        {
+            // arrange
+            var type = new DecimalType();
+
+            // act
+            bool success = type.TryDeserialize(null, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(value);
+        }
     }
 }

--- a/src/Core/Types.Tests/Types/Scalars/FloatTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/FloatTypeTests.cs
@@ -53,5 +53,94 @@ namespace HotChocolate.Types
             Assert.IsType<double>(result);
             Assert.Equal(123d, result);
         }
+
+        [Fact]
+        public void Deserialize_Int_To_Double()
+        {
+            // arrange
+            var type = new FloatType();
+            int serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((double)123, Assert.IsType<double>(value));
+        }
+
+        [Fact]
+        public void Deserialize_NullableInt_To_Double()
+        {
+            // arrange
+            var type = new FloatType();
+            int? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((double)123, Assert.IsType<double>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Decimal_To_Double()
+        {
+            // arrange
+            var type = new FloatType();
+            decimal serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((double)123, Assert.IsType<double>(value));
+        }
+
+        [Fact]
+        public void Deserialize_NullableDecimal_To_Double()
+        {
+            // arrange
+            var type = new FloatType();
+            decimal? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((double)123, Assert.IsType<double>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Double_To_Double()
+        {
+            // arrange
+            var type = new FloatType();
+            double serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((double)123, Assert.IsType<double>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Null_To_Null()
+        {
+            // arrange
+            var type = new FloatType();
+
+            // act
+            bool success = type.TryDeserialize(null, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(value);
+        }
     }
 }

--- a/src/Core/Types.Tests/Types/Scalars/LongTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/LongTypeTests.cs
@@ -1,4 +1,5 @@
 ﻿using HotChocolate.Language;
+using Xunit;
 
 namespace HotChocolate.Types
 {
@@ -23,5 +24,92 @@ namespace HotChocolate.Types
 
         protected override long GetMinValue => long.MinValue;
         protected override string GetAssertMinValue => "-9223372036854775808";
+
+        [Fact]
+        public void Deserialize_Int_To_Long()
+        {
+            // arrange
+            var type = new LongType();
+            int serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((long)123, Assert.IsType<long>(value));
+        }
+
+        [Fact]
+        public void Deserialize_NullableInt_To_Long()
+        {
+            // arrange
+            var type = new LongType();
+            int? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((long)123, Assert.IsType<long>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Decimal_To_Long()
+        {
+            // arrange
+            var type = new LongType();
+            decimal serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.False(success);
+        }
+
+        [Fact]
+        public void Deserialize_NullableDecimal_To_Long()
+        {
+            // arrange
+            var type = new LongType();
+            decimal? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.False(success);
+        }
+
+        [Fact]
+        public void Deserialize_Long_To_Long()
+        {
+            // arrange
+            var type = new LongType();
+            long serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((long)123, Assert.IsType<long>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Null_To_Null()
+        {
+            // arrange
+            var type = new LongType();
+
+            // act
+            bool success = type.TryDeserialize(null, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(value);
+        }
     }
 }

--- a/src/Core/Types.Tests/Types/Scalars/ScalarsTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/ScalarsTests.cs
@@ -62,28 +62,28 @@ namespace HotChocolate.Types
         public void Decimal_Is_Float()
         {
             // arrange
-            decimal d = 123.123;
+            decimal d = 123.123M;
 
             // act
-            bool isScalar = Scalars.TryGetKind(value, out ScalarValueKind kind);
+            bool isScalar = Scalars.TryGetKind(d, out ScalarValueKind kind);
 
             // assert
             Assert.True(isScalar);
-            Assert.Equal(expectedKind, kind);
+            Assert.Equal(ScalarValueKind.Float, kind);
         }
 
         [Fact]
         public void NullableDecimal_Is_Float()
         {
             // arrange
-            decimal? d = 123.123;
+            decimal? d = 123.123M;
 
             // act
-            bool isScalar = Scalars.TryGetKind(value, out ScalarValueKind kind);
+            bool isScalar = Scalars.TryGetKind(d, out ScalarValueKind kind);
 
             // assert
             Assert.True(isScalar);
-            Assert.Equal(expectedKind, kind);
+            Assert.Equal(ScalarValueKind.Float, kind);
         }
 
         [Fact]

--- a/src/Core/Types.Tests/Types/Scalars/ScalarsTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/ScalarsTests.cs
@@ -86,6 +86,19 @@ namespace HotChocolate.Types
             Assert.Equal(expectedKind, kind);
         }
 
+        [Fact]
+        public void Object_Is_Not_A_Serialized_Scalar()
+        {
+            // arrange
+            object o = new object();
+
+            // act
+            bool isScalar = Scalars.TryGetKind(o, out _);
+
+            // assert
+            Assert.False(isScalar);
+        }
+
         public enum Foo
         {
             Bar

--- a/src/Core/Types.Tests/Types/Scalars/ScalarsTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/ScalarsTests.cs
@@ -1,0 +1,7 @@
+namespace HotChocolate.Types
+{
+    public class ScalarsTests
+    {
+
+    }
+}

--- a/src/Core/Types.Tests/Types/Scalars/ScalarsTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/ScalarsTests.cs
@@ -1,7 +1,94 @@
+using System;
+using System.Reflection;
+using Xunit;
+
 namespace HotChocolate.Types
 {
     public class ScalarsTests
     {
+        [InlineData(Foo.Bar, ScalarValueKind.Enum)]
+        [InlineData("foo", ScalarValueKind.String)]
+        [InlineData((short)1, ScalarValueKind.Integer)]
+        [InlineData((int)1, ScalarValueKind.Integer)]
+        [InlineData((long)1, ScalarValueKind.Integer)]
+        [InlineData((ushort)1, ScalarValueKind.Integer)]
+        [InlineData((uint)1, ScalarValueKind.Integer)]
+        [InlineData((ulong)1, ScalarValueKind.Integer)]
+        [InlineData((float)1, ScalarValueKind.Float)]
+        [InlineData((double)1, ScalarValueKind.Float)]
+        [InlineData(null, ScalarValueKind.Null)]
+        [Theory]
+        public void TryGetKind(object value, ScalarValueKind expectedKind)
+        {
+            // arrange
+            // act
+            bool isScalar = Scalars.TryGetKind(value, out ScalarValueKind kind);
 
+            // assert
+            Assert.True(isScalar);
+            Assert.Equal(expectedKind, kind);
+        }
+
+        [InlineData(Foo.Bar, ScalarValueKind.Enum)]
+        [InlineData((short)1, ScalarValueKind.Integer)]
+        [InlineData((int)1, ScalarValueKind.Integer)]
+        [InlineData((long)1, ScalarValueKind.Integer)]
+        [InlineData((ushort)1, ScalarValueKind.Integer)]
+        [InlineData((uint)1, ScalarValueKind.Integer)]
+        [InlineData((ulong)1, ScalarValueKind.Integer)]
+        [InlineData((float)1, ScalarValueKind.Float)]
+        [InlineData((double)1, ScalarValueKind.Float)]
+        [Theory]
+        public void TryGetKind_From_Nullable(
+            object value,
+            ScalarValueKind expectedKind)
+        {
+            // arrange
+            Type type = typeof(Nullable<>).MakeGenericType(value.GetType());
+            ConstructorInfo constructor =
+                type.GetConstructor(new[] { value.GetType() });
+            object nullableValue = constructor.Invoke(new[] { value });
+
+            // act
+            bool isScalar = Scalars.TryGetKind(
+                nullableValue, out ScalarValueKind kind);
+
+            // assert
+            Assert.True(isScalar);
+            Assert.Equal(expectedKind, kind);
+        }
+
+        [Fact]
+        public void Decimal_Is_Float()
+        {
+            // arrange
+            decimal d = 123.123;
+
+            // act
+            bool isScalar = Scalars.TryGetKind(value, out ScalarValueKind kind);
+
+            // assert
+            Assert.True(isScalar);
+            Assert.Equal(expectedKind, kind);
+        }
+
+        [Fact]
+        public void NullableDecimal_Is_Float()
+        {
+            // arrange
+            decimal? d = 123.123;
+
+            // act
+            bool isScalar = Scalars.TryGetKind(value, out ScalarValueKind kind);
+
+            // assert
+            Assert.True(isScalar);
+            Assert.Equal(expectedKind, kind);
+        }
+
+        public enum Foo
+        {
+            Bar
+        }
     }
 }

--- a/src/Core/Types.Tests/Types/Scalars/ShortTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/ShortTypeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using HotChocolate.Language;
+using Xunit;
 
 namespace HotChocolate.Types
 {
@@ -26,5 +27,92 @@ namespace HotChocolate.Types
         protected override short GetMinValue => short.MinValue;
         protected override string GetAssertMinValue =>
             short.MinValue.ToString("D", CultureInfo.InvariantCulture);
+
+        [Fact]
+        public void Deserialize_Int_To_Short()
+        {
+            // arrange
+            var type = new ShortType();
+            int serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((short)123, Assert.IsType<short>(value));
+        }
+
+        [Fact]
+        public void Deserialize_NullableInt_To_Short()
+        {
+            // arrange
+            var type = new ShortType();
+            int? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((short)123, Assert.IsType<short>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Decimal_To_Short()
+        {
+            // arrange
+            var type = new ShortType();
+            decimal serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.False(success);
+        }
+
+        [Fact]
+        public void Deserialize_NullableDecimal_To_Short()
+        {
+            // arrange
+            var type = new ShortType();
+            decimal? serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.False(success);
+        }
+
+        [Fact]
+        public void Deserialize_Short_To_Short()
+        {
+            // arrange
+            var type = new ShortType();
+            short serialized = 123;
+
+            // act
+            bool success = type.TryDeserialize(serialized, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal((short)123, Assert.IsType<short>(value));
+        }
+
+        [Fact]
+        public void Deserialize_Null_To_Null()
+        {
+            // arrange
+            var type = new ShortType();
+
+            // act
+            bool success = type.TryDeserialize(null, out object value);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(value);
+        }
     }
 }

--- a/src/Core/Types.Tests/Types/Scalars/UuidTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/UuidTypeTests.cs
@@ -7,6 +7,65 @@ namespace HotChocolate.Types
     public class UuidTypeTests
     {
         [Fact]
+        public void IsInstanceOfType_StringLiteral()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var guid = Guid.NewGuid();
+            var literal = new StringValueNode(guid.ToString("N"));
+
+            // act
+            bool isOfType = uuidType.IsInstanceOfType(guid);
+
+            // assert
+            Assert.True(isOfType);
+        }
+
+        [Fact]
+        public void IsInstanceOfType_NullLiteral()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var guid = Guid.NewGuid();
+            var literal = new NullValueNode(null);
+
+            // act
+            bool isOfType = uuidType.IsInstanceOfType(literal);
+
+            // assert
+            Assert.True(isOfType);
+        }
+
+        [Fact]
+        public void IsInstanceOfType_IntLiteral()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var guid = Guid.NewGuid();
+            var literal = new IntValueNode(123);
+
+            // act
+            bool isOfType = uuidType.IsInstanceOfType(literal);
+
+            // assert
+            Assert.False(isOfType);
+        }
+
+        [Fact]
+        public void IsInstanceOfType_Null()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var guid = Guid.NewGuid();
+
+            // act
+            Action action = () => uuidType.IsInstanceOfType(null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
         public void Serialize_Guid()
         {
             // arrange
@@ -62,6 +121,19 @@ namespace HotChocolate.Types
 
             // assert
             Assert.Null(value);
+        }
+
+        [Fact]
+        public void ParseLiteral_Null()
+        {
+            // arrange
+            var uuidType = new UuidType();
+
+            // act
+            Action action = () => uuidType.ParseLiteral(null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
         }
 
         [Fact]

--- a/src/Core/Types.Tests/Types/Scalars/UuidTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/UuidTypeTests.cs
@@ -110,6 +110,20 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public void ParseLiteral_IntValueNode()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var literal = new IntValueNode(123);
+
+            // act
+            Action action = () => uuidType.ParseLiteral(literal);
+
+            // assert
+            Assert.Throws<ScalarSerializationException>(action);
+        }
+
+        [Fact]
         public void ParseLiteral_NullValueNode()
         {
             // arrange

--- a/src/Core/Types.Tests/Types/Scalars/UuidTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/UuidTypeTests.cs
@@ -94,6 +94,79 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public void Serialize_Int()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var value = 123;
+
+            // act
+            Action action = () => uuidType.Serialize(value);
+
+            // assert
+            Assert.Throws<ScalarSerializationException>(action);
+        }
+
+        [Fact]
+        public void Deserialize_Null()
+        {
+            // arrange
+            var uuidType = new UuidType();
+
+            // act
+            var success = uuidType.TryDeserialize(null, out object o);
+
+            // assert
+            Assert.True(success);
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void Deserialize_String()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var guid = Guid.NewGuid();
+
+            // act
+            var success = uuidType.TryDeserialize(
+                guid.ToString("N"), out object o);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal(guid, o);
+        }
+
+        [Fact]
+        public void Deserialize_Guid()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var guid = Guid.NewGuid();
+
+            // act
+            var success = uuidType.TryDeserialize(guid, out object o);
+
+            // assert
+            Assert.True(success);
+            Assert.Equal(guid, o);
+        }
+
+        [Fact]
+        public void Deserialize_Int()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            var value = 123;
+
+            // act
+            var success = uuidType.TryDeserialize(value, out _);
+
+            // assert
+            Assert.False(success);
+        }
+
+        [Fact]
         public void ParseLiteral_StringValueNode()
         {
             // arrange
@@ -180,6 +253,20 @@ namespace HotChocolate.Types
             // assert
             Assert.True(stringLiteral is NullValueNode);
             Assert.Null(((NullValueNode)stringLiteral).Value);
+        }
+
+        [Fact]
+        public void ParseValue_Int()
+        {
+            // arrange
+            var uuidType = new UuidType();
+            int value = 123;
+
+            // act
+            Action action = () => uuidType.ParseValue(value);
+
+            // assert
+            Assert.Throws<ScalarSerializationException>(action);
         }
 
         [Fact]

--- a/src/Core/Types/Types/Scalars/DateTimeType.cs
+++ b/src/Core/Types/Types/Scalars/DateTimeType.cs
@@ -46,14 +46,47 @@ namespace HotChocolate.Types
                 CultureInfo.InvariantCulture);
         }
 
-        protected override bool TryParseLiteral(
-            string literal,
+        public override bool TryDeserialize(object serialized, out object value)
+        {
+            if (serialized is null)
+            {
+                value = null;
+                return true;
+            }
+
+            if (serialized is string s
+                && TryDeserializeFromString(s, out object d))
+            {
+                value = d;
+                return true;
+            }
+
+            if (serialized is DateTimeOffset)
+            {
+                value = serialized;
+                return true;
+            }
+
+            if (serialized is DateTime dt)
+            {
+                value = new DateTimeOffset(
+                    dt.ToUniversalTime(),
+                    TimeSpan.Zero);
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        protected override bool TryDeserializeFromString(
+            string serialized,
             out object obj)
         {
-            if (literal != null
-                && literal.EndsWith("Z")
+            if (serialized != null
+                && serialized.EndsWith("Z")
                 && DateTime.TryParse(
-                    literal,
+                    serialized,
                     CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal,
                     out DateTime zuluTime))
@@ -65,7 +98,7 @@ namespace HotChocolate.Types
             }
 
             if (DateTimeOffset.TryParse(
-                literal,
+                serialized,
                 out DateTimeOffset dateTime))
             {
                 obj = dateTime;

--- a/src/Core/Types/Types/Scalars/DateTimeTypeBase.cs
+++ b/src/Core/Types/Types/Scalars/DateTimeTypeBase.cs
@@ -99,24 +99,6 @@ namespace HotChocolate.Types
                 TypeResourceHelper.Scalar_Cannot_Serialize(Name));
         }
 
-        public override bool TryDeserialize(object serialized, out object value)
-        {
-            if (serialized is null)
-            {
-                value = null;
-                return true;
-            }
-
-            if (serialized is string s && TryParseLiteral(s, out object d))
-            {
-                value = d;
-                return true;
-            }
-
-            value = null;
-            return false;
-        }
-
         protected virtual bool TrySerialize(
             object value,
             out string serializedValue)
@@ -144,10 +126,10 @@ namespace HotChocolate.Types
         }
 
         private bool TryParseLiteral(StringValueNode literal, out object obj) =>
-            TryParseLiteral(literal.Value, out obj);
+            TryDeserializeFromString(literal.Value, out obj);
 
-        protected abstract bool TryParseLiteral(
-            string literal,
+        protected abstract bool TryDeserializeFromString(
+            string serialized,
             out object obj);
 
         protected abstract string Serialize(DateTime value);

--- a/src/Core/Types/Types/Scalars/DateType.cs
+++ b/src/Core/Types/Types/Scalars/DateType.cs
@@ -59,10 +59,10 @@ namespace HotChocolate.Types
         }
 
         protected override bool TryDeserializeFromString(
-            string literal, out object obj)
+            string serialized, out object obj)
         {
             if (DateTime.TryParse(
-                literal,
+                serialized,
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.AssumeLocal,
                 out DateTime dateTime))

--- a/src/Core/Types/Types/Scalars/DateType.cs
+++ b/src/Core/Types/Types/Scalars/DateType.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using HotChocolate.Language;
 using HotChocolate.Properties;
 
 namespace HotChocolate.Types
@@ -28,7 +27,38 @@ namespace HotChocolate.Types
             return value.ToString(_dateFormat, CultureInfo.InvariantCulture);
         }
 
-        protected override bool TryParseLiteral(
+        public override bool TryDeserialize(object serialized, out object value)
+        {
+            if (serialized is null)
+            {
+                value = null;
+                return true;
+            }
+
+            if (serialized is string s
+                && TryDeserializeFromString(s, out object d))
+            {
+                value = d;
+                return true;
+            }
+
+            if (serialized is DateTime)
+            {
+                value = serialized;
+                return true;
+            }
+
+            if (serialized is DateTimeOffset dto)
+            {
+                value = dto.UtcDateTime;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        protected override bool TryDeserializeFromString(
             string literal, out object obj)
         {
             if (DateTime.TryParse(

--- a/src/Core/Types/Types/Scalars/DecimalType.cs
+++ b/src/Core/Types/Types/Scalars/DecimalType.cs
@@ -119,7 +119,8 @@ namespace HotChocolate.Types
                 return true;
             }
 
-            if (TryConvertSerialized(serialized, ScalarKind.Float, out decimal c))
+            if (TryConvertSerialized(serialized, ScalarValueKind.Float, out decimal c)
+                || TryConvertSerialized(serialized, ScalarValueKind.Integer, out c))
             {
                 value = c;
                 return true;

--- a/src/Core/Types/Types/Scalars/DecimalType.cs
+++ b/src/Core/Types/Types/Scalars/DecimalType.cs
@@ -2,7 +2,6 @@ using System;
 using System.Globalization;
 using HotChocolate.Language;
 using HotChocolate.Properties;
-using HotChocolate.Utilities;
 
 namespace HotChocolate.Types
 {

--- a/src/Core/Types/Types/Scalars/DecimalType.cs
+++ b/src/Core/Types/Types/Scalars/DecimalType.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using HotChocolate.Language;
 using HotChocolate.Properties;
+using HotChocolate.Utilities;
 
 namespace HotChocolate.Types
 {
@@ -113,9 +114,15 @@ namespace HotChocolate.Types
                 return true;
             }
 
-            if (serialized is decimal d)
+            if (serialized is decimal)
             {
-                value = d;
+                value = serialized;
+                return true;
+            }
+
+            if (TryConvertSerialized(serialized, ScalarKind.Float, out decimal c))
+            {
+                value = c;
                 return true;
             }
 

--- a/src/Core/Types/Types/Scalars/FloatType.cs
+++ b/src/Core/Types/Types/Scalars/FloatType.cs
@@ -136,7 +136,8 @@ namespace HotChocolate.Types
                 return true;
             }
 
-            if (TryConvertSerialized(serialized, ScalarKind.Float, out double c))
+            if (TryConvertSerialized(serialized, ScalarValueKind.Float, out double c)
+                || TryConvertSerialized(serialized, ScalarValueKind.Integer, out c))
             {
                 value = c;
                 return true;

--- a/src/Core/Types/Types/Scalars/FloatType.cs
+++ b/src/Core/Types/Types/Scalars/FloatType.cs
@@ -130,9 +130,15 @@ namespace HotChocolate.Types
                 return true;
             }
 
-            if (serialized is double d)
+            if (serialized is double)
             {
-                value = d;
+                value = serialized;
+                return true;
+            }
+
+            if (TryConvertSerialized(serialized, ScalarKind.Float, out double c))
+            {
+                value = c;
                 return true;
             }
 

--- a/src/Core/Types/Types/Scalars/IntTypeBase.cs
+++ b/src/Core/Types/Types/Scalars/IntTypeBase.cs
@@ -134,7 +134,7 @@ namespace HotChocolate.Types
                 return true;
             }
 
-            if (TryConvertSerialized(serialized, ScalarKind.Integer, out int c)
+            if (TryConvertSerialized(serialized, ScalarValueKind.Integer, out int c)
                 && c >= _min && c <= _max)
             {
                 value = c;

--- a/src/Core/Types/Types/Scalars/IntTypeBase.cs
+++ b/src/Core/Types/Types/Scalars/IntTypeBase.cs
@@ -130,7 +130,14 @@ namespace HotChocolate.Types
 
             if (serialized is int i && i >= _min && i <= _max)
             {
-                value = i;
+                value = serialized;
+                return true;
+            }
+
+            if (TryConvertSerialized(serialized, ScalarKind.Integer, out int c)
+                && c >= _min && c <= _max)
+            {
+                value = c;
                 return true;
             }
 

--- a/src/Core/Types/Types/Scalars/NumericTypeBase.cs
+++ b/src/Core/Types/Types/Scalars/NumericTypeBase.cs
@@ -106,7 +106,7 @@ namespace HotChocolate.Types
                 return true;
             }
 
-            if (TryConvertSerialized(serialized, ScalarKind.Integer, out T c))
+            if (TryConvertSerialized(serialized, ScalarValueKind.Integer, out T c))
             {
                 value = c;
                 return true;

--- a/src/Core/Types/Types/Scalars/NumericTypeBase.cs
+++ b/src/Core/Types/Types/Scalars/NumericTypeBase.cs
@@ -1,6 +1,7 @@
 using System;
 using HotChocolate.Language;
 using HotChocolate.Properties;
+using HotChocolate.Utilities;
 
 namespace HotChocolate.Types
 {
@@ -102,6 +103,12 @@ namespace HotChocolate.Types
             if (serialized is T v)
             {
                 value = v;
+                return true;
+            }
+
+            if (TryConvertSerialized(serialized, ScalarKind.Integer, out T c))
+            {
+                value = c;
                 return true;
             }
 

--- a/src/Core/Types/Types/Scalars/ScalarType.cs
+++ b/src/Core/Types/Types/Scalars/ScalarType.cs
@@ -206,7 +206,7 @@ namespace HotChocolate.Types
             out T value)
         {
             if (Scalars.TryGetKind(serialized, out ScalarKind kind)
-                && kind == ScalarKind.Integer
+                && kind == expectedKind
                 && _converter.TryConvert<object, T>(serialized, out T c))
             {
                 value = c;

--- a/src/Core/Types/Types/Scalars/ScalarType.cs
+++ b/src/Core/Types/Types/Scalars/ScalarType.cs
@@ -202,10 +202,10 @@ namespace HotChocolate.Types
 
         protected static bool TryConvertSerialized<T>(
             object serialized,
-            ScalarKind expectedKind,
+            ScalarValueKind expectedKind,
             out T value)
         {
-            if (Scalars.TryGetKind(serialized, out ScalarKind kind)
+            if (Scalars.TryGetKind(serialized, out ScalarValueKind kind)
                 && kind == expectedKind
                 && _converter.TryConvert<object, T>(serialized, out T c))
             {

--- a/src/Core/Types/Types/Scalars/ScalarType.cs
+++ b/src/Core/Types/Types/Scalars/ScalarType.cs
@@ -3,6 +3,7 @@ using System;
 using HotChocolate.Language;
 using HotChocolate.Properties;
 using HotChocolate.Configuration;
+using HotChocolate.Utilities;
 
 namespace HotChocolate.Types
 {
@@ -15,6 +16,8 @@ namespace HotChocolate.Types
         : TypeSystemObjectBase
         , ILeafType
     {
+        private static readonly ITypeConversion _converter =
+            TypeConversion.Default;
         private readonly Dictionary<string, object> _contextData =
             new Dictionary<string, object>();
 
@@ -195,6 +198,23 @@ namespace HotChocolate.Types
             ICompletionContext context,
             IDictionary<string, object> contextData)
         {
+        }
+
+        protected static bool TryConvertSerialized<T>(
+            object serialized,
+            ScalarKind expectedKind,
+            out T value)
+        {
+            if (Scalars.TryGetKind(serialized, out ScalarKind kind)
+                && kind == ScalarKind.Integer
+                && _converter.TryConvert<object, T>(serialized, out T c))
+            {
+                value = c;
+                return true;
+            }
+
+            value = default;
+            return false;
         }
     }
 }

--- a/src/Core/Types/Types/Scalars/ScalarValueKind.cs
+++ b/src/Core/Types/Types/Scalars/ScalarValueKind.cs
@@ -1,0 +1,12 @@
+namespace HotChocolate.Types
+{
+    public enum ScalarValueKind
+    {
+        String,
+        Integer,
+        Float,
+        Boolean,
+        Enum,
+        Null
+    }
+}

--- a/src/Core/Types/Types/Scalars/Scalars.cs
+++ b/src/Core/Types/Types/Scalars/Scalars.cs
@@ -83,21 +83,32 @@ namespace HotChocolate.Types
                     typeof(PaginationAmountType), TypeContext.None) },
            };
 
-        private static readonly Dictionary<Type, ScalarKind> _scalarKinds =
-            new Dictionary<Type, ScalarKind>
+        private static readonly Dictionary<Type, ScalarValueKind> _scalarKinds =
+            new Dictionary<Type, ScalarValueKind>
             {
-                { typeof(string), ScalarKind.String },
-                { typeof(long), ScalarKind.Integer },
-                { typeof(int), ScalarKind.Integer },
-                { typeof(short), ScalarKind.Integer },
-                { typeof(ulong), ScalarKind.Integer },
-                { typeof(uint), ScalarKind.Integer },
-                { typeof(ushort), ScalarKind.Integer },
-                { typeof(byte), ScalarKind.Integer },
-                { typeof(float), ScalarKind.Float },
-                { typeof(double), ScalarKind.Float },
-                { typeof(decimal), ScalarKind.Float },
-                { typeof(bool), ScalarKind.Float }
+                { typeof(string), ScalarValueKind.String },
+                { typeof(long), ScalarValueKind.Integer },
+                { typeof(int), ScalarValueKind.Integer },
+                { typeof(short), ScalarValueKind.Integer },
+                { typeof(long?), ScalarValueKind.Integer },
+                { typeof(int?), ScalarValueKind.Integer },
+                { typeof(short?), ScalarValueKind.Integer },
+                { typeof(ulong), ScalarValueKind.Integer },
+                { typeof(uint), ScalarValueKind.Integer },
+                { typeof(ushort), ScalarValueKind.Integer },
+                { typeof(ulong?), ScalarValueKind.Integer },
+                { typeof(uint?), ScalarValueKind.Integer },
+                { typeof(ushort?), ScalarValueKind.Integer },
+                { typeof(byte), ScalarValueKind.Integer },
+                { typeof(byte?), ScalarValueKind.Integer },
+                { typeof(float), ScalarValueKind.Float },
+                { typeof(double), ScalarValueKind.Float },
+                { typeof(decimal), ScalarValueKind.Float },
+                { typeof(float?), ScalarValueKind.Float },
+                { typeof(double?), ScalarValueKind.Float },
+                { typeof(decimal?), ScalarValueKind.Float },
+                { typeof(bool), ScalarValueKind.Float },
+                { typeof(bool?), ScalarValueKind.Float }
             };
 
         internal static bool TryGetScalar(
@@ -126,11 +137,11 @@ namespace HotChocolate.Types
             return typeName.HasValue && _nameLookup.ContainsKey(typeName);
         }
 
-        public static bool TryGetKind(object value, out ScalarKind kind)
+        public static bool TryGetKind(object value, out ScalarValueKind kind)
         {
             if (value is null)
             {
-                kind = ScalarKind.Null;
+                kind = ScalarValueKind.Null;
                 return true;
             }
 
@@ -138,21 +149,11 @@ namespace HotChocolate.Types
 
             if (valueType.IsEnum)
             {
-                kind = ScalarKind.Enum;
+                kind = ScalarValueKind.Enum;
                 return true;
             }
 
             return _scalarKinds.TryGetValue(valueType, out kind);
         }
-    }
-
-    public enum ScalarKind
-    {
-        String,
-        Integer,
-        Float,
-        Boolean,
-        Enum,
-        Null
     }
 }

--- a/src/Core/Types/Types/Scalars/Scalars.cs
+++ b/src/Core/Types/Types/Scalars/Scalars.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Types
@@ -82,6 +83,23 @@ namespace HotChocolate.Types
                     typeof(PaginationAmountType), TypeContext.None) },
            };
 
+        private static readonly Dictionary<Type, ScalarKind> _scalarKinds =
+            new Dictionary<Type, ScalarKind>
+            {
+                { typeof(string), ScalarKind.String },
+                { typeof(long), ScalarKind.Integer },
+                { typeof(int), ScalarKind.Integer },
+                { typeof(short), ScalarKind.Integer },
+                { typeof(ulong), ScalarKind.Integer },
+                { typeof(uint), ScalarKind.Integer },
+                { typeof(ushort), ScalarKind.Integer },
+                { typeof(byte), ScalarKind.Integer },
+                { typeof(float), ScalarKind.Float },
+                { typeof(double), ScalarKind.Float },
+                { typeof(decimal), ScalarKind.Float },
+                { typeof(bool), ScalarKind.Float }
+            };
+
         internal static bool TryGetScalar(
             Type clrType,
             out IClrTypeReference schemaType)
@@ -107,5 +125,34 @@ namespace HotChocolate.Types
         {
             return typeName.HasValue && _nameLookup.ContainsKey(typeName);
         }
+
+        public static bool TryGetKind(object value, out ScalarKind kind)
+        {
+            if (value is null)
+            {
+                kind = ScalarKind.Null;
+                return true;
+            }
+
+            Type valueType = value.GetType();
+
+            if (valueType.IsEnum)
+            {
+                kind = ScalarKind.Enum;
+                return true;
+            }
+
+            return _scalarKinds.TryGetValue(valueType, out kind);
+        }
+    }
+
+    public enum ScalarKind
+    {
+        String,
+        Integer,
+        Float,
+        Boolean,
+        Enum,
+        Null
     }
 }

--- a/src/Core/Types/Types/Scalars/UuidType.cs
+++ b/src/Core/Types/Types/Scalars/UuidType.cs
@@ -105,9 +105,9 @@ namespace HotChocolate.Types
                 return true;
             }
 
-            if (serialized is Guid g)
+            if (serialized is Guid)
             {
-                value = g;
+                value = serialized;
                 return true;
             }
 


### PR DESCRIPTION
The variable conversion was wrong and lead to bools being converted to strings instead of throwing an error.

Fixes #714