### PR TITLE
Refine Attribute Support

### DIFF
--- a/src/Core/Types.Filters/UseFilteringAttribute.cs
+++ b/src/Core/Types.Filters/UseFilteringAttribute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Types
 {
@@ -21,7 +22,10 @@ namespace HotChocolate.Types
         /// <value>The filter type</value>
         public Type FilterType { get; set; }
 
-        public override void OnConfigure(IObjectFieldDescriptor descriptor)
+        public override void OnConfigure(
+            IDescriptorContext context,
+            IObjectFieldDescriptor descriptor,
+            MemberInfo member)
         {
             if (FilterType is null)
             {

--- a/src/Core/Types.Sorting/UseSortingAttribute.cs
+++ b/src/Core/Types.Sorting/UseSortingAttribute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Types
 {
@@ -21,7 +22,10 @@ namespace HotChocolate.Types
         /// <value>The sort type</value>
         public Type SortType { get; set; }
 
-        public override void OnConfigure(IObjectFieldDescriptor descriptor)
+        public override void OnConfigure(
+            IDescriptorContext context,
+            IObjectFieldDescriptor descriptor,
+            MemberInfo member)
         {
             if (SortType is null)
             {

--- a/src/Core/Types.Tests/Types/EnumTypeDescriptorAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/EnumTypeDescriptorAttributeTests.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Linq;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
 using Xunit;
 
 namespace HotChocolate.Types
@@ -43,7 +46,10 @@ namespace HotChocolate.Types
         public class RenameValueAttribute
             : EnumValueDescriptorAttribute
         {
-            public override void OnConfigure(IEnumValueDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IEnumValueDescriptor descriptor,
+                FieldInfo field)
             {
                 descriptor.Name("ABC");
             }
@@ -60,7 +66,10 @@ namespace HotChocolate.Types
         public class RenameTypeAttribute
             : EnumTypeDescriptorAttribute
         {
-            public override void OnConfigure(IEnumTypeDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IEnumTypeDescriptor descriptor,
+                Type type)
             {
                 descriptor.Name("Abc");
             }

--- a/src/Core/Types.Tests/Types/EnumTypeDescriptorAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/EnumTypeDescriptorAttributeTests.cs
@@ -35,6 +35,19 @@ namespace HotChocolate.Types
             Assert.NotNull(schema.GetType<EnumType>("Abc"));
         }
 
+        [Fact]
+        public void Annotated_Enum3_With_EnumTypeAttribute()
+        {
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddEnumType<Enum3>()
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create();
+
+            // assert
+            Assert.NotNull(schema.GetType<EnumType>("Foo"));
+        }
+
         public enum Enum1
         {
 
@@ -57,6 +70,14 @@ namespace HotChocolate.Types
 
         [RenameType]
         public enum Enum2
+        {
+
+            Value1,
+            Value2
+        }
+
+        [EnumType(Name = "Foo")]
+        public enum Enum3
         {
 
             Value1,

--- a/src/Core/Types.Tests/Types/InputObjectTypeAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/InputObjectTypeAttributeTests.cs
@@ -39,6 +39,22 @@ namespace HotChocolate.Types
                     .ContainsField("foo"));
         }
 
+        [Fact]
+        public void Annotated_Struct1_With_InputObjectTypeAttribute()
+        {
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddInputObjectType<Struct1>()
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create();
+
+            // assert
+            Assert.True(
+                schema.GetType<InputObjectType>("Foo")
+                    .Fields
+                    .ContainsField("foo"));
+        }
+
         public class Object1
         {
             [RenameField]
@@ -59,6 +75,12 @@ namespace HotChocolate.Types
 
         [RenameType]
         public class Object2
+        {
+            public string Foo { get; set; }
+        }
+
+        [InputObjectType(Name = "Foo")]
+        public struct Struct1
         {
             public string Foo { get; set; }
         }

--- a/src/Core/Types.Tests/Types/InputObjectTypeAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/InputObjectTypeAttributeTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
 using Xunit;
 
 namespace HotChocolate.Types
@@ -45,7 +48,10 @@ namespace HotChocolate.Types
         public class RenameFieldAttribute
             : InputFieldDescriptorAttribute
         {
-            public override void OnConfigure(IInputFieldDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IInputFieldDescriptor descriptor,
+                MemberInfo member)
             {
                 descriptor.Name("bar");
             }
@@ -60,7 +66,10 @@ namespace HotChocolate.Types
         public class RenameTypeAttribute
             : InputObjectTypeDescriptorAttribute
         {
-            public override void OnConfigure(IInputObjectTypeDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IInputObjectTypeDescriptor descriptor,
+                Type type)
             {
                 descriptor.Name("Bar");
             }

--- a/src/Core/Types.Tests/Types/InterfaceTypeAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/InterfaceTypeAttributeTests.cs
@@ -79,6 +79,21 @@ namespace HotChocolate.Types
                     .Fields.ContainsField("abc"));
         }
 
+        [Fact]
+        public void Annotated_Class_With_InterfaceTypeAttribute()
+        {
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddInterfaceType<Object1>()
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create();
+
+            // assert
+            Assert.True(
+                schema.GetType<InterfaceType>("Foo")
+                    .Fields.ContainsField("bar"));
+        }
+
         public interface Interface1
         {
             string GetField([ArgumentDefaultValue("abc")]string argument);
@@ -138,6 +153,12 @@ namespace HotChocolate.Types
             {
                 descriptor.Field("abc").Type<StringType>();
             }
+        }
+
+        [InterfaceType(Name = "Foo")]
+        public class Object1
+        {
+            public string? Bar { get; set; }
         }
     }
 }

--- a/src/Core/Types.Tests/Types/InterfaceTypeAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/InterfaceTypeAttributeTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
 using Xunit;
 
 #nullable enable
@@ -92,7 +94,10 @@ namespace HotChocolate.Types
 
             public object DefaultValue { get; }
 
-            public override void OnConfigure(IArgumentDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IArgumentDescriptor descriptor,
+                ParameterInfo parameter)
             {
                 descriptor.DefaultValue(DefaultValue);
             }
@@ -107,7 +112,10 @@ namespace HotChocolate.Types
         public class PropertyAddContextDataAttribute
             : InterfaceFieldDescriptorAttribute
         {
-            public override void OnConfigure(IInterfaceFieldDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IInterfaceFieldDescriptor descriptor,
+                MemberInfo member)
             {
                 descriptor.Extend().OnBeforeCompletion(
                     (c, d) => d.ContextData.Add("abc", "def"));
@@ -123,7 +131,10 @@ namespace HotChocolate.Types
         public class InterfaceAddFieldAttribute
             : InterfaceTypeDescriptorAttribute
         {
-            public override void OnConfigure(IInterfaceTypeDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IInterfaceTypeDescriptor descriptor,
+                Type type)
             {
                 descriptor.Field("abc").Type<StringType>();
             }

--- a/src/Core/Types.Tests/Types/ObjectTypeAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/ObjectTypeAttributeTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
 using Xunit;
 
 #nullable enable
@@ -94,7 +96,10 @@ namespace HotChocolate.Types
 
             public object DefaultValue { get; }
 
-            public override void OnConfigure(IArgumentDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IArgumentDescriptor descriptor,
+                ParameterInfo parameterInfo)
             {
                 descriptor.DefaultValue(DefaultValue);
             }
@@ -112,7 +117,10 @@ namespace HotChocolate.Types
         public class PropertyAddContextDataAttribute
             : ObjectFieldDescriptorAttribute
         {
-            public override void OnConfigure(IObjectFieldDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IObjectFieldDescriptor descriptor,
+                MemberInfo member)
             {
                 descriptor.Extend().OnBeforeCompletion(
                     (c, d) => d.ContextData.Add("abc", "def"));
@@ -131,7 +139,10 @@ namespace HotChocolate.Types
         public class ObjectAddFieldAttribute
             : ObjectTypeDescriptorAttribute
         {
-            public override void OnConfigure(IObjectTypeDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IObjectTypeDescriptor descriptor,
+                Type type)
             {
                 descriptor.Field("abc").Resolver<string>("def");
             }

--- a/src/Core/Types.Tests/Types/ObjectTypeAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/ObjectTypeAttributeTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using HotChocolate.Types.Descriptors;
+using Snapshooter.Xunit;
 using Xunit;
 
 #nullable enable
@@ -78,6 +79,33 @@ namespace HotChocolate.Types
             Assert.True(schema.GetType<ObjectType>("Object3").Fields.ContainsField("abc"));
         }
 
+        [Fact]
+        public void ObjectTypeAttribute_Mark_Struct_As_ObjectType()
+        {
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddType<StructQuery>()
+                .ModifyOptions(o => o.RemoveUnreachableTypes = true)
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
+        [Fact]
+        public void ExtendObjectTypeAttribute_Extend_Query_Type()
+        {
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddType<StructQuery>()
+                .AddType<StructQueryExtension>()
+                .ModifyOptions(o => o.RemoveUnreachableTypes = true)
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public class Object1
         {
             public string GetField([ArgumentDefaultValue("abc")]string argument)
@@ -146,6 +174,18 @@ namespace HotChocolate.Types
             {
                 descriptor.Field("abc").Resolver<string>("def");
             }
+        }
+
+        [ObjectType(Name = "Query")]
+        public struct StructQuery
+        {
+            public string? Foo { get; }
+        }
+
+        [ExtendObjectType(Name = "Query")]
+        public class StructQueryExtension
+        {
+            public string? Bar { get; }
         }
     }
 }

--- a/src/Core/Types.Tests/Types/Relay/UsePagingAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/Relay/UsePagingAttributeTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace HotChocolate.Types.Relay
+{
+    public class UsePagingAttributeTests
+    {
+        [Fact]
+        public void UsePagingAttribute_Infer_Types()
+        {
+            SchemaBuilder.New()
+                .AddQueryType<Query>()
+                .Create()
+                .ToString()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void UsePagingAttribute_Infer_Types_On_Interface()
+        {
+            SchemaBuilder.New()
+                .AddType<IHasFoos>()
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create()
+                .ToString()
+                .MatchSnapshot();
+        }
+
+        public class Query
+        {
+            [UsePaging]
+            public IQueryable<Foo> Foos { get; set; }
+        }
+
+        public class Foo
+        {
+            public string Bar { get; set; }
+        }
+
+        public class IHasFoos
+        {
+            [UsePaging]
+            IQueryable<Foo> Foos { get; }
+        }
+    }
+}

--- a/src/Core/Types.Tests/Types/Relay/UsePagingAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/Relay/UsePagingAttributeTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
+using HotChocolate.Execution;
 using Snapshooter.Xunit;
 using Xunit;
 
@@ -17,6 +19,17 @@ namespace HotChocolate.Types.Relay
         }
 
         [Fact]
+        public void UsePagingAttribute_Execute_Query()
+        {
+            SchemaBuilder.New()
+                .AddQueryType<Query>()
+                .Create()
+                .MakeExecutable()
+                .Execute("{ foos(first: 1) { nodes { bar } } }")
+                .MatchSnapshot();
+        }
+
+        [Fact]
         public void UsePagingAttribute_Infer_Types_On_Interface()
         {
             SchemaBuilder.New()
@@ -30,7 +43,11 @@ namespace HotChocolate.Types.Relay
         public class Query
         {
             [UsePaging]
-            public IQueryable<Foo> Foos { get; set; }
+            public IQueryable<Foo> Foos { get; set; } = new List<Foo>
+            {
+                new Foo { Bar = "first" },
+                new Foo { Bar = "second" },
+            }.AsQueryable();
         }
 
         public class Foo

--- a/src/Core/Types.Tests/Types/Relay/UsePagingAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/Relay/UsePagingAttributeTests.cs
@@ -55,7 +55,7 @@ namespace HotChocolate.Types.Relay
             public string Bar { get; set; }
         }
 
-        public class IHasFoos
+        public interface IHasFoos
         {
             [UsePaging]
             IQueryable<Foo> Foos { get; }

--- a/src/Core/Types.Tests/Types/Relay/__snapshots__/UsePagingAttributeTests.UsePagingAttribute_Execute_Query.snap
+++ b/src/Core/Types.Tests/Types/Relay/__snapshots__/UsePagingAttributeTests.UsePagingAttribute_Execute_Query.snap
@@ -1,0 +1,14 @@
+﻿{
+  "Data": {
+    "foos": {
+      "nodes": [
+        {
+          "bar": "first"
+        }
+      ]
+    }
+  },
+  "Extensions": {},
+  "Errors": [],
+  "ContextData": {}
+}

--- a/src/Core/Types.Tests/Types/Relay/__snapshots__/UsePagingAttributeTests.UsePagingAttribute_Infer_Types.snap
+++ b/src/Core/Types.Tests/Types/Relay/__snapshots__/UsePagingAttributeTests.UsePagingAttribute_Infer_Types.snap
@@ -1,0 +1,53 @@
+﻿schema {
+  query: Query
+}
+
+type Foo {
+  bar: String
+}
+
+"A connection to a list of items."
+type FooConnection {
+  "A list of edges."
+  edges: [FooEdge!]
+  "A flattened list of the nodes."
+  nodes: [Foo]
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+"An edge in a connection."
+type FooEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: Foo
+}
+
+"Information about pagination in a connection."
+type PageInfo {
+  "When paginating forwards, the cursor to continue."
+  endCursor: String
+  "Indicates whether more edges exist following the set defined by the clients arguments."
+  hasNextPage: Boolean!
+  "Indicates whether more edges exist prior the set defined by the clients arguments."
+  hasPreviousPage: Boolean!
+  "When paginating backwards, the cursor to continue."
+  startCursor: String
+}
+
+type Query {
+  foos(after: String before: String first: PaginationAmount last: PaginationAmount): FooConnection
+}
+
+"The `Boolean` scalar type represents `true` or `false`."
+scalar Boolean
+
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+scalar PaginationAmount
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/Relay/__snapshots__/UsePagingAttributeTests.UsePagingAttribute_Infer_Types_On_Interface.snap
+++ b/src/Core/Types.Tests/Types/Relay/__snapshots__/UsePagingAttributeTests.UsePagingAttribute_Infer_Types_On_Interface.snap
@@ -1,3 +1,49 @@
-﻿type IHasFoos {
-
+﻿interface IHasFoos {
+  foos(after: String before: String first: PaginationAmount last: PaginationAmount): FooConnection
 }
+
+type Foo {
+  bar: String
+}
+
+"A connection to a list of items."
+type FooConnection {
+  "A list of edges."
+  edges: [FooEdge!]
+  "A flattened list of the nodes."
+  nodes: [Foo]
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+"An edge in a connection."
+type FooEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: Foo
+}
+
+"Information about pagination in a connection."
+type PageInfo {
+  "When paginating forwards, the cursor to continue."
+  endCursor: String
+  "Indicates whether more edges exist following the set defined by the clients arguments."
+  hasNextPage: Boolean!
+  "Indicates whether more edges exist prior the set defined by the clients arguments."
+  hasPreviousPage: Boolean!
+  "When paginating backwards, the cursor to continue."
+  startCursor: String
+}
+
+"The `Boolean` scalar type represents `true` or `false`."
+scalar Boolean
+
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+scalar PaginationAmount
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/Relay/__snapshots__/UsePagingAttributeTests.UsePagingAttribute_Infer_Types_On_Interface.snap
+++ b/src/Core/Types.Tests/Types/Relay/__snapshots__/UsePagingAttributeTests.UsePagingAttribute_Infer_Types_On_Interface.snap
@@ -1,0 +1,3 @@
+﻿type IHasFoos {
+
+}

--- a/src/Core/Types.Tests/Types/UnionTypeAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/UnionTypeAttributeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using HotChocolate.Types.Descriptors;
+using Snapshooter.Xunit;
 using Xunit;
 
 #nullable enable
@@ -22,6 +23,20 @@ namespace HotChocolate.Types
             Assert.NotNull(schema.GetType<UnionType>("Abc"));
         }
 
+        [Fact]
+        public void UnionTypeAttribute_Infer_Union()
+        {
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddType<IUnion2>()
+                .AddType<Union2Type1>()
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         [SetName]
         public interface IUnion1 { }
 
@@ -37,5 +52,11 @@ namespace HotChocolate.Types
                 descriptor.Name("Abc");
             }
         }
+
+        [UnionType(Name = "Union")]
+        public interface IUnion2 { }
+
+        [ObjectType(Name = "Type")]
+        public class Union2Type1 : IUnion2 { }
     }
 }

--- a/src/Core/Types.Tests/Types/UnionTypeAttributeTests.cs
+++ b/src/Core/Types.Tests/Types/UnionTypeAttributeTests.cs
@@ -1,3 +1,5 @@
+using System;
+using HotChocolate.Types.Descriptors;
 using Xunit;
 
 #nullable enable
@@ -27,7 +29,10 @@ namespace HotChocolate.Types
 
         public class SetNameAttribute : UnionTypeDescriptorAttribute
         {
-            public override void OnConfigure(IUnionTypeDescriptor descriptor)
+            public override void OnConfigure(
+                IDescriptorContext context,
+                IUnionTypeDescriptor descriptor,
+                Type type)
             {
                 descriptor.Name("Abc");
             }

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeAttributeTests.ExtendObjectTypeAttribute_Extend_Query_Type.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeAttributeTests.ExtendObjectTypeAttribute_Extend_Query_Type.snap
@@ -1,0 +1,11 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  bar: String
+  foo: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeAttributeTests.ObjectTypeAttribute_Mark_Struct_As_ObjectType.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeAttributeTests.ObjectTypeAttribute_Mark_Struct_As_ObjectType.snap
@@ -1,0 +1,10 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  foo: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/UnionTypeAttributeTests.UnionTypeAttribute_Infer_Union.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/UnionTypeAttributeTests.UnionTypeAttribute_Infer_Union.snap
@@ -1,0 +1,5 @@
+﻿type Type {
+
+}
+
+union Union = Type

--- a/src/Core/Types/Configuration/SchemaTypeResolver.cs
+++ b/src/Core/Types/Configuration/SchemaTypeResolver.cs
@@ -31,12 +31,6 @@ namespace HotChocolate.Configuration
                     .MakeGenericType(unresolvedType.Type),
                     TypeContext.Output);
             }
-            else if (IsObjectTypeExtension(unresolvedType))
-            {
-                schemaType = new ClrTypeReference(typeof(ObjectTypeExtension<>)
-                    .MakeGenericType(unresolvedType.Type),
-                    TypeContext.Output);
-            }
             else if (IsObjectType(unresolvedType))
             {
                 schemaType = new ClrTypeReference(typeof(ObjectType<>)

--- a/src/Core/Types/Configuration/SchemaTypeResolver.cs
+++ b/src/Core/Types/Configuration/SchemaTypeResolver.cs
@@ -13,9 +13,27 @@ namespace HotChocolate.Configuration
             IClrTypeReference unresolvedType,
             out IClrTypeReference schemaType)
         {
-            if (IsInterfaceType(unresolvedType))
+            if (IsObjectTypeExtension(unresolvedType))
+            {
+                schemaType = new ClrTypeReference(typeof(ObjectTypeExtension<>)
+                    .MakeGenericType(unresolvedType.Type),
+                    TypeContext.Output);
+            }
+            else if (IsUnionType(unresolvedType))
+            {
+                schemaType = new ClrTypeReference(typeof(UnionType<>)
+                    .MakeGenericType(unresolvedType.Type),
+                    TypeContext.Output);
+            }
+            else if (IsInterfaceType(unresolvedType))
             {
                 schemaType = new ClrTypeReference(typeof(InterfaceType<>)
+                    .MakeGenericType(unresolvedType.Type),
+                    TypeContext.Output);
+            }
+            else if (IsObjectTypeExtension(unresolvedType))
+            {
+                schemaType = new ClrTypeReference(typeof(ObjectTypeExtension<>)
                     .MakeGenericType(unresolvedType.Type),
                     TypeContext.Output);
             }
@@ -47,31 +65,50 @@ namespace HotChocolate.Configuration
 
         private static bool IsObjectType(IClrTypeReference unresolvedType)
         {
-            return IsComplexType(unresolvedType)
+            return (IsComplexType(unresolvedType)
+                || unresolvedType.Type.IsDefined(typeof(ObjectTypeAttribute), true))
+                && (unresolvedType.Context == TypeContext.Output
+                    || unresolvedType.Context == TypeContext.None);
+        }
+
+        private static bool IsObjectTypeExtension(IClrTypeReference unresolvedType) =>
+            unresolvedType.Type.IsDefined(typeof(ExtendObjectTypeAttribute), true);
+
+        private static bool IsUnionType(IClrTypeReference unresolvedType)
+        {
+            return unresolvedType.Type.IsDefined(typeof(UnionTypeAttribute), true)
                 && (unresolvedType.Context == TypeContext.Output
                     || unresolvedType.Context == TypeContext.None);
         }
 
         private static bool IsInterfaceType(IClrTypeReference unresolvedType)
         {
-            return unresolvedType.Type.IsInterface
+            return (unresolvedType.Type.IsInterface
+                || unresolvedType.Type.IsDefined(typeof(InterfaceTypeAttribute), true))
                 && (unresolvedType.Context == TypeContext.Output
                     || unresolvedType.Context == TypeContext.None);
         }
 
         private static bool IsInputObjectType(IClrTypeReference unresolvedType)
         {
-            return IsComplexType(unresolvedType)
+            return (IsComplexType(unresolvedType)
+                || unresolvedType.Type.IsDefined(typeof(InputObjectTypeAttribute), true))
                 && !unresolvedType.Type.IsAbstract
                 && unresolvedType.Context == TypeContext.Input;
+        }
+
+        private static bool IsEnumType(IClrTypeReference unresolvedType)
+        {
+            return (unresolvedType.Type.IsEnum
+                || unresolvedType.Type.IsDefined(typeof(EnumTypeAttribute), true))
+                && IsPublic(unresolvedType);
         }
 
         private static bool IsComplexType(IClrTypeReference unresolvedType)
         {
             bool isComplexType =
-                (unresolvedType.Type.IsClass
-                    && (unresolvedType.Type.IsPublic
-                        || unresolvedType.Type.IsNestedPublic))
+                unresolvedType.Type.IsClass
+                    && IsPublic(unresolvedType)
                     && unresolvedType.Type != typeof(string);
 
             if (!isComplexType && unresolvedType.Type.IsGenericType)
@@ -83,11 +120,10 @@ namespace HotChocolate.Configuration
             return isComplexType;
         }
 
-        private static bool IsEnumType(IClrTypeReference unresolvedType)
+        private static bool IsPublic(IClrTypeReference unresolvedType)
         {
-            return (unresolvedType.Type.IsEnum
-                    && (unresolvedType.Type.IsPublic
-                        || unresolvedType.Type.IsNestedPublic));
+            return unresolvedType.Type.IsPublic
+                || unresolvedType.Type.IsNestedPublic;
         }
     }
 }

--- a/src/Core/Types/Types/Attributes/ArgumentDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/ArgumentDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class ArgumentDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IArgumentDescriptor d)
+            if (descriptor is IArgumentDescriptor d
+                && element is ParameterInfo p)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, p);
             }
         }
 
-        public abstract void OnConfigure(IArgumentDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IArgumentDescriptor descriptor,
+            ParameterInfo parameter);
     }
 }

--- a/src/Core/Types/Types/Attributes/DescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/DescriptorAttribute.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
     public abstract class DescriptorAttribute
         : Attribute
     {
-        internal protected abstract void TryConfigure(IDescriptor descriptor);
+        internal protected abstract void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element);
     }
 }

