### PR TITLE
Allow filtering on nullable value type properties

### DIFF
--- a/src/Core/Types.Filters.Tests/ComparableFilterInputTypeTests.cs
+++ b/src/Core/Types.Filters.Tests/ComparableFilterInputTypeTests.cs
@@ -227,6 +227,19 @@ namespace HotChocolate.Types.Filters
             schema.ToString().MatchSnapshot();
         }
 
+        [Fact]
+        public void Model_With_Nullable_Properties()
+        {
+            // arrange
+            // act
+            var schema = CreateSchema(
+                new FilterInputType<FooNullable>(
+                    d => d.Filter(f => f.BarShort)));
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public enum FooBar
         {
             Foo,
@@ -242,6 +255,11 @@ namespace HotChocolate.Types.Filters
             public double BarDouble { get; set; }
             public decimal BarDecimal { get; set; }
             public FooBar FooBar { get; set; }
+        }
+
+        public class FooNullable
+        {
+            public short? BarShort { get; set; }
         }
 
         public class Bar

--- a/src/Core/Types.Filters.Tests/QueryableFilterVisitorBooleanTests.cs
+++ b/src/Core/Types.Filters.Tests/QueryableFilterVisitorBooleanTests.cs
@@ -32,7 +32,6 @@ namespace HotChocolate.Types.Filters
             Assert.False(func(b));
         }
 
-
         [Fact]
         public void Create_BooleanNotEqual_Expression()
         {
@@ -57,9 +56,68 @@ namespace HotChocolate.Types.Filters
             Assert.False(func(b));
         }
 
+        [Fact]
+        public void Create_NullableBooleanEqual_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("bar",
+                    new BooleanValueNode(true)));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { Bar = true };
+            Assert.True(func(a));
+
+            var b = new FooNullable { Bar = false };
+            Assert.False(func(b));
+
+            var c = new FooNullable { Bar = null };
+            Assert.False(func(c));
+        }
+
+        [Fact]
+        public void Create_NullableBooleanNotEqual_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("bar",
+                    new BooleanValueNode(false)));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { Bar = false };
+            Assert.True(func(a));
+
+            var b = new FooNullable { Bar = true };
+            Assert.False(func(b));
+
+            var c = new FooNullable { Bar = null };
+            Assert.False(func(c));
+        }
+
         public class Foo
         {
             public bool Bar { get; set; }
+        }
+
+        public class FooNullable
+        {
+            public bool? Bar { get; set; }
         }
 
         public class FooFilterType
