### PR TITLE
Add GraphQL endpoint option for Playground

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Playground/PlaygroundOptions.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Playground/PlaygroundOptions.cs
@@ -18,6 +18,11 @@ namespace HotChocolate.AspNetCore.Playground
         }
 
         /// <summary>
+        /// The endpoint of the GraphQL service.
+        /// </summary>
+        public Uri? GraphQLEndpoint { get; set; }
+
+        /// <summary>
         /// The path of the Playground middleware.
         /// </summary>
         public PathString Path

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Voyager/SettingsMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Voyager/SettingsMiddleware.cs
@@ -33,7 +33,8 @@ namespace HotChocolate.AspNetCore.Voyager
         /// <returns></returns>
         public async Task InvokeAsync(HttpContext context)
         {
-            string queryUrl = BuildUrl(context.Request, _queryPath);
+            string queryUrl = _options.GraphQLEndpoint?.AbsoluteUri
+                ?? BuildUrl(context.Request, _queryPath);
 
             context.Response.ContentType = "application/javascript";
 

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Voyager/VoyagerOptions.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Voyager/VoyagerOptions.cs
@@ -9,6 +9,8 @@ namespace HotChocolate.AspNetCore.Voyager
         private PathString _path = new PathString("/voyager");
         private PathString _queryPath = new PathString("/");
 
+        public Uri? GraphQLEndpoint { get; set; }
+
         public PathString Path
         {
             get => _path;

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Playground/PlaygroundMiddlewareTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Playground/PlaygroundMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Snapshooter.Xunit;
 using Xunit;
 using HotChocolate.AspNetCore.Playground;
 using HotChocolate.AspNetCore.Tests.Utilities;
+using System;
 
 namespace HotChocolate.AspNetCore
 {
@@ -58,6 +59,43 @@ namespace HotChocolate.AspNetCore
 
             TestServer server = CreateServer(options);
             string settingsUri = "/foo/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+            options.EnableSubscription = false;
+            options.Path = "/foo-bar";
+            options.GraphQLEndpoint = new Uri("https://hotchocolate.io/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/foo-bar/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpointWithSubscriptions()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+            options.Path = "/bar";
+            options.GraphQLEndpoint = new Uri("https://microsoft.com/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/bar/settings.js";
 
             // act
             string settings_js = await GetSettingsAsync(server, settingsUri);

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Playground/PlaygroundOptionsTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Playground/PlaygroundOptionsTests.cs
@@ -17,6 +17,7 @@ namespace HotChocolate.AspNetCore
             Assert.Equal("/playground", options.Path);
             Assert.Equal("/", options.QueryPath);
             Assert.Equal("/", options.SubscriptionPath);
+            Assert.Null(options.GraphQLEndpoint);
         }
 
         [Fact]
@@ -32,6 +33,19 @@ namespace HotChocolate.AspNetCore
             Assert.Equal("/foo", options.Path);
             Assert.Equal("/", options.QueryPath);
             Assert.Equal("/", options.SubscriptionPath);
+        }
+
+        [Fact]
+        public void SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+
+            // act
+            options.GraphQLEndpoint = new Uri("https://localhost:5000/graphql");
+
+            // act
+            Assert.Equal("https://localhost:5000/graphql", options.GraphQLEndpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -165,6 +179,21 @@ namespace HotChocolate.AspNetCore
 
             // act
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void GraphQLEndpoint_Set_To_Null_Or_Invalid_Exceptions()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+
+            // act
+            Action invalidUriAction = () => options.GraphQLEndpoint = new Uri("not a uri");
+            Action nullUriAction = () => options.GraphQLEndpoint = new Uri(null);
+
+            // act
+            Assert.Throws<UriFormatException>(invalidUriAction);
+            Assert.Throws<ArgumentNullException>(nullUriAction);
         }
     }
 }

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Playground/__snapshots__/PlaygroundMiddlewareTests.SetGraphQLEndpoint.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Playground/__snapshots__/PlaygroundMiddlewareTests.SetGraphQLEndpoint.snap
@@ -1,0 +1,6 @@
+﻿
+                window.Settings = {
+                    url: "https://hotchocolate.io/graphql",
+                    subscriptionUrl: null,
+                }
+            

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Playground/__snapshots__/PlaygroundMiddlewareTests.SetGraphQLEndpointWithSubscriptions.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Playground/__snapshots__/PlaygroundMiddlewareTests.SetGraphQLEndpointWithSubscriptions.snap
@@ -1,0 +1,6 @@
+﻿
+                window.Settings = {
+                    url: "https://microsoft.com/graphql",
+                    subscriptionUrl: "wss://microsoft.com/graphql",
+                }
+            

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Voyager/VoyagerMiddlewareTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Voyager/VoyagerMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Snapshooter.Xunit;
 using Xunit;
 using HotChocolate.AspNetCore.Tests.Utilities;
 using HotChocolate.AspNetCore.Voyager;
+using System;
 
 namespace HotChocolate.AspNetCore
 {
@@ -41,6 +42,24 @@ namespace HotChocolate.AspNetCore
 
             TestServer server = CreateServer(options);
             string settingsUri = "/foo/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+            options.Path = "/foo-bar";
+            options.GraphQLEndpoint = new Uri("https://github.com/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/foo-bar/settings.js";
 
             // act
             string settings_js = await GetSettingsAsync(server, settingsUri);

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Voyager/VoyagerOptionsTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Voyager/VoyagerOptionsTests.cs
@@ -16,6 +16,7 @@ namespace HotChocolate.AspNetCore
             // act
             Assert.Equal("/voyager", options.Path);
             Assert.Equal("/", options.QueryPath);
+            Assert.Null(options.GraphQLEndpoint);
         }
 
         [Fact]
@@ -30,6 +31,19 @@ namespace HotChocolate.AspNetCore
             // act
             Assert.Equal("/foo", options.Path);
             Assert.Equal("/", options.QueryPath);
+        }
+
+        [Fact]
+        public void SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+
+            // act
+            options.GraphQLEndpoint = new Uri("https://localhost:8081/graphql");
+
+            // act
+            Assert.Equal("https://localhost:8081/graphql", options.GraphQLEndpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -100,6 +114,21 @@ namespace HotChocolate.AspNetCore
 
             // act
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void GraphQLEndpoint_Set_To_Null_Or_Invalid_Exceptions()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+
+            // act
+            Action invalidAction = () => options.GraphQLEndpoint = new Uri("not valid");
+            Action nullAction = () => options.GraphQLEndpoint = new Uri(null);
+
+            // act
+            Assert.Throws<UriFormatException>(invalidAction);
+            Assert.Throws<ArgumentNullException>(nullAction);
         }
     }
 }

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Voyager/__snapshots__/VoyagerMiddlewareTests.SetGraphQLEndpoint.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Voyager/__snapshots__/VoyagerMiddlewareTests.SetGraphQLEndpoint.snap
@@ -1,0 +1,5 @@
+﻿
+                window.Settings = {
+                    url: "https://github.com/graphql",
+                }
+            


### PR DESCRIPTION
Adds ability to specify an endpoint for playground:

```
app.UsePlayground(new PlaygroundOptions() 
{
    GraphQLEndpoint = "https://hotchocolate.io/graphql"
});

app.UseVoyager(new VoyagerOptions() 
{
    GraphQLEndpoint = "https://hotchocolate.io/graphql"
});
```

Addresses #906 