### PR TITLE
Set Error.Path for HTTP exceptions

### DIFF
--- a/src/Stitching/Stitching.Tests/Middleware/DelegateToRemoteSchemaMiddlewareTests.cs
+++ b/src/Stitching/Stitching.Tests/Middleware/DelegateToRemoteSchemaMiddlewareTests.cs
@@ -1144,7 +1144,7 @@ namespace HotChocolate.Stitching
             }
 
             // assert
-            Snapshot.Match(result);
+            result.MatchSnapshot(options => options.IgnoreField("Errors[0].Exception.StackTrace"));
         }
 
         private class ServiceUnavailableDelegatingHandler : DelegatingHandler

--- a/src/Stitching/Stitching.Tests/Middleware/DelegateToRemoteSchemaMiddlewareTests.cs
+++ b/src/Stitching/Stitching.Tests/Middleware/DelegateToRemoteSchemaMiddlewareTests.cs
@@ -10,6 +10,7 @@ using HotChocolate.Types;
 using HotChocolate.Resolvers;
 using FileResource = ChilliCream.Testing.FileResource;
 using HotChocolate.AspNetCore.Tests.Utilities;
+using System.Threading;
 
 namespace HotChocolate.Stitching
 {
@@ -1089,6 +1090,70 @@ namespace HotChocolate.Stitching
 
             // assert
             Snapshot.Match(result);
+        }
+
+        [Fact]
+        public async Task HttpErrorsHavePathSet()
+        {
+            // arrange
+            var connections = new Dictionary<string, HttpClient>();
+            IHttpClientFactory clientFactory = CreateRemoteSchemas(connections);
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton(clientFactory);
+            serviceCollection.AddStitchedSchema(builder =>
+                builder.AddSchemaFromHttp("contract")
+                    .AddSchemaFromHttp("customer")
+                    .AddExtensionsFromString(
+                        FileResource.Open("StitchingExtensions.graphql"))
+                    .AddSchemaConfiguration(c =>
+                        c.RegisterType<PaginationAmountType>()));
+
+            IServiceProvider services =
+                serviceCollection.BuildServiceProvider();
+
+            ISchema schema = services.GetRequiredService<ISchema>();
+            IQueryExecutor executor = services
+                .GetRequiredService<IQueryExecutor>();
+            IExecutionResult result = null;
+
+            // have to replace the http client after the schema is built
+            connections["customer"] = new HttpClient(new ServiceUnavailableDelegatingHandler())
+            {
+                BaseAddress = connections["customer"].BaseAddress
+            };
+
+
+            // act
+            using (IServiceScope scope = services.CreateScope())
+            {
+                IReadOnlyQueryRequest request =
+                    QueryRequestBuilder.New()
+                        .SetQuery(@"
+                        {
+                            customer(id: ""Q3VzdG9tZXIKZDE="") {
+                                contracts {
+                                    id
+                                }
+                            }
+                        }")
+                        .SetServices(scope.ServiceProvider)
+                        .Create();
+
+                result = await executor.ExecuteAsync(request);
+            }
+
+            // assert
+            Snapshot.Match(result);
+        }
+
+        private class ServiceUnavailableDelegatingHandler : DelegatingHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable);
+                return Task.FromResult(response);
+            }
         }
 
         [Fact]

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/DelegateToRemoteSchemaMiddlewareTests.AddErrorFilter.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/DelegateToRemoteSchemaMiddlewareTests.AddErrorFilter.snap
@@ -49,6 +49,7 @@
             "code": "ERROR_CODE"
           }
         },
+        "schemaName": "contract",
         "STITCH": "SOMETHING"
       }
     },
@@ -83,6 +84,7 @@
             "code": "ERROR_CODE"
           }
         },
+        "schemaName": "contract",
         "STITCH": "SOMETHING"
       }
     }

