### PR TITLE
Added format option to the UUID type.

### DIFF
--- a/src/Core/Types.Tests/Types/Scalars/UuidTypeTests.cs
+++ b/src/Core/Types.Tests/Types/Scalars/UuidTypeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using HotChocolate.Language;
+using Snapshooter.Xunit;
 using Xunit;
 
 namespace HotChocolate.Types
@@ -277,6 +278,91 @@ namespace HotChocolate.Types
 
             // assert
             Assert.Equal(TypeKind.Scalar, type.Kind);
+        }
+
+        [InlineData('N')]
+        [InlineData('D')]
+        [InlineData('B')]
+        [InlineData('P')]
+        [Theory]
+        public void Serialize_With_Format(char format)
+        {
+            // arrange
+            var uuidType = new UuidType(format: format);
+            Guid guid = Guid.Empty;
+
+            // act
+            string s = (string)uuidType.Serialize(guid);
+
+            // assert
+            Assert.Equal(guid.ToString(format.ToString()), s);
+        }
+
+        [InlineData('N')]
+        [InlineData('D')]
+        [InlineData('B')]
+        [InlineData('P')]
+        [Theory]
+        public void Deserialize_With_Format(char format)
+        {
+            // arrange
+            var uuidType = new UuidType(format: format);
+            Guid guid = Guid.Empty;
+            string serialized = guid.ToString(format.ToString());
+
+            // act
+            Guid deserialized = (Guid)uuidType.Deserialize(serialized);
+
+            // assert
+            Assert.Equal(guid, deserialized);
+        }
+
+        [InlineData('N')]
+        [InlineData('D')]
+        [InlineData('B')]
+        [InlineData('P')]
+        [Theory]
+        public void ParseValue_With_Format(char format)
+        {
+            // arrange
+            var uuidType = new UuidType(format: format);
+            Guid guid = Guid.Empty;
+
+            // act
+            var s = (StringValueNode)uuidType.ParseValue(guid);
+
+            // assert
+            Assert.Equal(guid.ToString(format.ToString()), s.Value);
+        }
+
+        [InlineData('N')]
+        [InlineData('D')]
+        [InlineData('B')]
+        [InlineData('P')]
+        [Theory]
+        public void ParseLiteral_With_Format(char format)
+        {
+            // arrange
+            var uuidType = new UuidType(format: format);
+            Guid guid = Guid.Empty;
+            var literal = new StringValueNode(guid.ToString(format.ToString()));
+
+            // act
+            Guid deserialized = (Guid)uuidType.ParseLiteral(literal);
+
+            // assert
+            Assert.Equal(guid, deserialized);
+        }
+
+        [Fact]
+        public void Specify_Invalid_Format()
+        {
+            // arrange
+            // act
+            Action action = () => new UuidType(format: 'z');
+
+            // assert
+            Assert.Throws<ArgumentException>(action).Message.MatchSnapshot();
         }
     }
 }

--- a/src/Core/Types.Tests/Types/Scalars/__snapshots__/UuidTypeTests.Specify_Invalid_Format.snap
+++ b/src/Core/Types.Tests/Types/Scalars/__snapshots__/UuidTypeTests.Specify_Invalid_Format.snap
@@ -1,0 +1,2 @@
+﻿Unknown format. Guid supports the following format chars: { `N`, `D`, `B`, `P` }.
+https://docs.microsoft.com/en-us/dotnet/api/system.buffers.text.utf8parser.tryparse?view=netcore-3.1#System_Buffers_Text_Utf8Parser_TryParse_System_ReadOnlySpan_System_Byte__System_Guid__System_Int32__System_Char_ (Parameter 'format')

--- a/src/Core/Types.Tests/Types/__snapshots__/InputObjectTypeNonNullTests.Nullable_Dictionary_Is_Correctly_Detected.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InputObjectTypeNonNullTests.Nullable_Dictionary_Is_Correctly_Detected.snap
@@ -1,0 +1,19 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  foo(input: FooInput!): String!
+}
+
+input FooInput {
+  contextData: [KeyValuePairOfStringAndStringInput!]
+}
+
+input KeyValuePairOfStringAndStringInput {
+  key: String!
+  value: String!
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_DeprecateField_With_Reason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_DeprecateField_With_Reason.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: Foo
+}
+
+type Foo {
+  description: String @deprecated(reason: "Foo")
+  name(a: String): String
+}
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_DeprecateField_Without_Reason.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_DeprecateField_Without_Reason.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: Foo
+}
+
+type Foo {
+  description: String @deprecated
+  name(a: String): String
+}
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types/Types/Scalars/UuidType.cs
+++ b/src/Core/Types/Types/Scalars/UuidType.cs
@@ -3,46 +3,49 @@ using System;
 using HotChocolate.Language;
 using HotChocolate.Properties;
 