--- a/src/Core/Types/Types/Attributes/EnumTypeAttribute.cs
+++ b/src/Core/Types/Types/Attributes/EnumTypeAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
+
+namespace HotChocolate.Types
+{
+    [AttributeUsage(
+        AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Struct,
+        Inherited = true,
+        AllowMultiple = false)]
+    public sealed class EnumTypeAttribute
+        : EnumTypeDescriptorAttribute
+    {
+        public string? Name { get; set; }
+
+        public override void OnConfigure(
+            IDescriptorContext context,
+            IEnumTypeDescriptor descriptor,
+            Type type)
+        {
+            if (!string.IsNullOrEmpty(Name))
+            {
+                descriptor.Name(Name);
+            }
+        }
+    }
+
+}

--- a/src/Core/Types/Types/Attributes/EnumTypeDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/EnumTypeDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class EnumTypeDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IEnumTypeDescriptor d)
+            if (descriptor is IEnumTypeDescriptor d
+                && element is Type t)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, t);
             }
         }
 
-        public abstract void OnConfigure(IEnumTypeDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IEnumTypeDescriptor descriptor,
+            Type type);
     }
 }

--- a/src/Core/Types/Types/Attributes/EnumValueDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/EnumValueDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class EnumValueDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IEnumValueDescriptor d)
+            if (descriptor is IEnumValueDescriptor d
+                && element is FieldInfo f)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, f);
             }
         }
 
