### PR TITLE
Added schema builder refinements.

### DIFF
--- a/src/Core/Types.Tests/Extensions/SchemaBuilderExtensions.Types.Tests.cs
+++ b/src/Core/Types.Tests/Extensions/SchemaBuilderExtensions.Types.Tests.cs
@@ -652,7 +652,213 @@ namespace HotChocolate
             builder.Create().ToString().MatchSnapshot();
         }
 
+        [Fact]
+        public void AddInterfaceType_BuilderIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddInterfaceType(
+                    null, c => { });
 
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddInterfaceType_ConfigureIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddInterfaceType(
+                    SchemaBuilder.New(), null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddInterfaceTypeT_BuilderIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddInterfaceType<Foo>(
+                    null, c => { });
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddInterfaceTypeT_ConfigureIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddInterfaceType<Foo>(
+                    SchemaBuilder.New(), null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddunionType_BuilderIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddUnionType(
+                    null, c => { });
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddUnionType_ConfigureIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddUnionType(
+                    SchemaBuilder.New(), null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddUnionTypeT_BuilderIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddUnionType<Foo>(
+                    null, c => { });
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddUnionTypeT_ConfigureIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddUnionType<Foo>(
+                    SchemaBuilder.New(), null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddInputObjectType_BuilderIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddInputObjectType(
+                    null, c => { });
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddInputObjectType_ConfigureIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddInputObjectType(
+                    SchemaBuilder.New(), null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddInputObjectTypeT_BuilderIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddInputObjectType<Foo>(
+                    null, c => { });
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddInputObjectTypeT_ConfigureIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddInputObjectType<Foo>(
+                    SchemaBuilder.New(), null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddEnumType_BuilderIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddEnumType(
+                    null, c => { });
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddEnumType_ConfigureIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddEnumType(
+                    SchemaBuilder.New(), null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddEnumTypeT_BuilderIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddEnumType<Foo>(
+                    null, c => { });
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddEnumTypeT_ConfigureIsNull_ArgumentNullException()
+        {
+            // arrange
+            // act
+            Action action = () =>
+                SchemaBuilderExtensions.AddObjectType<Foo>(
+                    SchemaBuilder.New(), null);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
 
         public class QueryType
            : ObjectType
@@ -746,6 +952,17 @@ namespace HotChocolate
                 descriptor.Name("my");
                 descriptor.Location(DirectiveLocation.Field);
             }
+        }
+
+        public interface IMyInterface
+        {
+
+        }
+
+        public enum MyEnum
+        {
+            A,
+            B
         }
     }
 }

--- a/src/Core/Types.Tests/Extensions/SchemaBuilderExtensions.Types.Tests.cs
+++ b/src/Core/Types.Tests/Extensions/SchemaBuilderExtensions.Types.Tests.cs
@@ -2,6 +2,7 @@ using System;
 using Snapshooter.Xunit;
 using Xunit;
 using HotChocolate.Types;
+using HotChocolate.Language;
 
 namespace HotChocolate
 {
@@ -666,6 +667,24 @@ namespace HotChocolate
         }
 
         [Fact]
+        public void AddInterfaceType_With_Descriptor()
+        {
+            // arrange
+            SchemaBuilder builder = SchemaBuilder.New();
+
+            // act
+            SchemaBuilderExtensions.AddInterfaceType(
+                builder, d => d.Name("ABC").Field("abc").Type<StringType>());
+
+            // assert
+            builder
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
+        }
+
+        [Fact]
         public void AddInterfaceType_ConfigureIsNull_ArgumentNullException()
         {
             // arrange
@@ -705,7 +724,25 @@ namespace HotChocolate
         }
 
         [Fact]
-        public void AddunionType_BuilderIsNull_ArgumentNullException()
+        public void AddInterfaceTypeT_With_Descriptor()
+        {
+            // arrange
+            SchemaBuilder builder = SchemaBuilder.New();
+
+            // act
+            SchemaBuilderExtensions.AddInterfaceType<IMyInterface>(
+                builder, d => d.Field("abc").Type<StringType>());
+
+            // assert
+            builder
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void AddUnionType_BuilderIsNull_ArgumentNullException()
         {
             // arrange
             // act
@@ -728,6 +765,29 @@ namespace HotChocolate
 
             // assert
             Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddUnionType_With_Descriptor()
+        {
+            // arrange
+            SchemaBuilder builder = SchemaBuilder.New();
+            builder.AddObjectType(d => d
+                .Name("Foo")
+                .Field("bar")
+                .Type<StringType>()
+                .Resolver("empty"));
+
+            // act
+            SchemaBuilderExtensions.AddUnionType(
+                builder, d => d.Name("ABC").Type(new NamedTypeNode("Foo")));
+
+            // assert
+            builder
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
         }
 
         [Fact]
@@ -757,6 +817,29 @@ namespace HotChocolate
         }
 
         [Fact]
+        public void AddUnionTypeT_With_Descriptor()
+        {
+            // arrange
+            SchemaBuilder builder = SchemaBuilder.New();
+            builder.AddObjectType(d => d
+                .Name("Foo")
+                .Field("bar")
+                .Type<StringType>()
+                .Resolver("empty"));
+
+            // act
+            SchemaBuilderExtensions.AddUnionType<IMyInterface>(
+                builder, d => d.Name("ABC").Type(new NamedTypeNode("Foo")));
+
+            // assert
+            builder
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
+        }
+
+        [Fact]
         public void AddInputObjectType_BuilderIsNull_ArgumentNullException()
         {
             // arrange
@@ -780,6 +863,24 @@ namespace HotChocolate
 
             // assert
             Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void AddInputObjectType_With_Descriptor()
+        {
+            // arrange
+            SchemaBuilder builder = SchemaBuilder.New();
+
+            // act
+            SchemaBuilderExtensions.AddInputObjectType(
+                builder, d => d.Name("Foo").Field("bar").Type<StringType>());
+
+            // assert
+            builder
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
         }
 
         [Fact]
@@ -809,6 +910,25 @@ namespace HotChocolate
         }
 
         [Fact]
+        public void AddInputObjectTypeT_With_Descriptor()
+        {
+            // arrange
+            SchemaBuilder builder = SchemaBuilder.New();
+
+            // act
+            SchemaBuilderExtensions.AddInputObjectType<Bar>(
+                builder, d => d.Field("qux").Type<StringType>());
+
+            // assert
+            builder
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
+        }
+
+
+        [Fact]
         public void AddEnumType_BuilderIsNull_ArgumentNullException()
         {
             // arrange
@@ -835,6 +955,24 @@ namespace HotChocolate
         }
 
         [Fact]
+        public void AddEnumType_With_Descriptor()
+        {
+            // arrange
+            SchemaBuilder builder = SchemaBuilder.New();
+
+            // act
+            SchemaBuilderExtensions.AddEnumType(
+                builder, d => d.Name("Foo").Value("bar").Name("BAZ"));
+
+            // assert
+            builder
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
+        }
+
+        [Fact]
         public void AddEnumTypeT_BuilderIsNull_ArgumentNullException()
         {
             // arrange
@@ -858,6 +996,24 @@ namespace HotChocolate
 
             // assert
             Assert.Throws<ArgumentNullException>(action);
+        }
+
+         [Fact]
+        public void AddEnumTypeT_With_Descriptor()
+        {
+            // arrange
+            SchemaBuilder builder = SchemaBuilder.New();
+
+            // act
+            SchemaBuilderExtensions.AddEnumType<MyEnum>(
+                builder, d => d.BindValuesExplicitly().Value(MyEnum.A));
+
+            // assert
+            builder
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
         }
 
         public class QueryType
@@ -950,7 +1106,7 @@ namespace HotChocolate
                 IDirectiveTypeDescriptor descriptor)
             {
                 descriptor.Name("my");
-                descriptor.Location(DirectiveLocation.Field);
+                descriptor.Location(Types.DirectiveLocation.Field);
             }
         }
 

--- a/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddEnumType_With_Descriptor.snap
+++ b/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddEnumType_With_Descriptor.snap
@@ -1,0 +1,3 @@
+﻿enum Foo {
+  BAZ
+}

--- a/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddInputObjectTypeT_With_Descriptor.snap
+++ b/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddInputObjectTypeT_With_Descriptor.snap
@@ -1,0 +1,7 @@
+﻿input BarInput {
+  baz: String
+  qux: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddInputObjectType_With_Descriptor.snap
+++ b/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddInputObjectType_With_Descriptor.snap
@@ -1,0 +1,6 @@
+﻿input Foo {
+  bar: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddInterfaceTypeT_With_Descriptor.snap
+++ b/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddInterfaceTypeT_With_Descriptor.snap
@@ -1,0 +1,6 @@
+﻿interface IMyInterface {
+  abc: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddInterfaceType_With_Descriptor.snap
+++ b/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddInterfaceType_With_Descriptor.snap
@@ -1,0 +1,6 @@
+﻿interface ABC {
+  abc: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddUnionTypeT_With_Descriptor.snap
+++ b/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddUnionTypeT_With_Descriptor.snap
@@ -1,0 +1,8 @@
+﻿type Foo {
+  bar: String
+}
+
+union ABC = Foo
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddUnionType_With_Descriptor.snap
+++ b/src/Core/Types.Tests/Extensions/__snapshots__/SchemaBuilderExtensionsTypeTests.AddUnionType_With_Descriptor.snap
@@ -1,0 +1,8 @@
+﻿type Foo {
+  bar: String
+}
+
+union ABC = Foo
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/Descriptors/EnumTypeDescriptorTests.cs
+++ b/src/Core/Types.Tests/Types/Descriptors/EnumTypeDescriptorTests.cs
@@ -84,7 +84,7 @@ namespace HotChocolate.Types
             // act
             IEnumTypeDescriptor desc = descriptor;
             desc.Item(FooEnum.Bar1).Name("FOOBAR");
-            desc.BindItems(BindingBehavior.Explicit);
+            desc.BindValues(BindingBehavior.Explicit);
 
             // assert
             EnumTypeDefinition description = descriptor.CreateDefinition();

--- a/src/Core/Types.Tests/Types/EnumTypeExtensionTests.cs
+++ b/src/Core/Types.Tests/Types/EnumTypeExtensionTests.cs
@@ -134,7 +134,7 @@ namespace HotChocolate.Types
             protected override void Configure(
                 IEnumTypeDescriptor<Foo> descriptor)
             {
-                descriptor.BindItems(BindingBehavior.Explicit);
+                descriptor.BindValues(BindingBehavior.Explicit);
                 descriptor.Item(Foo.Bar);
                 descriptor.Item(Foo.Baz);
             }

--- a/src/Core/Types.Tests/Types/EnumTypeTests.cs
+++ b/src/Core/Types.Tests/Types/EnumTypeTests.cs
@@ -155,7 +155,7 @@ namespace HotChocolate.Types
             {
                 c.RegisterType(new EnumType<Foo>(d =>
                 {
-                    d.BindItems(BindingBehavior.Explicit);
+                    d.BindValues(BindingBehavior.Explicit);
                     d.Item(Foo.Bar1);
                 }));
                 c.Options.StrictValidation = false;
@@ -178,7 +178,7 @@ namespace HotChocolate.Types
             {
                 c.RegisterType(new EnumType<Foo>(d =>
                 {
-                    d.BindItemsImplicitly().BindItemsExplicitly();
+                    d.BindValuesImplicitly().BindValuesExplicitly();
                     d.Item(Foo.Bar1);
                 }));
                 c.Options.StrictValidation = false;

--- a/src/Core/Types/Extensions/SchemaBuilderExtensions.Types.cs
+++ b/src/Core/Types/Extensions/SchemaBuilderExtensions.Types.cs
@@ -285,6 +285,142 @@ namespace HotChocolate
             return builder.AddType(new ObjectType<T>(configure));
         }
 
+        public static ISchemaBuilder AddUnionType(
+           this ISchemaBuilder builder,
+           Action<IUnionTypeDescriptor> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return builder.AddType(new UnionType(configure));
+        }
+
+        public static ISchemaBuilder AddUnionType<T>(
+            this ISchemaBuilder builder,
+            Action<IUnionTypeDescriptor> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return builder.AddType(new UnionType<T>(configure));
+        }
+
+        public static ISchemaBuilder AddEnumType(
+           this ISchemaBuilder builder,
+           Action<IEnumTypeDescriptor> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return builder.AddType(new EnumType(configure));
+        }
+
+        public static ISchemaBuilder AddEnumType<T>(
+            this ISchemaBuilder builder,
+            Action<IEnumTypeDescriptor<T>> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return builder.AddType(new EnumType<T>(configure));
+        }
+
+        public static ISchemaBuilder AddInterfaceType(
+           this ISchemaBuilder builder,
+           Action<IInterfaceTypeDescriptor> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return builder.AddType(new InterfaceType(configure));
+        }
+
+        public static ISchemaBuilder AddInterfaceType<T>(
+            this ISchemaBuilder builder,
+            Action<IInterfaceTypeDescriptor<T>> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return builder.AddType(new InterfaceType<T>(configure));
+        }
+
+        public static ISchemaBuilder AddInputObjectType(
+           this ISchemaBuilder builder,
+           Action<IInputObjectTypeDescriptor> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return builder.AddType(new InputObjectType(configure));
+        }
+
+        public static ISchemaBuilder AddInputObjectType<T>(
+            this ISchemaBuilder builder,
+            Action<IInputObjectTypeDescriptor<T>> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return builder.AddType(new InputObjectType<T>(configure));
+        }
+
         public static ISchemaBuilder AddType<T>(
             this ISchemaBuilder builder)
         {

--- a/src/Core/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor.cs
@@ -44,16 +44,19 @@ namespace HotChocolate.Types
         IEnumTypeDescriptor BindItems(
             BindingBehavior behavior);
 
+        IEnumTypeDescriptor BindValues(
+            BindingBehavior behavior);
+
         /// <summary>
         /// Defines that all enum values have to be specified explicitly.
         /// </summary>
-        IEnumTypeDescriptor BindItemsExplicitly();
+        IEnumTypeDescriptor BindValuesExplicitly();
 
         /// <summary>
         /// Defines that all enum values shall be infered
         /// from the associated .Net type,
         /// </summary>
-        IEnumTypeDescriptor BindItemsImplicitly();
+        IEnumTypeDescriptor BindValuesImplicitly();
 
         IEnumTypeDescriptor Directive<T>(
             T directiveInstance)

--- a/src/Core/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor~1.cs
+++ b/src/Core/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor~1.cs
@@ -39,16 +39,18 @@ namespace HotChocolate.Types
 
         IEnumTypeDescriptor<T> BindItems(BindingBehavior behavior);
 
+        IEnumTypeDescriptor<T> BindValues(BindingBehavior behavior);
+
         /// <summary>
         /// Defines that all enum values have to be specified explicitly.
         /// </summary>
-        IEnumTypeDescriptor<T> BindItemsExplicitly();
+        IEnumTypeDescriptor<T> BindValuesExplicitly();
 
         /// <summary>
         /// Defines that all enum values shall be infered
         /// from the associated .Net type,
         /// </summary>
-        IEnumTypeDescriptor<T> BindItemsImplicitly();
+        IEnumTypeDescriptor<T> BindValuesImplicitly();
 
         IEnumTypeDescriptor<T> Directive<TDirective>(
             TDirective directiveInstance)

--- a/src/Core/Types/Types/Descriptors/EnumTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/EnumTypeDescriptor.cs
@@ -94,17 +94,21 @@ namespace HotChocolate.Types.Descriptors
         }
 
         public IEnumTypeDescriptor BindItems(
+            BindingBehavior behavior) =>
+            BindValues(behavior);
+
+        public IEnumTypeDescriptor BindValues(
             BindingBehavior behavior)
         {
             Definition.Values.BindingBehavior = behavior;
             return this;
         }
 
-        public IEnumTypeDescriptor BindItemsExplicitly() =>
-            BindItems(BindingBehavior.Explicit);
+        public IEnumTypeDescriptor BindValuesExplicitly() =>
+            BindValues(BindingBehavior.Explicit);
 
-        public IEnumTypeDescriptor BindItemsImplicitly() =>
-            BindItems(BindingBehavior.Implicit);
+        public IEnumTypeDescriptor BindValuesImplicitly() =>
+            BindValues(BindingBehavior.Implicit);
 
         public IEnumValueDescriptor Item<T>(T value)
         {

--- a/src/Core/Types/Types/Descriptors/EnumTypeDescriptor~1.cs
+++ b/src/Core/Types/Types/Descriptors/EnumTypeDescriptor~1.cs
@@ -30,17 +30,21 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
-        public new IEnumTypeDescriptor<T> BindItems(BindingBehavior behavior)
+        public new IEnumTypeDescriptor<T> BindItems(
+            BindingBehavior behavior) =>
+            BindValues(behavior);
+
+        public new IEnumTypeDescriptor<T> BindValues(BindingBehavior behavior)
         {
-            base.BindItems(behavior);
+            base.BindValues(behavior);
             return this;
         }
 
-        public new IEnumTypeDescriptor<T> BindItemsExplicitly() =>
-            BindItems(BindingBehavior.Explicit);
+        public new IEnumTypeDescriptor<T> BindValuesExplicitly() =>
+            BindValues(BindingBehavior.Explicit);
 
-        public new IEnumTypeDescriptor<T> BindItemsImplicitly() =>
-            BindItems(BindingBehavior.Implicit);
+        public new IEnumTypeDescriptor<T> BindValuesImplicitly() =>
+            BindValues(BindingBehavior.Implicit);
 
         public IEnumValueDescriptor Item(T value)
         {


### PR DESCRIPTION
We now have for all types the ability to define the types add the schema builder.

```csharp
SchemaBuilder.New().AddEnumType(d => d.Value("bar")).Create();
```