### PR TITLE
Fixed namespace of AddInMemorySubscriptions

### DIFF
--- a/src/Core/Subscriptions.InMemory/DependencyInjection/InMemorySubscriptionServiceCollectionExtensions.cs
+++ b/src/Core/Subscriptions.InMemory/DependencyInjection/InMemorySubscriptionServiceCollectionExtensions.cs
@@ -1,9 +1,8 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using HotChocolate.Subscriptions;
 using HotChocolate.Subscriptions.InMemory;
 
-namespace HotChocolate
+namespace HotChocolate.Subscriptions
 {
     public static class InMemoryPubSubServiceCollectionExtensions
     {


### PR DESCRIPTION
As it differed from AddRedisSubscriptions

Summary of the changes
- Updated namespace of InMemoryPubSubServiceCollectionExtensions class

Builds and tests pass locally