--- a/src/Stitching/Stitching.Tests/Middleware/__snapshots__/DelegateToRemoteSchemaMiddlewareTests.HttpErrorsHavePathSet.snap
+++ b/src/Stitching/Stitching.Tests/Middleware/__snapshots__/DelegateToRemoteSchemaMiddlewareTests.HttpErrorsHavePathSet.snap
@@ -1,0 +1,45 @@
+﻿{
+  "Data": {
+    "customer": null
+  },
+  "Extensions": {},
+  "Errors": [
+    {
+      "Message": "Unexpected Execution Error",
+      "Code": "STITCHING_HTTP_REQUEST_EXCEPTION",
+      "Path": [
+        "customer"
+      ],
+      "Locations": [
+        {
+          "Line": 3,
+          "Column": 29
+        }
+      ],
+      "Exception": {
+        "StackTrace": "   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()\n   at HotChocolate.Stitching.Utilities.HttpQueryClient.FetchInternalAsync(HttpQueryRequest request, HttpClient httpClient) in C:\\Dev\\GitHub\\hotchocolate\\src\\Stitching\\Stitching\\Utilities\\HttpQueryClient.cs:line 139\n   at HotChocolate.Stitching.Utilities.HttpQueryClient.FetchAsync(HttpQueryRequest request, HttpClient httpClient, IEnumerable`1 interceptors, CancellationToken cancellationToken) in C:\\Dev\\GitHub\\hotchocolate\\src\\Stitching\\Stitching\\Utilities\\HttpQueryClient.cs:line 46\n   at HotChocolate.Stitching.Delegation.RemoteQueryMiddleware.InvokeAsync(IQueryContext context) in C:\\Dev\\GitHub\\hotchocolate\\src\\Stitching\\Stitching\\Delegation\\RemoteQueryMiddleware.cs:line 39",
+        "Message": "Response status code does not indicate success: 503 (Service Unavailable).",
+        "Data": {},
+        "InnerException": null,
+        "HelpLink": null,
+        "Source": "System.Net.Http",
+        "HResult": -2146233088
+      },
+      "Extensions": {
+        "code": "STITCHING_HTTP_REQUEST_EXCEPTION",
+        "remote": {
+          "Message": "Unexpected Execution Error",
+          "Code": "STITCHING_HTTP_REQUEST_EXCEPTION",
+          "Path": null,
+          "Locations": [],
+          "Exception": null,
+          "Extensions": {
+            "code": "STITCHING_HTTP_REQUEST_EXCEPTION"
+          }
+        },
+        "schemaName": "customer"
+      }
+    }
+  ],
+  "ContextData": {}
+}

--- a/src/Stitching/Stitching/ErrorCodes.cs
+++ b/src/Stitching/Stitching/ErrorCodes.cs
@@ -1,6 +1,6 @@
 namespace HotChocolate.Stitching
 {
-    internal static class ErrorCodes
+    public static class ErrorCodes
     {
         public const string ArgumentNotDefined = "STITCHING_ARG_NOT_DEFINED";
         public const string FieldNotDefined = "STITCHING_FLD_NOT_DEFINED";

--- a/src/Stitching/Stitching/Middleware/DelegateToRemoteSchemaMiddleware.cs
+++ b/src/Stitching/Stitching/Middleware/DelegateToRemoteSchemaMiddleware.cs
@@ -195,6 +195,11 @@ namespace HotChocolate.Stitching
                     builder.SetPath(path)
                         .ClearLocations()
                         .AddLocation(context.FieldSelection);
+                } else if (IsHttpError(error))
+                {
+                    builder.SetPath(context.Path)
+                        .ClearLocations()
+                        .AddLocation(context.FieldSelection);
                 }
 
                 context.ReportError(builder.Build());
@@ -225,6 +230,8 @@ namespace HotChocolate.Stitching
 
             return current;
         }
+
+        private static bool IsHttpError(IError error) => error.Code == ErrorCodes.HttpRequestException;
 
         private static IReadOnlyCollection<VariableValue> CreateVariableValues(
             IMiddlewareContext context,


### PR DESCRIPTION
- Sets the Error.Path on HTTP exceptions for better error diagnostics.
- Add the schema name to the error extensions.

Resolves #1112 