-        public abstract void OnConfigure(IEnumValueDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IEnumValueDescriptor descriptor,
+            FieldInfo field);
     }
 }

--- a/src/Core/Types/Types/Attributes/ExtendObjectTypeAttribute.cs
+++ b/src/Core/Types/Types/Attributes/ExtendObjectTypeAttribute.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+using System;
+
+namespace HotChocolate.Types
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Struct,
+        Inherited = true,
+        AllowMultiple = false)]
+    public sealed class ExtendObjectTypeAttribute : Attribute
+    {
+        public ExtendObjectTypeAttribute(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/src/Core/Types/Types/Attributes/ExtendObjectTypeAttribute.cs
+++ b/src/Core/Types/Types/Attributes/ExtendObjectTypeAttribute.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Types
 {
@@ -8,13 +9,20 @@ namespace HotChocolate.Types
         AttributeTargets.Class | AttributeTargets.Struct,
         Inherited = true,
         AllowMultiple = false)]
-    public sealed class ExtendObjectTypeAttribute : Attribute
+    public sealed class ExtendObjectTypeAttribute
+        : ObjectTypeDescriptorAttribute
     {
-        public ExtendObjectTypeAttribute(string name)
-        {
-            Name = name;
-        }
+        public string? Name { get; set; }
 
-        public string Name { get; }
+        public override void OnConfigure(
+            IDescriptorContext context,
+            IObjectTypeDescriptor descriptor,
+            Type type)
+        {
+            if (!string.IsNullOrEmpty(Name))
+            {
+                descriptor.Name(Name);
+            }
+        }
     }
 }