@@ -67,6 +125,17 @@ namespace HotChocolate.Types.Filters
         {
             protected override void Configure(
                 IFilterInputTypeDescriptor<Foo> descriptor)
+            {
+                descriptor.Filter(t => t.Bar)
+                    .AllowEquals().And().AllowNotEquals();
+            }
+        }
+
+        public class FooNullableFilterType
+            : FilterInputType<FooNullable>
+        {
+            protected override void Configure(
+                IFilterInputTypeDescriptor<FooNullable> descriptor)
             {
                 descriptor.Filter(t => t.Bar)
                     .AllowEquals().And().AllowNotEquals();

--- a/src/Core/Types.Filters.Tests/QueryableFilterVisitorComparableTests.cs
+++ b/src/Core/Types.Filters.Tests/QueryableFilterVisitorComparableTests.cs
@@ -332,6 +332,364 @@ namespace HotChocolate.Types.Filters
             Assert.False(func(b));
         }
 
+        [Fact]
+        public void Create_NullableShortEqual_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 12 };
+            Assert.True(func(a));
+
+            var b = new FooNullable { BarShort = 13 };
+            Assert.False(func(b));
+
+            var c = new FooNullable { BarShort = null };
+            Assert.False(func(c));
+        }
+
+        [Fact]
+        public void Create_NullableShortNotEqual_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_not",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 13 };
+            Assert.True(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.False(func(b));
+
+            var c = new FooNullable { BarShort = null };
+            Assert.True(func(c));
+        }
+
+
+        [Fact]
+        public void Create_NullableShortGreaterThan_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_gt",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 11 };
+            Assert.False(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.False(func(b));
+
+            var c = new FooNullable { BarShort = 13 };
+            Assert.True(func(c));
+
+            var d = new FooNullable { BarShort = null };
+            Assert.False(func(d));
+        }
+
+        [Fact]
+        public void Create_NullableShortNotGreaterThan_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_not_gt",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 11 };
+            Assert.True(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.True(func(b));
+
+            var c = new FooNullable { BarShort = 13 };
+            Assert.False(func(c));
+
+            var d = new FooNullable { BarShort = null };
+            Assert.True(func(d));
+        }
+
+
+        [Fact]
+        public void Create_NullableShortGreaterThanOrEquals_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_gte",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 11 };
+            Assert.False(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.True(func(b));
+
+            var c = new FooNullable { BarShort = 13 };
+            Assert.True(func(c));
+
+            var d = new FooNullable { BarShort = null };
+            Assert.False(func(d));
+        }
+
+        [Fact]
+        public void Create_NullableShortNotGreaterThanOrEquals_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_not_gte",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 11 };
+            Assert.True(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.False(func(b));
+
+            var c = new FooNullable { BarShort = 13 };
+            Assert.False(func(c));
+
+            var d = new FooNullable { BarShort = null };
+            Assert.True(func(d));
+        }
+
+
+
+        [Fact]
+        public void Create_NullableShortLowerThan_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_lt",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 11 };
+            Assert.True(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.False(func(b));
+
+            var c = new FooNullable { BarShort = 13 };
+            Assert.False(func(c));
+
+            var d = new FooNullable { BarShort = null };
+            Assert.False(func(d));
+        }
+
+        [Fact]
+        public void Create_NullableShortNotLowerThan_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_not_lt",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 11 };
+            Assert.False(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.True(func(b));
+
+            var c = new FooNullable { BarShort = 13 };
+            Assert.True(func(c));
+
+            var d = new FooNullable { BarShort = null };
+            Assert.True(func(d));
+        }
+
+
+        [Fact]
+        public void Create_NullableShortLowerThanOrEquals_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_lte",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 11 };
+            Assert.True(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.True(func(b));
+
+            var c = new FooNullable { BarShort = 13 };
+            Assert.False(func(c));
+
+            var d = new FooNullable { BarShort = null };
+            Assert.False(func(d));
+        }
+
+        [Fact]
+        public void Create_NullableShortNotLowerThanOrEquals_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_not_lte",
+                    new IntValueNode("12")));
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 11 };
+            Assert.False(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.False(func(b));
+
+            var c = new FooNullable { BarShort = 13 };
+            Assert.True(func(c));
+
+            var d = new FooNullable { BarShort = null };
+            Assert.True(func(d));
+        }
+
+        [Fact]
+        public void Create_NullableShortIn_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_in",
+                new ListValueNode(new[]
+                {
+                    new IntValueNode("13"),
+                    new IntValueNode("14")
+                }))
+            );
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(
+                fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 13 };
+            Assert.True(func(a));
+
+            var b = new FooNullable { BarShort = 12 };
+            Assert.False(func(b));
+
+            var c = new FooNullable { BarShort = null };
+            Assert.False(func(c));
+        }
+
+        [Fact]
+        public void Create_NullableShortNotIn_Expression()
+        {
+            // arrange
+            var value = new ObjectValueNode(
+                new ObjectFieldNode("barShort_not_in",
+                new ListValueNode(new[] { new IntValueNode("13"), new IntValueNode("14") }
+                ))
+            );
+
+            var fooNullableType = CreateType(new FooNullableFilterType());
+
+            // act
+            var filter = new QueryableFilterVisitor(fooNullableType, typeof(FooNullable), TypeConversion.Default);
+            value.Accept(filter);
+            Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
+
+            // assert
+            var a = new FooNullable { BarShort = 12 };
+            Assert.True(func(a));
+
+            var b = new FooNullable { BarShort = 13 };
+            Assert.False(func(b));
+
+            var c = new FooNullable { BarShort = null };
+            Assert.True(func(c));
+        }
 
         public class Foo
         {
@@ -341,6 +699,11 @@ namespace HotChocolate.Types.Filters
             public float BarFloat { get; set; }
             public double BarDouble { get; set; }
             public decimal BarDecimal { get; set; }
+        }
+
+        public class FooNullable
+        {
+            public short? BarShort { get; set; }
         }
 
         public class FooFilterType
@@ -355,6 +718,16 @@ namespace HotChocolate.Types.Filters
                 descriptor.Filter(x => x.BarFloat);
                 descriptor.Filter(x => x.BarDouble);
                 descriptor.Filter(x => x.BarDecimal);
+            }
+        }
+
+        public class FooNullableFilterType
+            : FilterInputType<FooNullable>
+        {
+            protected override void Configure(
+                IFilterInputTypeDescriptor<FooNullable> descriptor)
+            {
+                descriptor.Filter(x => x.BarShort);
             }
         }
     }

--- a/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Model_With_Nullable_Properties.snap
+++ b/src/Core/Types.Filters.Tests/__snapshots__/ComparableFilterInputTypeTests.Model_With_Nullable_Properties.snap
@@ -1,0 +1,30 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  foo: String
+}
+
+input FooNullableFilter {
+  AND: [FooNullableFilter!]
+  barShort: Short
+  barShort_gt: Short
+  barShort_gte: Short
+  barShort_in: [Short]
+  barShort_lt: Short
+  barShort_lte: Short
+  barShort_not: Short
+  barShort_not_gt: Short
+  barShort_not_gte: Short
+  barShort_not_in: [Short]
+  barShort_not_lt: Short
+  barShort_not_lte: Short
+  OR: [FooNullableFilter!]
+}
+
+"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
+scalar Short
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Filters/Expressions/FilterExpressionBuilder.cs
+++ b/src/Core/Types.Filters/Expressions/FilterExpressionBuilder.cs
@@ -27,6 +27,13 @@ namespace HotChocolate.Types.Filters.Expressions
                 && m.GetParameters().Length == 1
                 && m.GetParameters().Single().ParameterType == typeof(string));
 
