### PR TITLE
Add Arg helper type for supporting nullable feature

### DIFF
--- a/src/Core/Types.Tests/Utilities/ArgTests.cs
+++ b/src/Core/Types.Tests/Utilities/ArgTests.cs
@@ -1,0 +1,20 @@
+using System;
+using HotChocolate.Types;
+using Xunit;
+
+namespace HotChocolate.Utilities
+{
+    public class ArgTests
+    {
+        [Fact]
+        public void WhenCalled_ShouldThrow()
+        {
+            // arrange
+            Action action = () => Arg.Is<string>();
+
+            // act
+            // assert
+            Assert.Throws<NotSupportedException>(action);
+        }
+    }
+}

--- a/src/Core/Types/Utilities/Arg.cs
+++ b/src/Core/Types/Utilities/Arg.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace HotChocolate.Types
+{
+    public static class Arg
+    {
+        public static T Is<T>()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
This resolves #1128

### Example 1
```csharp
descriptor
    .Field<MyMutation>(s => s.AddAsync(Arg.Is<InputType>()));
```

### Example 2
```csharp
using static HotChocolate.Types.Arg;
...
descriptor
    .Field<MyMutation>(s => s.AddAsync(Is<InputType>()));
```