### PR TITLE
[Server] Adds Custom Message Handler

### DIFF
--- a/src/Server/AspNetCore.Subscriptions.Tests/CustomMessageHandlerMock.cs
+++ b/src/Server/AspNetCore.Subscriptions.Tests/CustomMessageHandlerMock.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using HotChocolate.AspNetCore.Subscriptions.Messages;
+using HotChocolate.Server;
+
+namespace HotChocolate.AspNetCore.Subscriptions
+{
+    public class CustomMessageHandlerMock
+        : MessageHandler<InitializeConnectionMessage>
+    {
+        public bool HasBeenCalled { get; set; } = false;
+
+        protected override Task HandleAsync(
+            ISocketConnection connection,
+            InitializeConnectionMessage message,
+            CancellationToken cancellationToken)
+        {
+            HasBeenCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Server/AspNetCore.Subscriptions.Tests/SubscriptionTestBase.cs
+++ b/src/Server/AspNetCore.Subscriptions.Tests/SubscriptionTestBase.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using HotChocolate.AspNetCore.Subscriptions.Messages;
 using HotChocolate.AspNetCore.Tests.Utilities;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -32,6 +33,13 @@ namespace HotChocolate.AspNetCore.Subscriptions
             return ServerFactory.Create(
                 services => services.AddStarWars(),
                 app => app.UseGraphQL(path));
+        }
+
+        protected TestServer CreateStarWarsServer(Action<IServiceCollection> configureServices)
+        {
+            return ServerFactory.Create(
+                services => configureServices(services.AddStarWars()),
+                app => app.UseGraphQL());
         }
 
         protected async Task<ClientQueryResult> DeserializeAsync(

--- a/src/Server/AspNetCore.Subscriptions/Messages/ICustomMessageHandler.cs
+++ b/src/Server/AspNetCore.Subscriptions/Messages/ICustomMessageHandler.cs
@@ -1,0 +1,6 @@
+namespace HotChocolate.AspNetCore.Subscriptions.Messages
+{
+    public interface ICustomMessageHandler : IMessageHandler
+    {
+    }
+}

--- a/src/Server/AspNetCore.Subscriptions/Messages/MessageHandler.cs
+++ b/src/Server/AspNetCore.Subscriptions/Messages/MessageHandler.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using HotChocolate.AspNetCore.Subscriptions.Messages;
 using HotChocolate.Server;
 
 namespace HotChocolate.AspNetCore.Subscriptions.Messages
 {
     public abstract class MessageHandler<T>
-        : IMessageHandler
+        : IMessageHandler, ICustomMessageHandler
         where T : OperationMessage
     {
         public bool CanHandle(OperationMessage message)


### PR DESCRIPTION
Introduce a new way to intercept messages. 
```csharp
public class CustomMessageHandler
        : MessageHandler<InitializeConnectionMessage>
    {

        protected override Task HandleAsync(
            ISocketConnection connection,
            InitializeConnectionMessage message,
            CancellationToken cancellationToken)
        {
             // is called every time a InitializeConnectionMessage is triggered
        }
    }

// startup.cs
services.AddSingleton<ICustomMessageHandler, CustomMessageHandler>()
```