--- a/src/Core/Types/Types/Attributes/InputFieldDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/InputFieldDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class InputFieldDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IInputFieldDescriptor d)
+            if (descriptor is IInputFieldDescriptor d
+                && element is MemberInfo m)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, m);
             }
         }
 
-        public abstract void OnConfigure(IInputFieldDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IInputFieldDescriptor descriptor,
+            MemberInfo member);
     }
 }

--- a/src/Core/Types/Types/Attributes/InputObjectTypeAttribute.cs
+++ b/src/Core/Types/Types/Attributes/InputObjectTypeAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
+
+namespace HotChocolate.Types
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Struct,
+        Inherited = true,
+        AllowMultiple = false)]
+    public sealed class InputObjectTypeAttribute
+        : InputObjectTypeDescriptorAttribute
+    {
+        public string? Name { get; set; }
+
+        public override void OnConfigure(
+            IDescriptorContext context,
+            IInputObjectTypeDescriptor descriptor,
+            Type type)
+        {
+            if (!string.IsNullOrEmpty(Name))
+            {
+                descriptor.Name(Name);
+            }
+        }
+    }
+
+}

--- a/src/Core/Types/Types/Attributes/InputObjectTypeDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/InputObjectTypeDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class InputObjectTypeDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IInputObjectTypeDescriptor d)
+            if (descriptor is IInputObjectTypeDescriptor d
+                && element is Type t)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, t);
             }
         }
 
