### PR TITLE
Fixes #1210. Create a new service scope when cloning RequestContext

### DIFF
--- a/src/Core/Core.Tests/Execution/ExecutionContextTests.cs
+++ b/src/Core/Core.Tests/Execution/ExecutionContextTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using HotChocolate.Execution.Instrumentation;
 using HotChocolate.Language;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -70,12 +71,11 @@ namespace HotChocolate.Execution
 
             var errorHandler = new Mock<IErrorHandler>();
 
-            var services = new Mock<IServiceProvider>();
-            services.Setup(t => t.GetService(typeof(IErrorHandler)))
-                .Returns(errorHandler.Object);
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IErrorHandler>(errorHandler.Object);
+            var services = serviceCollection.BuildServiceProvider();
 
-            IRequestServiceScope serviceScope = services.Object
-                .CreateRequestServiceScope();
+            IRequestServiceScope serviceScope = services.CreateRequestServiceScope();
 
             var variables = new Mock<IVariableValueCollection>();
 

--- a/src/Core/Core/Execution/RequestContext.cs
+++ b/src/Core/Core/Execution/RequestContext.cs
@@ -5,6 +5,7 @@ using HotChocolate.Execution.Instrumentation;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using HotChocolate.Types;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace HotChocolate.Execution
 {
@@ -49,8 +50,10 @@ namespace HotChocolate.Execution
 
         public IRequestContext Clone()
         {
+            IServiceScope serviceScope = ServiceScope.ServiceProvider.CreateScope();
+
             return new RequestContext(
-                ServiceScope,
+                new RequestServiceScope(serviceScope.ServiceProvider, serviceScope),
                 _factory,
                 CachedQuery,
                 new ConcurrentDictionary<string, object>(ContextData),


### PR DESCRIPTION
Create a new service scope when cloning RequestContext

Doing so ensures that any queries that use the cloned context get their
own scoped service instances instead of using the scoped service instances
of the original RequestContext.

This solves the issue of inadvertently having subscription event queries
use the service scope of the originating long-lived subscription request.

Addresses #1210
