### PR TITLE
fix(DI): fix hashprovider DI which has multiple constructors

### DIFF
--- a/src/Core/Core/Execution/Extensions/QueryExecutionBuilderExtensions.cs
+++ b/src/Core/Core/Execution/Extensions/QueryExecutionBuilderExtensions.cs
@@ -702,8 +702,7 @@ namespace HotChocolate.Execution
             }
 
             builder.Services.TryAddSingleton<
-                IDocumentHashProvider,
-                MD5DocumentHashProvider>();
+                IDocumentHashProvider>(new MD5DocumentHashProvider());
             return builder;
         }
 


### PR DESCRIPTION
MD5DocumentHashProvider has multiple constructors which doesn't work properly with DI. this change specifies the constructor explicitly.

Fixes #1305