-        public abstract void OnConfigure(IInputObjectTypeDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IInputObjectTypeDescriptor descriptor,
+            Type type);
     }
 }

--- a/src/Core/Types/Types/Attributes/InterfaceFieldDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/InterfaceFieldDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class InterfaceFieldDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IInterfaceFieldDescriptor d)
+            if (descriptor is IInterfaceFieldDescriptor d
+                && element is MemberInfo m)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, m);
             }
         }
 
-        public abstract void OnConfigure(IInterfaceFieldDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IInterfaceFieldDescriptor descriptor,
+            MemberInfo member);
     }
 }

--- a/src/Core/Types/Types/Attributes/InterfaceTypeAttribute.cs
+++ b/src/Core/Types/Types/Attributes/InterfaceTypeAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
+
+namespace HotChocolate.Types
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Interface,
+        Inherited = true,
+        AllowMultiple = false)]
+    public sealed class InterfaceTypeAttribute
+        : InterfaceTypeDescriptorAttribute
+    {
+        public string? Name { get; set; }
+
+        public override void OnConfigure(
+            IDescriptorContext context,
+            IInterfaceTypeDescriptor descriptor,
+            Type type)
+        {
+            if (!string.IsNullOrEmpty(Name))
+            {
+                descriptor.Name(Name);
+            }
+        }
+    }
+
+}

