### PR TITLE
Fix package restores in Visual Studio 2019

### DIFF
--- a/src/Client/StrawberryShake.sln
+++ b/src/Client/StrawberryShake.sln
@@ -3,33 +3,33 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29209.62
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Generators", "Generators\Generators.csproj", "{B612718F-C1B9-46BC-BC0C-2BA1B7D1E7EE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Generators", "Generators\Generators.csproj", "{B612718F-C1B9-46BC-BC0C-2BA1B7D1E7EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Generators.Tests", "Generators.Tests\Generators.Tests.csproj", "{7773E0E5-E30F-4E19-813F-4C786DA73E84}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Generators.Tests", "Generators.Tests\Generators.Tests.csproj", "{7773E0E5-E30F-4E19-813F-4C786DA73E84}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "referenced", "referenced", "{221C2F3F-C438-446F-AB2F-DA35447FC69F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Language", "..\Core\Language\Language.csproj", "{4F515CD7-6A42-4140-AB66-CFB14A1A26EF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Language", "..\Core\Language\Language.csproj", "{4F515CD7-6A42-4140-AB66-CFB14A1A26EF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Types", "..\Core\Types\Types.csproj", "{F2EFEA97-FE45-4FB5-9854-7B2254221531}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Types", "..\Core\Types\Types.csproj", "{F2EFEA97-FE45-4FB5-9854-7B2254221531}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenDonut", "..\DataLoader\Core\GreenDonut.csproj", "{F8990120-CA95-4DA6-B0FA-158AF4E58633}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreenDonut", "..\DataLoader\Core\GreenDonut.csproj", "{F8990120-CA95-4DA6-B0FA-158AF4E58633}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utilities", "..\Core\Utilities\Utilities.csproj", "{CBBD223D-BC08-4F57-A2EB-603837ADD9F0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Utilities", "..\Core\Utilities\Utilities.csproj", "{CBBD223D-BC08-4F57-A2EB-603837ADD9F0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abstractions", "..\Core\Abstractions\Abstractions.csproj", "{820D1C91-5F64-44BE-A980-58BC0A4F830B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Abstractions", "..\Core\Abstractions\Abstractions.csproj", "{820D1C91-5F64-44BE-A980-58BC0A4F830B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Subscriptions", "..\Core\Subscriptions\Subscriptions.csproj", "{0069628F-D881-4053-904B-075A1BD27692}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Subscriptions", "..\Core\Subscriptions\Subscriptions.csproj", "{0069628F-D881-4053-904B-075A1BD27692}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "..\Core\Core\Core.csproj", "{37E8CC3C-A52F-429D-BA6E-CBB1BE7057D1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "..\Core\Core\Core.csproj", "{37E8CC3C-A52F-429D-BA6E-CBB1BE7057D1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abstractions", "Abstractions\Abstractions.csproj", "{81D2B39A-F400-4EF0-9D5F-AC939BBB6372}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Abstractions", "Abstractions\Abstractions.csproj", "{81D2B39A-F400-4EF0-9D5F-AC939BBB6372}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Http", "Http\Http.csproj", "{3421F7FF-5562-4F4E-B8D1-F7ED984FC2E6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Http", "Http\Http.csproj", "{3421F7FF-5562-4F4E-B8D1-F7ED984FC2E6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo", "Demo\Demo.csproj", "{C2BAE857-1FFF-4BD7-A4A3-E94820A1A68D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Demo", "Demo\Demo.csproj", "{C2BAE857-1FFF-4BD7-A4A3-E94820A1A68D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-graphql", "dotnet-graphql\dotnet-graphql.csproj", "{77B58A25-3B54-4E00-B034-D1BEDBE25FA6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-graphql", "dotnet-graphql\dotnet-graphql.csproj", "{77B58A25-3B54-4E00-B034-D1BEDBE25FA6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Core/Core.sln
+++ b/src/Core/Core.sln
@@ -41,13 +41,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Types.Filters.Tests", "Type
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Types.Tests.Documentation", "Types.Tests.Documentation\Types.Tests.Documentation.csproj", "{38537BB2-BDD9-4842-BD2D-0B84B371F1D8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PersistedQueries.FileSystem", "PersistedQueries.FileSystem\PersistedQueries.FileSystem.csproj", "{BC4DAE10-B145-4F9F-9504-BF5EA4C42A60}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PersistedQueries.FileSystem", "PersistedQueries.FileSystem\PersistedQueries.FileSystem.csproj", "{BC4DAE10-B145-4F9F-9504-BF5EA4C42A60}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Subscriptions.Redis", "Subscriptions.Redis\Subscriptions.Redis.csproj", "{85660981-4992-49A8-A786-D6FB82E01463}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Subscriptions.Redis", "Subscriptions.Redis\Subscriptions.Redis.csproj", "{85660981-4992-49A8-A786-D6FB82E01463}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarWars", "StarWars\StarWars.csproj", "{6D66B162-D2F6-411E-8F9C-F0B3AB5A9289}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StarWars", "StarWars\StarWars.csproj", "{6D66B162-D2F6-411E-8F9C-F0B3AB5A9289}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PersistedQueries.Redis", "PersistedQueries.Redis\PersistedQueries.Redis.csproj", "{B4CC72E4-C93E-4AFB-8381-BFF6F4B06CC9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PersistedQueries.Redis", "PersistedQueries.Redis\PersistedQueries.Redis.csproj", "{B4CC72E4-C93E-4AFB-8381-BFF6F4B06CC9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PersistedQueries.FileSystem.Tests", "PersistedQueries.FileSystem.Tests\PersistedQueries.FileSystem.Tests.csproj", "{F3657CF0-6B18-4021-8CCF-A7C131E4F745}"
 EndProject
@@ -63,9 +63,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreenDonut", "..\DataLoader
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Types.Sorting", "Types.Sorting\Types.Sorting.csproj", "{F3B8AE0B-C6D9-4B45-8131-40E93CFE6BB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Types.Sorting.Tests", "Types.Sorting.Tests\Types.Sorting.Tests.csproj", "{A23C8758-6173-46F8-B132-28E5B75846B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Types.Sorting.Tests", "Types.Sorting.Tests\Types.Sorting.Tests.csproj", "{A23C8758-6173-46F8-B132-28E5B75846B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Types.Sorting.Mongo.Tests", "Types.Sorting.Mongo.Tests\Types.Sorting.Mongo.Tests.csproj", "{E8843255-77EB-471F-B682-528BB4B5D1D5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Types.Sorting.Mongo.Tests", "Types.Sorting.Mongo.Tests\Types.Sorting.Mongo.Tests.csproj", "{E8843255-77EB-471F-B682-528BB4B5D1D5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Server/Server.sln
+++ b/src/Server/Server.sln
@@ -59,7 +59,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore.Abstractions", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore.Tests.Utilities", "AspNetCore.Tests.Utilities\AspNetCore.Tests.Utilities.csproj", "{AF440449-DBE1-40AB-B155-87C3B31E7378}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarWars", "..\Core\StarWars\StarWars.csproj", "{9CA71125-2837-4F92-9822-CB41B64E2E43}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StarWars", "..\Core\StarWars\StarWars.csproj", "{9CA71125-2837-4F92-9822-CB41B64E2E43}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetClassic.Abstractions", "AspNetClassic.Abstractions\AspNetClassic.Abstractions.csproj", "{B930D413-E013-4DE6-B1AB-C88BE946E615}"
 EndProject

--- a/src/Templates/StarWars/content/StarWars.sln
+++ b/src/Templates/StarWars/content/StarWars.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarWars", "StarWars\StarWars.csproj", "{DD35F196-1631-4C30-8369-68FACB27BA8A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StarWars", "StarWars\StarWars.csproj", "{DD35F196-1631-4C30-8369-68FACB27BA8A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
A number of solutions somehow had the wrong project type guid. They couldn't be opened correctly in Visual Studio 2019 and package restores failed with an unhelpful error message.