### PR TITLE
fix(Sorting): fix global explicit binding

### DIFF
--- a/src/Core/Types.Sorting.Tests/SortInputTypeTests.cs
+++ b/src/Core/Types.Sorting.Tests/SortInputTypeTests.cs
@@ -7,6 +7,31 @@ namespace HotChocolate.Types.Sorting
     public class SortInputTypeTests
         : TypeTestBase
     {
+
+        [Fact]
+        public void Create_Global_Explicit_Sorting()
+        {
+            // arrange
+            // act
+            ISchemaBuilder builder = SchemaBuilder.New()
+               .AddQueryType(c =>
+                   c.Name("Query")
+                       .Field("foo")
+                       .Type<StringType>()
+                       .Resolver("bar"))
+               .AddType(new SortInputType<Foo>(
+                   d => d.BindFieldsExplicitly()
+                   .Sortable(f => f.Bar)
+                ))
+               .ModifyOptions(t => t.DefaultBindingBehavior = BindingBehavior.Explicit);
+
+            ISchema schema = builder.Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
+
         [Fact]
         public void Create_Implicit_Sorting_NoBindInvocation()
         {

--- a/src/Core/Types.Sorting.Tests/__snapshots__/SortInputTypeTests.Create_Global_Explicit_Sorting.snap
+++ b/src/Core/Types.Sorting.Tests/__snapshots__/SortInputTypeTests.Create_Global_Explicit_Sorting.snap
@@ -1,0 +1,19 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  foo: String
+}
+
+input FooSort {
+  bar: SortOperationKind
+}
+
+enum SortOperationKind {
+  ASC
+  DESC
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Sorting/SortOperationKindType.cs
+++ b/src/Core/Types.Sorting/SortOperationKindType.cs
@@ -3,5 +3,11 @@ namespace HotChocolate.Types.Sorting
     public class SortOperationKindType
         : EnumType<SortOperationKind>
     {
+        protected override void Configure(IEnumTypeDescriptor<SortOperationKind> descriptor)
+        {
+            base.Configure(descriptor);
+            descriptor.Value(SortOperationKind.Asc);
+            descriptor.Value(SortOperationKind.Desc);
+        }
     }
 }


### PR DESCRIPTION
Fixes sorting when `DefaultBindingBehavior` is set to  `BindingBehavior.Explicit`


Addresses #1242