--- a/src/Core/Types/Types/Attributes/InterfaceTypeDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/InterfaceTypeDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class InterfaceTypeDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IInterfaceTypeDescriptor d)
+            if (descriptor is IInterfaceTypeDescriptor d
+                && element is Type t)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, t);
             }
         }
 
-        public abstract void OnConfigure(IInterfaceTypeDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IInterfaceTypeDescriptor descriptor,
+            Type type);
     }
 }

--- a/src/Core/Types/Types/Attributes/ObjectFieldDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/ObjectFieldDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class ObjectFieldDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IObjectFieldDescriptor d)
+            if (descriptor is IObjectFieldDescriptor d
+                && element is MemberInfo m)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, m);
             }
         }
 
-        public abstract void OnConfigure(IObjectFieldDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IObjectFieldDescriptor descriptor,
+            MemberInfo member);
     }
 }

--- a/src/Core/Types/Types/Attributes/ObjectTypeAttribute.cs
+++ b/src/Core/Types/Types/Attributes/ObjectTypeAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
+
+namespace HotChocolate.Types
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface,
+        Inherited = true,
+        AllowMultiple = false)]
+    public sealed class ObjectTypeAttribute
+        : ObjectTypeDescriptorAttribute
+    {
+        public string? Name { get; set; }
+
+        public override void OnConfigure(
+            IDescriptorContext context,
+            IObjectTypeDescriptor descriptor,
+            Type type)
+        {
+            if (!string.IsNullOrEmpty(Name))
+            {
+                descriptor.Name(Name);
+            }
+        }
+    }
+
+}

--- a/src/Core/Types/Types/Attributes/ObjectTypeDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/ObjectTypeDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class ObjectTypeDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IObjectTypeDescriptor d)
+            if (descriptor is IObjectTypeDescriptor d
+                && element is Type t)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, t);
             }
         }
 
-        public abstract void OnConfigure(IObjectTypeDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IObjectTypeDescriptor descriptor,
+            Type type);
     }
 }

--- a/src/Core/Types/Types/Attributes/UnionTypeAttribute.cs
+++ b/src/Core/Types/Types/Attributes/UnionTypeAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
+
+namespace HotChocolate.Types
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Interface,
+        Inherited = true,
+        AllowMultiple = false)]
+    public class UnionTypeAttribute
+        : UnionTypeDescriptorAttribute
+    {
+        public string? Name { get; set; }
+
+        public override void OnConfigure(
+            IDescriptorContext context,
+            IUnionTypeDescriptor descriptor,
+            Type type)
+        {
+            if (!string.IsNullOrEmpty(Name))
+            {
+                descriptor.Name(Name);
+            }
+        }
+    }
+
+}

--- a/src/Core/Types/Types/Attributes/UnionTypeAttribute.cs
+++ b/src/Core/Types/Types/Attributes/UnionTypeAttribute.cs
@@ -9,7 +9,7 @@ namespace HotChocolate.Types
         AttributeTargets.Class | AttributeTargets.Interface,
         Inherited = true,
         AllowMultiple = false)]
-    public class UnionTypeAttribute
+    public sealed class UnionTypeAttribute
         : UnionTypeDescriptorAttribute
     {
         public string? Name { get; set; }

--- a/src/Core/Types/Types/Attributes/UnionTypeDescriptorAttribute.cs
+++ b/src/Core/Types/Types/Attributes/UnionTypeDescriptorAttribute.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+#nullable enable
 
 namespace HotChocolate.Types
 {
@@ -9,14 +13,21 @@ namespace HotChocolate.Types
     public abstract class UnionTypeDescriptorAttribute
         : DescriptorAttribute
     {
-        internal protected sealed override void TryConfigure(IDescriptor descriptor)
+        internal protected sealed override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
-            if (descriptor is IUnionTypeDescriptor d)
+            if (descriptor is IUnionTypeDescriptor d
+                && element is Type t)
             {
-                OnConfigure(d);
+                OnConfigure(context, d, t);
             }
         }
 
-        public abstract void OnConfigure(IUnionTypeDescriptor descriptor);
+        public abstract void OnConfigure(
+            IDescriptorContext context,
+            IUnionTypeDescriptor descriptor,
+            Type type);
     }
 }

--- a/src/Core/Types/Types/Descriptors/ArgumentDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ArgumentDescriptor.cs
@@ -53,7 +53,10 @@ namespace HotChocolate.Types.Descriptors
 
             if (Definition.Parameter is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.Parameter);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.Parameter);
             }
         }
 

