### PR TITLE
Infer Default Values From Parameters and Properties V10

### DIFF
--- a/src/Core/Types.Tests/Types/DirectiveTypeTests.cs
+++ b/src/Core/Types.Tests/Types/DirectiveTypeTests.cs
@@ -502,6 +502,28 @@ namespace HotChocolate.Types
             Assert.Throws<SchemaException>(action);
         }
 
+        [Fact]
+        public void Infer_Directive_Argument_Defaults_From_Properties()
+        {
+            // arrange
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType(c => c
+                    .Name("Query")
+                    .Directive("foo")
+                    .Field("foo")
+                    .Type<StringType>()
+                    .Resolver("bar"))
+                .AddDirectiveType(new DirectiveType<DirectiveWithDefaults>(d => d
+                    .Name("foo")
+                    .Location(DirectiveLocation.Object)
+                    .Use<DirectiveMiddleware>()))
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public class CustomDirectiveType
             : DirectiveType<CustomDirective>
         {
@@ -549,6 +571,13 @@ namespace HotChocolate.Types
 
         public class CustomDirective2
         {
+            public string Argument1 { get; set; }
+            public string Argument2 { get; set; }
+        }
+
+        public class DirectiveWithDefaults
+        {
+            [DefaultValue("abc")]
             public string Argument1 { get; set; }
             public string Argument2 { get; set; }
         }

--- a/src/Core/Types.Tests/Types/InputObjectTypeTests.cs
+++ b/src/Core/Types.Tests/Types/InputObjectTypeTests.cs
@@ -1033,6 +1033,24 @@ namespace HotChocolate.Types
             result.MatchSnapshot();
         }
 
+        [Fact]
+        public void Input_Infer_Default_Values()
+        {
+            // arrange
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType(d => d
+                    .Name("Query")
+                    .Field("abc")
+                    .Argument("def", a => a.Type<InputObjectType<InputWithDefault>>())
+                    .Resolver("ghi"))
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
+
         public class SimpleInput
         {
             public int Id { get; set; }
@@ -1169,6 +1187,17 @@ namespace HotChocolate.Types
             public string Bar { get; }
             public string Baz { get; set; }
             public string Qux { get; private set; }
+        }
+
+        public class InputWithDefault
+        {
+            [DefaultValue("abc")]
+            public string WithStringDefault { get; set;}
+
+            [DefaultValue(null)]
+            public string WithNullDefault { get; set;}
+
+            public string WithoutDefault { get; set;}
         }
     }
 }

--- a/src/Core/Types.Tests/Types/InputObjectTypeTests.cs
+++ b/src/Core/Types.Tests/Types/InputObjectTypeTests.cs
@@ -1050,7 +1050,6 @@ namespace HotChocolate.Types
             schema.ToString().MatchSnapshot();
         }
 
-
         public class SimpleInput
         {
             public int Id { get; set; }

--- a/src/Core/Types.Tests/Types/ObjectTypeTests.cs
+++ b/src/Core/Types.Tests/Types/ObjectTypeTests.cs
@@ -1501,6 +1501,19 @@ namespace HotChocolate.Types
             schema.ToString().MatchSnapshot();
         }
 
+        [Fact]
+        public void Infer_Argument_Default_Values()
+        {
+            // arrange
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType<QueryWithArgumentDefaults>()
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
         public class GenericFoo<T>
         {
             public T Value { get; }
@@ -1642,6 +1655,17 @@ namespace HotChocolate.Types
         public class MyListQuery
         {
             public MyList List { get; set; }
+        }
+
+        public class QueryWithArgumentDefaults
+        {
+            public string Field1(
+                string a = null,
+                string b = "abc") => null;
+
+            public string Field2(
+                [DefaultValue(null)]string a,
+                [DefaultValue("abc")]string b) => null;
         }
     }
 }

--- a/src/Core/Types.Tests/Types/__snapshots__/DirectiveTypeTests.Infer_Directive_Argument_Defaults_From_Properties.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/DirectiveTypeTests.Infer_Directive_Argument_Defaults_From_Properties.snap
@@ -1,0 +1,12 @@
+﻿schema {
+  query: Query
+}
+
+type Query @foo {
+  foo: String
+}
+
+directive @foo(argument1: String = "abc" argument2: String) on OBJECT
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/InputObjectTypeTests.Input_Infer_Default_Values.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/InputObjectTypeTests.Input_Infer_Default_Values.snap
@@ -1,0 +1,16 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  abc(def: InputWithDefaultInput): String
+}
+
+input InputWithDefaultInput {
+  withNullDefault: String
+  withoutDefault: String
+  withStringDefault: String = "abc"
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Infer_Argument_Default_Values.snap
+++ b/src/Core/Types.Tests/Types/__snapshots__/ObjectTypeTests.Infer_Argument_Default_Values.snap
@@ -1,0 +1,11 @@
+﻿schema {
+  query: QueryWithArgumentDefaults
+}
+
+type QueryWithArgumentDefaults {
+  field1(a: String b: String = "abc"): String
+  field2(a: String b: String = "abc"): String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String

--- a/src/Core/Types/Types/Descriptors/ArgumentDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/ArgumentDescriptor.cs
@@ -32,7 +32,6 @@ namespace HotChocolate.Types.Descriptors
 
             Definition.Name = argumentName;
             Definition.Type = argumentType.GetInputType();
-            Definition.DefaultValue = NullValueNode.Default;
         }
 
         public ArgumentDescriptor(
@@ -43,8 +42,12 @@ namespace HotChocolate.Types.Descriptors
             Definition.Name = context.Naming.GetArgumentName(parameter);
             Definition.Description = context.Naming.GetArgumentDescription(parameter);
             Definition.Type = context.Inspector.GetArgumentType(parameter);
-            Definition.DefaultValue = NullValueNode.Default;
             Definition.Parameter = parameter;
+
+            if (context.Inspector.TryGetDefaultValue(parameter, out object defaultValue))
+            {
+                Definition.NativeDefaultValue = defaultValue;
+            }
         }
 
         protected override void OnCreateDefinition(ArgumentDefinition definition)

--- a/src/Core/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
@@ -263,5 +263,35 @@ namespace HotChocolate.Types.Descriptors
                 attribute.TryConfigure(context, descriptor, attributeProvider);
             }
         }
+
+        public virtual bool TryGetDefaultValue(ParameterInfo parameter, out object defaultValue)
+        {
+            if (parameter.IsDefined(typeof(DefaultValueAttribute)))
+            {
+                defaultValue = parameter.GetCustomAttribute<DefaultValueAttribute>().Value;
+                return true;
+            }
+
+            if (parameter.HasDefaultValue)
+            {
+                defaultValue = parameter.RawDefaultValue;
+                return true;
+            }
+
+            defaultValue = null;
+            return false;
+        }
+
+        public virtual bool TryGetDefaultValue(PropertyInfo parameter, out object defaultValue)
+        {
+            if (parameter.IsDefined(typeof(DefaultValueAttribute)))
+            {
+                defaultValue = parameter.GetCustomAttribute<DefaultValueAttribute>().Value;
+                return true;
+            }
+
+            defaultValue = null;
+            return false;
+        }
     }
 }

--- a/src/Core/Types/Types/Descriptors/Conventions/ITypeInspector.cs
+++ b/src/Core/Types/Types/Descriptors/Conventions/ITypeInspector.cs
@@ -47,5 +47,9 @@ namespace HotChocolate.Types.Descriptors
             IDescriptorContext context,
             IDescriptor descriptor,
             ICustomAttributeProvider attributeProvider);
+
+        bool TryGetDefaultValue(ParameterInfo parameter, out object defaultValue);
+
+        bool TryGetDefaultValue(PropertyInfo parameter, out object defaultValue);
     }
 }

--- a/src/Core/Types/Types/Descriptors/DirectiveArgumentDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/DirectiveArgumentDescriptor.cs
@@ -15,7 +15,6 @@ namespace HotChocolate.Types.Descriptors
             : base(context)
         {
             Definition.Name = argumentName;
-            Definition.DefaultValue = NullValueNode.Default;
         }
 
         public DirectiveArgumentDescriptor(
@@ -29,6 +28,11 @@ namespace HotChocolate.Types.Descriptors
                 property, MemberKind.DirectiveArgument);
             Definition.Type = context.Inspector.GetInputReturnType(property);
             Definition.Property = property;
+
+            if (context.Inspector.TryGetDefaultValue(property, out object defaultValue))
+            {
+                Definition.NativeDefaultValue = defaultValue;
+            }
         }
 
         protected override void OnCreateDefinition(DirectiveArgumentDefinition definition)

--- a/src/Core/Types/Types/Descriptors/InputFieldDescriptor.cs
+++ b/src/Core/Types/Types/Descriptors/InputFieldDescriptor.cs
@@ -29,6 +29,11 @@ namespace HotChocolate.Types.Descriptors
             Definition.Description = context.Naming.GetMemberDescription(
                 property, MemberKind.InputObjectField);
             Definition.Type = context.Inspector.GetInputReturnType(property);
+
+            if (context.Inspector.TryGetDefaultValue(property, out object defaultValue))
+            {
+                Definition.NativeDefaultValue = defaultValue;
+            }
         }
 
         protected override void OnCreateDefinition(InputFieldDefinition definition)


### PR DESCRIPTION
This change brings in the capability to infer default values from parameters.

```csharp
public string Foo(string bar = "abc")
```

Also we can infer default values from the `System.ComponentModel.DefaultValueAttribute`.

This change brings in the capability to infer default values from parameters.

```csharp
public string Foo([DefaultValue("abc")]string bar)
```

```csharp
[DefaultValue("abc")
public string Foo { get; set; }
```

The attribute takes precedence over the default value assignment.
