### PR TITLE
Added check for DefaultValue in ArgumentNonNullValidator

### DIFF
--- a/src/Core/Core.Tests/Execution/Utilities/ArgumentNonNullValidatorTests.cs
+++ b/src/Core/Core.Tests/Execution/Utilities/ArgumentNonNullValidatorTests.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using HotChocolate.Language;
+using HotChocolate.Types;
+using Xunit;
+using static HotChocolate.Execution.ArgumentNonNullValidator;
+
+namespace HotChocolate.Execution
+{
+    public class ArgumentNonNullValidatorTests
+    {
+        [Fact]
+        public void Validate_Input_With_Non_Null_Props_That_Have_No_Value_But_A_DefaultValue()
+        {
+            // arrange
+            ISchema schema = SchemaBuilder.New()
+                .AddDocumentFromString(@"
+                    type Query {
+                        test(bar: Bar): String
+                    }
+
+                    input Bar {
+                        a: String! = ""bar""
+                    }
+                ")
+                .Use(next => context => Task.CompletedTask)
+                .Create();
+
+            IInputField field = schema.QueryType.Fields["test"].Arguments["bar"];
+
+            // act
+            Report report = ArgumentNonNullValidator.Validate(
+                field,
+                new ObjectValueNode(), Path.New("root"));
+
+            // assert
+            Assert.False(report.HasErrors);
+        }
+
+        [Fact]
+        public void Validate_Input_With_Non_Null_Props_That_Have_No_Value_And_No_DefaultValue()
+        {
+            // arrange
+            ISchema schema = SchemaBuilder.New()
+                .AddDocumentFromString(@"
+                    type Query {
+                        test(bar: Bar): String
+                    }
+
+                    input Bar {
+                        a: String!
+                    }
+                ")
+                .Use(next => context => Task.CompletedTask)
+                .Create();
+
+            IInputField field = schema.QueryType.Fields["test"].Arguments["bar"];
+
+            // act
+            Report report = ArgumentNonNullValidator.Validate(
+                field,
+                new ObjectValueNode(), Path.New("root"));
+
+            // assert
+            Assert.True(report.HasErrors);
+            Assert.Equal("/root/a", report.Path.ToString());
+        }
+    }
+}

--- a/src/Core/Core/Execution/Utilities/ArgumentNonNullValidator.cs
+++ b/src/Core/Core/Execution/Utilities/ArgumentNonNullValidator.cs
@@ -62,7 +62,8 @@ namespace HotChocolate.Execution
                 }
             }
 
-            if (innerType is InputObjectType inputType && value is ObjectValueNode ov)
+            if (innerType is InputObjectType inputType
+                && value is ObjectValueNode ov)
             {
                 return ValidateObject(inputType, ov, path);
             }

--- a/src/Core/Core/Execution/Utilities/ArgumentNonNullValidator.cs
+++ b/src/Core/Core/Execution/Utilities/ArgumentNonNullValidator.cs
@@ -24,7 +24,7 @@ namespace HotChocolate.Execution
             return ValidateInnerType(field.Type, value, path);
         }
 
-        public static Report Validate(
+        private static Report Validate(
             IType type,
             IValueNode value,
             Path path)

--- a/src/Core/Core/Execution/Utilities/FieldCollector.cs
+++ b/src/Core/Core/Execution/Utilities/FieldCollector.cs
@@ -325,7 +325,7 @@ namespace HotChocolate.Execution
             }
 
             Report report = ArgumentNonNullValidator.Validate(
-                argument.Type,
+                argument,
                 literal,
                 Path.New(argument.Name));
 


### PR DESCRIPTION
Added check for DefaultValue in ArgumentNonNullValidator in scope to be able to pass validation if a Non-Nullable field Is Null but has a Default Value

Summary of the changes

- Created an overload of `Validate()` method which takes an `IInputField field` as argument and checks the DefaultValue
- Made the new method the only public method. 

Fixes #1403 