--- a/src/Core/Types/Types/Descriptors/ArgumentDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ArgumentDescriptor.cs
@@ -49,8 +49,6 @@ namespace HotChocolate.Types.Descriptors
 
         protected override void OnCreateDefinition(ArgumentDefinition definition)
         {
-            base.OnCreateDefinition(definition);
-
             if (Definition.Parameter is { })
             {
                 Context.Inspector.ApplyAttributes(
@@ -58,6 +56,8 @@ namespace HotChocolate.Types.Descriptors
                     this,
                     Definition.Parameter);
             }
+
+            base.OnCreateDefinition(definition);
         }
 
         public new IArgumentDescriptor SyntaxNode(

--- a/src/Core/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
@@ -253,13 +253,14 @@ namespace HotChocolate.Types.Descriptors
         public bool IsSchemaType(Type type) => BaseTypes.IsSchemaType(type);
 
         public void ApplyAttributes(
+            IDescriptorContext context,
             IDescriptor descriptor,
             ICustomAttributeProvider attributeProvider)
         {
             foreach (var attribute in attributeProvider.GetCustomAttributes(true)
                 .OfType<DescriptorAttribute>())
             {
-                attribute.TryConfigure(descriptor);
+                attribute.TryConfigure(context, descriptor, attributeProvider);
             }
         }
     }

--- a/src/Core/Types/Types/Descriptors/Conventions/ITypeInspector.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/ITypeInspector.cs
@@ -44,6 +44,7 @@ namespace HotChocolate.Types.Descriptors
         bool IsSchemaType(Type type);
 
         void ApplyAttributes(
+            IDescriptorContext context,
             IDescriptor descriptor,
             ICustomAttributeProvider attributeProvider);
     }

--- a/src/Core/Types/Types/Descriptors/DirectiveArgumentDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveArgumentDescriptor.cs
@@ -33,8 +33,6 @@ namespace HotChocolate.Types.Descriptors
 
         protected override void OnCreateDefinition(DirectiveArgumentDefinition definition)
         {
-            base.OnCreateDefinition(definition);
-
             if (Definition.Property is { })
             {
                 Context.Inspector.ApplyAttributes(
@@ -42,6 +40,8 @@ namespace HotChocolate.Types.Descriptors
                     this,
                     Definition.Property);
             }
+
+            base.OnCreateDefinition(definition);
         }
 
         public new IDirectiveArgumentDescriptor SyntaxNode(

--- a/src/Core/Types/Types/Descriptors/DirectiveArgumentDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveArgumentDescriptor.cs
@@ -37,7 +37,10 @@ namespace HotChocolate.Types.Descriptors
 
             if (Definition.Property is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.Property);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.Property);
             }
         }
 

--- a/src/Core/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
@@ -67,6 +67,8 @@ namespace HotChocolate.Types.Descriptors
             OnCompleteArguments(arguments, handledMembers);
 
             definition.Arguments.AddRange(arguments.Values);
+
+            base.OnCreateDefinition(definition);
         }
 
         protected virtual void OnCompleteArguments(

--- a/src/Core/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
@@ -48,7 +48,10 @@ namespace HotChocolate.Types.Descriptors
         {
             if (Definition.ClrType is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.ClrType);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.ClrType);
             }
 
             var arguments =

--- a/src/Core/Types/Types/Descriptors/EnumTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/EnumTypeDescriptor.cs
@@ -52,6 +52,8 @@ namespace HotChocolate.Types.Descriptors
             {
                 definition.Values.Add(value);
             }
+
+            base.OnCreateDefinition(definition);
         }
 
         protected void AddImplicitValues(

--- a/src/Core/Types/Types/Descriptors/EnumTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/EnumTypeDescriptor.cs
@@ -37,7 +37,10 @@ namespace HotChocolate.Types.Descriptors
         {
             if (Definition.ClrType is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.ClrType);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.ClrType);
             }
 
             var values = Values.Select(t => t.CreateDefinition()).ToDictionary(t => t.Value);

--- a/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
@@ -35,8 +35,6 @@ namespace HotChocolate.Types.Descriptors
 
         protected override void OnCreateDefinition(EnumValueDefinition definition)
         {
-            base.OnCreateDefinition(definition);
-
             if (Definition.Member is { })
             {
                 Context.Inspector.ApplyAttributes(
@@ -44,6 +42,8 @@ namespace HotChocolate.Types.Descriptors
                     this,
                     Definition.Member);
             }
+
+            base.OnCreateDefinition(definition);
         }
 
         public IEnumValueDescriptor SyntaxNode(

--- a/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/EnumValueDescriptor.cs
@@ -39,7 +39,10 @@ namespace HotChocolate.Types.Descriptors
 
             if (Definition.Member is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.Member);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.Member);
             }
         }
 

--- a/src/Core/Types/Types/Descriptors/InputFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InputFieldDescriptor.cs
@@ -37,7 +37,10 @@ namespace HotChocolate.Types.Descriptors
 
             if (Definition.Property is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.Property);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.Property);
             }
         }
 

--- a/src/Core/Types/Types/Descriptors/InputFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InputFieldDescriptor.cs
@@ -33,8 +33,6 @@ namespace HotChocolate.Types.Descriptors
 
         protected override void OnCreateDefinition(InputFieldDefinition definition)
         {
-            base.OnCreateDefinition(definition);
-
             if (Definition.Property is { })
             {
                 Context.Inspector.ApplyAttributes(
@@ -42,6 +40,8 @@ namespace HotChocolate.Types.Descriptors
                     this,
                     Definition.Property);
             }
+
+            base.OnCreateDefinition(definition);
         }
 
         public new IInputFieldDescriptor SyntaxNode(

--- a/src/Core/Types/Types/Descriptors/InputObjectTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InputObjectTypeDescriptor.cs
@@ -63,6 +63,8 @@ namespace HotChocolate.Types.Descriptors
             OnCompleteFields(fields, handledProperties);
 
             Definition.Fields.AddRange(fields.Values);
+
+            base.OnCreateDefinition(definition);
         }
 
         protected virtual void OnCompleteFields(

--- a/src/Core/Types/Types/Descriptors/InputObjectTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InputObjectTypeDescriptor.cs
@@ -45,7 +45,10 @@ namespace HotChocolate.Types.Descriptors
         {
             if (Definition.ClrType is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.ClrType);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.ClrType);
             }
 
             var fields = new Dictionary<NameString, InputFieldDefinition>();