+#nullable enable
+
 namespace HotChocolate.Types
 {
     public sealed class UuidType
         : ScalarType<Guid, StringValueNode>
     {
-        private const char _format = 'N';
+        private readonly string _format;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UuidType"/> class.
         /// </summary>
-        public UuidType()
-            : base(ScalarNames.Uuid)
+        public UuidType(char format = '\0')
+            : this(ScalarNames.Uuid, format)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UuidType"/> class.
         /// </summary>
-        public UuidType(NameString name)
-            : base(name)
+        public UuidType(NameString name, char format = '\0')
+            : this(name, null, format)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UuidType"/> class.
         /// </summary>
-        public UuidType(NameString name, string description)
+        public UuidType(NameString name, string? description, char format = '\0')
             : base(name)
         {
             Description = description;
+            _format = CreateFormatString(format);
         }
 
         protected override bool IsInstanceOfType(StringValueNode literal)
         {
-            return Utf8Parser.TryParse(literal.AsSpan(), out Guid _, out int _, _format);
+            return Utf8Parser.TryParse(literal.AsSpan(), out Guid _, out int _, _format[0]);
         }
 
         protected override Guid ParseLiteral(StringValueNode literal)
         {
-            if (Utf8Parser.TryParse(literal.AsSpan(), out Guid g, out int _, _format))
+            if (Utf8Parser.TryParse(literal.AsSpan(), out Guid g, out int _, _format[0]))
             {
                 return g;
             }
@@ -54,10 +57,10 @@ namespace HotChocolate.Types
 
         protected override StringValueNode ParseValue(Guid value)
         {
-            return new StringValueNode(value.ToString("N"));
+            return new StringValueNode(value.ToString(_format));
         }
 
-        public override bool TrySerialize(object value, out object serialized)
+        public override bool TrySerialize(object value, out object? serialized)
         {
             if (value is null)
             {
@@ -67,7 +70,7 @@ namespace HotChocolate.Types
 
             if (value is Guid uri)
             {
-                serialized = uri.ToString("N");
+                serialized = uri.ToString(_format);
                 return true;
             }
 
@@ -75,7 +78,7 @@ namespace HotChocolate.Types
             return false;
         }
 
-        public override bool TryDeserialize(object serialized, out object value)
+        public override bool TryDeserialize(object serialized, out object? value)
         {
             if (serialized is null)
             {
@@ -97,6 +100,28 @@ namespace HotChocolate.Types
 
             value = null;
             return false;
+        }
+
+        private static string CreateFormatString(char format)
+        {
+            if (format != '\0'
+                && format != 'N'
+                && format != 'D'
+                && format != 'B'
+                && format != 'P')
+            {
+                throw new ArgumentException(
+                    "Unknown format. Guid supports the following format chars: " +
+                    $"{{ `N`, `D`, `B`, `P` }}.{Environment.NewLine}" +
+                    "https://docs.microsoft.com/en-us/dotnet/api/" +
+                    "system.buffers.text.utf8parser.tryparse?" +
+                    "view=netcore-3.1#System_Buffers_Text_Utf8Parser_" +
+                    "TryParse_System_ReadOnlySpan_System_Byte__System_Guid__" +
+                    "System_Int32__System_Char_",
+                    nameof(format));
+            }
+
+            return format == '\0' ? "N" : format.ToString();
         }
     }
 }

--- a/src/Core/Types/Types/Scalars/UuidType.cs
+++ b/src/Core/Types/Types/Scalars/UuidType.cs
@@ -15,6 +15,14 @@ namespace HotChocolate.Types
         /// <summary>
         /// Initializes a new instance of the <see cref="UuidType"/> class.
         /// </summary>
+        public UuidType()
+            : this('\0')
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UuidType"/> class.
+        /// </summary>
         public UuidType(char format = '\0')
             : this(ScalarNames.Uuid, format)
         {


### PR DESCRIPTION
With this PR we added a format option to the UUID Type.

```csharp
SchemaBuilder.New()
    .AddType(new UuidType(format: 'D'))
    ...
    .Create();
```

The allowed formatting options can be looked up here:


char | format 
---------|----------
D | nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn
B | {nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn}
P | (nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn)
N (default) | nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn

