### PR TITLE
Fixed Syntax Error Handling in Middleware

### DIFF
--- a/src/Server/AspNetCore.HttpGet/HttpGetMiddleware.cs
+++ b/src/Server/AspNetCore.HttpGet/HttpGetMiddleware.cs
@@ -40,7 +40,8 @@ namespace HotChocolate.AspNetCore
             : base(next,
                 options,
                 owinContextAccessor,
-                queryExecutor.Schema.Services)
+                queryExecutor.Schema.Services,
+                resultSerializer)
         {
             _queryExecutor = queryExecutor
                 ?? throw new ArgumentNullException(nameof(queryExecutor));
@@ -53,7 +54,7 @@ namespace HotChocolate.AspNetCore
             IHttpGetMiddlewareOptions options,
             IQueryExecutor queryExecutor,
             IQueryResultSerializer resultSerializer)
-                : base(next, options)
+            : base(next, options, resultSerializer)
         {
             _queryExecutor = queryExecutor
                 ?? throw new ArgumentNullException(nameof(queryExecutor));

--- a/src/Server/AspNetCore.HttpPost/HttpPostMiddleware.cs
+++ b/src/Server/AspNetCore.HttpPost/HttpPostMiddleware.cs
@@ -46,7 +46,8 @@ namespace HotChocolate.AspNetCore
             : base(next,
                 options,
                 owinContextAccessor,
-                queryExecutor.Schema.Services)
+                queryExecutor.Schema.Services,
+                resultSerializer)
         {
             _queryExecutor = queryExecutor
                 ?? throw new ArgumentNullException(nameof(queryExecutor));
@@ -73,7 +74,7 @@ namespace HotChocolate.AspNetCore
             IResponseStreamSerializer streamSerializer,
             IDocumentCache documentCache,
             IDocumentHashProvider documentHashProvider)
-            : base(next, options)
+            : base(next, options, resultSerializer)
         {
             _queryExecutor = queryExecutor
                 ?? throw new ArgumentNullException(nameof(queryExecutor));

--- a/src/Server/AspNetCore.Tests/GetMiddlewareTests.cs
+++ b/src/Server/AspNetCore.Tests/GetMiddlewareTests.cs
@@ -32,6 +32,22 @@ namespace HotChocolate.AspNetCore
         }
 
         [Fact]
+        public async Task HttpGet_Query_SyntaxException()
+        {
+            // arrange
+            TestServer server = CreateStarWarsServer();
+            var request = "{ ähero { name } }";
+
+            // act
+            HttpResponseMessage message =
+                await server.SendGetRequestAsync(request);
+
+            // assert
+            ClientQueryResult result = await DeserializeAsync(message);
+            result.MatchSnapshot();
+        }
+
+        [Fact]
         public async Task HttpGet_ContentType()
         {
             // arrange

--- a/src/Server/AspNetCore.Tests/PostMiddlewareTests.cs
+++ b/src/Server/AspNetCore.Tests/PostMiddlewareTests.cs
@@ -46,6 +46,32 @@ namespace HotChocolate.AspNetCore
         }
 
         [Fact]
+        public async Task HttpPost_Query_Syntax_Exception()
+        {
+            // arrange
+            TestServer server = CreateStarWarsServer();
+            var request = new ClientQueryRequest
+            {
+                Query =
+                @"
+                    {
+                        ähero {
+                            name
+                        }
+                    }
+                "
+            };
+
+            // act
+            HttpResponseMessage message =
+                await server.SendPostRequestAsync(request);
+
+            // assert
+            ClientQueryResult result = await DeserializeAsync(message);
+            result.MatchSnapshot();
+        }
+
+        [Fact]
         public async Task HttpPost_Check_Response_ContentType()
         {
             // arrange

--- a/src/Server/AspNetCore.Tests/__snapshots__/GetMiddlewareTests.HttpGet_Query_SyntaxException.snap
+++ b/src/Server/AspNetCore.Tests/__snapshots__/GetMiddlewareTests.HttpGet_Query_SyntaxException.snap
@@ -1,0 +1,15 @@
+﻿{
+  "Data": null,
+  "Errors": [
+    {
+      "message": "Unexpected character `Ã` (195).",
+      "locations": [
+        {
+          "line": 1,
+          "column": 3
+        }
+      ]
+    }
+  ],
+  "Extensions": null
+}

--- a/src/Server/AspNetCore.Tests/__snapshots__/PostMiddlewareTests.HttpPost_Query_Syntax_Exception.snap
+++ b/src/Server/AspNetCore.Tests/__snapshots__/PostMiddlewareTests.HttpPost_Query_Syntax_Exception.snap
@@ -1,0 +1,15 @@
+﻿{
+  "Data": null,
+  "Errors": [
+    {
+      "message": "Unexpected character `Ã` (195).",
+      "locations": [
+        {
+          "line": 3,
+          "column": 25
+        }
+      ]
+    }
+  ],
+  "Extensions": null
+}


### PR DESCRIPTION
With the new request parser we parse the request directly in the middleware short-circuiting the query engine in order to be more efficient in the context of ASP.Net. We did however forget to handle syntax errors correctly in the middleware. This PR fixes this.