### PR TITLE
Remove sealed from Authorize and State attribute

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Authorization/AuthorizeAttribute.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Authorization/AuthorizeAttribute.cs
@@ -12,7 +12,7 @@ namespace HotChocolate.AspNetCore.Authorization
         | AttributeTargets.Method,
         Inherited = true,
         AllowMultiple = true)]
-    public class AuthorizeAttribute : DescriptorAttribute
+    public sealed class AuthorizeAttribute : DescriptorAttribute
     {
         public string? Policy { get; set; }
 

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Authorization/AuthorizeAttribute.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Authorization/AuthorizeAttribute.cs
@@ -12,7 +12,7 @@ namespace HotChocolate.AspNetCore.Authorization
         | AttributeTargets.Method,
         Inherited = true,
         AllowMultiple = true)]
-    public sealed class AuthorizeAttribute : DescriptorAttribute
+    public class AuthorizeAttribute : DescriptorAttribute
     {
         public string? Policy { get; set; }
 

--- a/src/HotChocolate/Core/src/Abstractions/StateAttribute.cs
+++ b/src/HotChocolate/Core/src/Abstractions/StateAttribute.cs
@@ -4,7 +4,7 @@ using HotChocolate.Properties;
 namespace HotChocolate
 {
     [AttributeUsage(AttributeTargets.Parameter)]
-    public sealed class StateAttribute
+    public class StateAttribute
         : Attribute
     {
         public StateAttribute(string key)


### PR DESCRIPTION
 Removes sealed from Authorize and State attribute to better fit Microsofts attributes, as these need to be extendable.

Addresses #1472 (in this specific format)
