### PR TITLE
Use Expression.Not in FilterExpressionBuilder.Not

### DIFF
--- a/src/Core/Types.Filters/Expressions/FilterExpressionBuilder.cs
+++ b/src/Core/Types.Filters/Expressions/FilterExpressionBuilder.cs
@@ -53,7 +53,7 @@ namespace HotChocolate.Types.Filters.Expressions
 
         public static Expression Not(Expression expression)
         {
-            return Expression.Equal(expression, Expression.Constant(false));
+            return Expression.Not(expression);
         }
 
         public static Expression Equals(


### PR DESCRIPTION
Switches the FilterExpressionBuilder.Not method to use Expression.Not instead of comparing expression with the constant ```false```

Addresses #1393 