+        private static Expression NullableSafeConstantExpression(object value, Type type)
+        {
+            return Nullable.GetUnderlyingType(type) == null
+                ? (Expression)Expression.Constant(value)
+                : Expression.Convert(Expression.Constant(value), type);
+        }
+
         public static Expression Not(Expression expression)
         {
             return Expression.Equal(expression, Expression.Constant(false));
@@ -36,14 +43,14 @@ namespace HotChocolate.Types.Filters.Expressions
             MemberExpression property,
             object value)
         {
-            return Expression.Equal(property, Expression.Constant(value));
+            return Expression.Equal(property, NullableSafeConstantExpression(value, property.Type));
         }
 
         public static Expression NotEquals(
             MemberExpression property,
             object value)
         {
-            return Expression.NotEqual(property, Expression.Constant(value));
+            return Expression.NotEqual(property, NullableSafeConstantExpression(value, property.Type));
         }
 
         public static Expression In(
@@ -64,36 +71,28 @@ namespace HotChocolate.Types.Filters.Expressions
             MemberExpression property,
             object value)
         {
-            return Expression.GreaterThan(
-                property,
-                Expression.Constant(value));
+            return Expression.GreaterThan(property, NullableSafeConstantExpression(value, property.Type));
         }
 
         public static Expression GreaterThanOrEqual(
             MemberExpression property,
             object value)
         {
-            return Expression.GreaterThanOrEqual(
-                property,
-                Expression.Constant(value));
+            return Expression.GreaterThanOrEqual(property, NullableSafeConstantExpression(value, property.Type));
         }
 
         public static Expression LowerThan(
             MemberExpression property,
             object value)
         {
-            return Expression.LessThan(
-                property,
-                Expression.Constant(value));
+            return Expression.LessThan(property, NullableSafeConstantExpression(value, property.Type));
         }
 
         public static Expression LowerThanOrEqual(
             MemberExpression property,
             object value)
         {
-            return Expression.LessThanOrEqual(
-                property,
-                Expression.Constant(value));
+            return Expression.LessThanOrEqual(property, NullableSafeConstantExpression(value, property.Type));
         }
 
         public static Expression StartsWith(
@@ -102,8 +101,7 @@ namespace HotChocolate.Types.Filters.Expressions
         {
             return Expression.AndAlso(
                 Expression.NotEqual(property, Expression.Constant(null)),
-                Expression.Call(property, _startsWith,
-                    new[] { Expression.Constant(value) }));
+                Expression.Call(property, _startsWith, Expression.Constant(value)));
         }
 
         public static Expression EndsWith(
@@ -112,8 +110,7 @@ namespace HotChocolate.Types.Filters.Expressions
         {
             return Expression.AndAlso(
                 Expression.NotEqual(property, Expression.Constant(null)),
-                Expression.Call(property, _endsWith,
-                    new[] { Expression.Constant(value) }));
+                Expression.Call(property, _endsWith, Expression.Constant(value)));
         }
         public static Expression Contains(
             MemberExpression property,
@@ -121,8 +118,7 @@ namespace HotChocolate.Types.Filters.Expressions
         {
             return Expression.AndAlso(
                 Expression.NotEqual(property, Expression.Constant(null)),
-                Expression.Call(property, _contains,
-                    new[] { Expression.Constant(value) }));
+                Expression.Call(property, _contains, Expression.Constant(value)));
         }
     }
 }

--- a/src/Core/Types.Filters/FilterFieldDescriptorBase.cs
+++ b/src/Core/Types.Filters/FilterFieldDescriptorBase.cs
@@ -164,8 +164,12 @@ namespace HotChocolate.Types.Filters
                 {
                     if (clrRef.Type.IsValueType)
                     {
-                        return clrRef.WithType(
-                            typeof(Nullable<>).MakeGenericType(clrRef.Type));
+                        if (Nullable.GetUnderlyingType(clrRef.Type) == null)
+                        {
+                            return clrRef.WithType(
+                                typeof(Nullable<>).MakeGenericType(clrRef.Type));
+                        }
+                        return clrRef;
                     }
                     else if (clrRef.Type.IsGenericType
                         && clrRef.Type.GetGenericTypeDefinition() ==


### PR DESCRIPTION
Update FilterFieldDescriptorBase.RewriteTypeToNullableType to return the type if it is already a `Nullable<>`, and insert type conversion expressions where necessary in FilterExpressionBuilder.

Fixes #1034.

I saw that the first half of this fix was made by @PascalSenn in #1105, but the FilterExpressionBuilder change is required as well, and additionally, that pr is targeted at master, while this issue is under the 10.2.0 milestone.