--- a/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -58,7 +58,10 @@ namespace HotChocolate.Types.Descriptors
 
             if (Definition.Member is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.Member);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.Member);
             }
         }
 

--- a/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -52,10 +52,6 @@ namespace HotChocolate.Types.Descriptors
         protected override void OnCreateDefinition(
             InterfaceFieldDefinition definition)
         {
-            base.OnCreateDefinition(definition);
-
-            CompleteArguments(definition);
-
             if (Definition.Member is { })
             {
                 Context.Inspector.ApplyAttributes(
@@ -63,6 +59,10 @@ namespace HotChocolate.Types.Descriptors
                     this,
                     Definition.Member);
             }
+
+            base.OnCreateDefinition(definition);
+
+            CompleteArguments(definition);
         }
 
         private void CompleteArguments(InterfaceFieldDefinition definition)

--- a/src/Core/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
@@ -62,6 +62,8 @@ namespace HotChocolate.Types.Descriptors
             OnCompleteFields(fields, handledMembers);
 
             Definition.Fields.AddRange(fields.Values);
+
+            base.OnCreateDefinition(definition);
         }
 
         protected virtual void OnCompleteFields(

--- a/src/Core/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
@@ -44,7 +44,10 @@ namespace HotChocolate.Types.Descriptors
         {
             if (Definition.ClrType is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.ClrType);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.ClrType);
             }
 
             var fields = new Dictionary<NameString, InterfaceFieldDefinition>();

--- a/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -77,7 +77,10 @@ namespace HotChocolate.Types.Descriptors
 
             if (Definition.Member is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.Member);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.Member);
             }
         }
 

--- a/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -71,9 +71,6 @@ namespace HotChocolate.Types.Descriptors
         protected override void OnCreateDefinition(
             ObjectFieldDefinition definition)
         {
-            base.OnCreateDefinition(definition);
-
-            CompleteArguments(definition);
 
             if (Definition.Member is { })
             {
@@ -82,6 +79,10 @@ namespace HotChocolate.Types.Descriptors
                     this,
                     Definition.Member);
             }
+
+            base.OnCreateDefinition(definition);
+
+            CompleteArguments(definition);
         }
 
         private void CompleteArguments(ObjectFieldDefinition definition)

--- a/src/Core/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -47,7 +47,10 @@ namespace HotChocolate.Types.Descriptors
         {
             if (Definition.ClrType is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.ClrType);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.ClrType);
             }
 
             var fields = new Dictionary<NameString, ObjectFieldDefinition>();

--- a/src/Core/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -65,6 +65,8 @@ namespace HotChocolate.Types.Descriptors
             OnCompleteFields(fields, handledMembers);
 
             Definition.Fields.AddRange(fields.Values);
+
+            base.OnCreateDefinition(definition);
         }
 
         protected virtual void OnCompleteFields(

--- a/src/Core/Types/Types/Descriptors/ObjectTypeExtensionDescriptor~1.cs
+++ b/src/Core/Types/Types/Descriptors/ObjectTypeExtensionDescriptor~1.cs
@@ -16,6 +16,20 @@ namespace HotChocolate.Types.Descriptors
             Definition.FieldBindingType = typeof(T);
         }
 
+        protected override void OnCreateDefinition(
+            ObjectTypeDefinition definition)
+        {
+            if (definition.FieldBindingType is { })
+            {
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.FieldBindingType);
+            }
+
+            base.OnCreateDefinition(definition);
+        }
+
         protected override void OnCompleteFields(
             IDictionary<NameString, ObjectFieldDefinition> fields,
             ISet<MemberInfo> handledMembers)

--- a/src/Core/Types/Types/Descriptors/UnionTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/UnionTypeDescriptor.cs
@@ -39,6 +39,7 @@ namespace HotChocolate.Types.Descriptors
                     this,
                     Definition.ClrType);
             }
+
             base.OnCreateDefinition(definition);
         }
 

--- a/src/Core/Types/Types/Descriptors/UnionTypeDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/UnionTypeDescriptor.cs
@@ -34,7 +34,10 @@ namespace HotChocolate.Types.Descriptors
         {
             if (Definition.ClrType is { })
             {
-                Context.Inspector.ApplyAttributes(this, Definition.ClrType);
+                Context.Inspector.ApplyAttributes(
+                    Context,
+                    this,
+                    Definition.ClrType);
             }
             base.OnCreateDefinition(definition);
         }

--- a/src/Core/Types/Types/Relay/UsePagingAttribute.cs
+++ b/src/Core/Types/Types/Relay/UsePagingAttribute.cs
@@ -31,7 +31,10 @@ namespace HotChocolate.Types.Relay
 
         public Type? SchemaType { get; set; }
 
-        protected internal override void TryConfigure(IDescriptorContext context, IDescriptor descriptor, ICustomAttributeProvider element)
+        protected internal override void TryConfigure(
+            IDescriptorContext context,
+            IDescriptor descriptor,
+            ICustomAttributeProvider element)
         {
             if (element is MemberInfo m)
             {


### PR DESCRIPTION
This PR introduces new type attributes to force the type discovery to recognize a `struct` for instance as a `ObjectType`.

Also we have fixed the `UsePagingAttribute` and reworked the attribute base to include the annotated element and the descriptor context.

Last but not least we added the `ExtendObjectTypeAttribute`.

```csharp
ISchema schema = SchemaBuilder.New()
    .AddType<StructQuery>()
    .AddType<StructQueryExtension>()
    .ModifyOptions(o => o.RemoveUnreachableTypes = true)
    .Create();

[ObjectType(Name = "Query")]
public struct StructQuery
{
    public string? Foo { get; }
}

[ExtendObjectType(Name = "Query")]
public class StructQueryExtension
{
    public string? Bar { get; }
}
```

will result in:

```GraphQL
type Query {
    bar: String
    foo: String
}
```