### PR TITLE
Add GraphQL endpoint option for GraphiQL, Playground and Voyager

### DIFF
--- a/src/Server/AspNetClassic.Tests/GraphiQL/GraphiQLMiddlewareTests.cs
+++ b/src/Server/AspNetClassic.Tests/GraphiQL/GraphiQLMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using HotChocolate.AspNetClassic.GraphiQL;
 using Microsoft.Owin.Testing;
 using Microsoft.Owin;
+using System;
 
 namespace HotChocolate.AspNetClassic
 {
@@ -58,6 +59,43 @@ namespace HotChocolate.AspNetClassic
 
             TestServer server = CreateServer(options);
             string settingsUri = "/foo/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new GraphiQLOptions();
+            options.Path = new PathString("/foo-bar");
+            options.GraphQLEndpoint = new Uri("https://hotchocolate.io/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/foo-bar/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpointWithSubscriptions()
+        {
+            // arrange
+            var options = new GraphiQLOptions();
+            options.EnableSubscription = true;
+            options.Path = new PathString("/bar");
+            options.GraphQLEndpoint = new Uri("https://microsoft.com/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/bar/settings.js";
 
             // act
             string settings_js = await GetSettingsAsync(server, settingsUri);

--- a/src/Server/AspNetClassic.Tests/GraphiQL/GraphiQLOptionsTests.cs
+++ b/src/Server/AspNetClassic.Tests/GraphiQL/GraphiQLOptionsTests.cs
@@ -18,6 +18,7 @@ namespace HotChocolate.AspNetClassic
             Assert.Equal("/graphiql", options.Path.ToString());
             Assert.Equal("/", options.QueryPath.ToString());
             Assert.Equal("/", options.SubscriptionPath.ToString());
+            Assert.Null(options.GraphQLEndpoint);
         }
 
         [Fact]
@@ -33,6 +34,19 @@ namespace HotChocolate.AspNetClassic
             Assert.Equal("/foo", options.Path.ToString());
             Assert.Equal("/", options.QueryPath.ToString());
             Assert.Equal("/", options.SubscriptionPath.ToString());
+        }
+
+        [Fact]
+        public void SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new GraphiQLOptions();
+
+            // act
+            options.GraphQLEndpoint = new Uri("https://localhost:5000/graphql");
+
+            // act
+            Assert.Equal("https://localhost:5000/graphql", options.GraphQLEndpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -166,6 +180,21 @@ namespace HotChocolate.AspNetClassic
 
             // act
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void GraphQLEndpoint_Set_To_Null_Or_Invalid_Exceptions()
+        {
+            // arrange
+            var options = new GraphiQLOptions();
+
+            // act
+            Action invalidUriAction = () => options.GraphQLEndpoint = new Uri("not a uri");
+            Action nullUriAction = () => options.GraphQLEndpoint = new Uri(null);
+
+            // act
+            Assert.Throws<UriFormatException>(invalidUriAction);
+            Assert.Throws<ArgumentNullException>(nullUriAction);
         }
     }
 }

--- a/src/Server/AspNetClassic.Tests/Playground/PlaygroundMiddlewareTests.cs
+++ b/src/Server/AspNetClassic.Tests/Playground/PlaygroundMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using Microsoft.Owin.Testing;
 using HotChocolate.AspNetClassic.Playground;
 using Microsoft.Owin;
+using System;
 
 namespace HotChocolate.AspNetClassic
 {
@@ -65,6 +66,45 @@ namespace HotChocolate.AspNetClassic
             // act
             settings_js.MatchSnapshot();
         }
+
+
+        [Fact]
+        public async Task SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+            options.Path = new PathString("/foo-bar");
+            options.GraphQLEndpoint = new Uri("https://hotchocolate.io/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/foo-bar/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpointWithSubscriptions()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+            options.EnableSubscription = true;
+            options.Path = new PathString("/bar");
+            options.GraphQLEndpoint = new Uri("https://microsoft.com/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/bar/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
 
         [Fact]
         public async Task SetPath_Then_SetQueryPath()

--- a/src/Server/AspNetClassic.Tests/Playground/PlaygroundOptionsTests.cs
+++ b/src/Server/AspNetClassic.Tests/Playground/PlaygroundOptionsTests.cs
@@ -18,6 +18,7 @@ namespace HotChocolate.AspNetClassic
             Assert.Equal("/playground", options.Path.ToString());
             Assert.Equal("/", options.QueryPath.ToString());
             Assert.Equal("/", options.SubscriptionPath.ToString());
+            Assert.Null(options.GraphQLEndpoint);
         }
 
         [Fact]
@@ -33,6 +34,19 @@ namespace HotChocolate.AspNetClassic
             Assert.Equal("/foo", options.Path.ToString());
             Assert.Equal("/", options.QueryPath.ToString());
             Assert.Equal("/", options.SubscriptionPath.ToString());
+        }
+
+        [Fact]
+        public void SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+
+            // act
+            options.GraphQLEndpoint = new Uri("https://localhost:5000/graphql");
+
+            // act
+            Assert.Equal("https://localhost:5000/graphql", options.GraphQLEndpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -166,6 +180,21 @@ namespace HotChocolate.AspNetClassic
 
             // act
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void GraphQLEndpoint_Set_To_Null_Or_Invalid_Exceptions()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+
+            // act
+            Action invalidUriAction = () => options.GraphQLEndpoint = new Uri("not a uri");
+            Action nullUriAction = () => options.GraphQLEndpoint = new Uri(null);
+
+            // act
+            Assert.Throws<UriFormatException>(invalidUriAction);
+            Assert.Throws<ArgumentNullException>(nullUriAction);
         }
     }
 }

--- a/src/Server/AspNetClassic.Tests/Voyager/VoyagerMiddlewareTests.cs
+++ b/src/Server/AspNetClassic.Tests/Voyager/VoyagerMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using Microsoft.Owin.Testing;
 using HotChocolate.AspNetClassic.Voyager;
 using Microsoft.Owin;
+using System;
 
 namespace HotChocolate.AspNetClassic
 {
@@ -41,6 +42,24 @@ namespace HotChocolate.AspNetClassic
 
             TestServer server = CreateServer(options);
             string settingsUri = "/foo/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+            options.Path = new PathString("/foo-bar");
+            options.GraphQLEndpoint = new Uri("https://github.com/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/foo-bar/settings.js";
 
             // act
             string settings_js = await GetSettingsAsync(server, settingsUri);

--- a/src/Server/AspNetClassic.Tests/Voyager/VoyagerOptionsTests.cs
+++ b/src/Server/AspNetClassic.Tests/Voyager/VoyagerOptionsTests.cs
@@ -17,6 +17,7 @@ namespace HotChocolate.AspNetClassic
             // act
             Assert.Equal("/voyager", options.Path.ToString());
             Assert.Equal("/", options.QueryPath.ToString());
+            Assert.Null(options.GraphQLEndpoint);
         }
 
         [Fact]
@@ -31,6 +32,19 @@ namespace HotChocolate.AspNetClassic
             // act
             Assert.Equal("/foo", options.Path.ToString());
             Assert.Equal("/", options.QueryPath.ToString());
+        }
+
+        [Fact]
+        public void SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+
+            // act
+            options.GraphQLEndpoint = new Uri("https://localhost:8081/graphql");
+
+            // act
+            Assert.Equal("https://localhost:8081/graphql", options.GraphQLEndpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -101,6 +115,21 @@ namespace HotChocolate.AspNetClassic
 
             // act
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void GraphQLEndpoint_Set_To_Null_Or_Invalid_Exceptions()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+
+            // act
+            Action invalidAction = () => options.GraphQLEndpoint = new Uri("not valid");
+            Action nullAction = () => options.GraphQLEndpoint = new Uri(null);
+
+            // act
+            Assert.Throws<UriFormatException>(invalidAction);
+            Assert.Throws<ArgumentNullException>(nullAction);
         }
     }
 }

--- a/src/Server/AspNetCore.Abstractions/GraphiQLOptionsBase.cs
+++ b/src/Server/AspNetCore.Abstractions/GraphiQLOptionsBase.cs
@@ -28,6 +28,7 @@ namespace HotChocolate.AspNetCore
             _path = _defaultPath = defaultPath;
         }
 
+        public Uri GraphQLEndpoint { get; set; }
 
         /// <summary>
         /// The path of the GraphiQL middleware.

--- a/src/Server/AspNetCore.Playground/SettingsMiddleware.cs
+++ b/src/Server/AspNetCore.Playground/SettingsMiddleware.cs
@@ -64,10 +64,11 @@ namespace HotChocolate.AspNetCore.Playground
         public async Task InvokeAsync(HttpContext context)
 #endif
         {
-            string queryUrl = BuildUrl(context.Request, false, _queryPath);
+            string queryUrl = BuildUrl(_options.GraphQLEndpoint, context.Request, false, _queryPath);
+
             string subscriptionUrl = _options.EnableSubscription
-                ? $"\"{BuildUrl(context.Request, true, _subscriptionPath)}\""
-                : "null";
+               ? $"\"{BuildUrl(_options.GraphQLEndpoint, context.Request, true, _subscriptionPath)}\""
+               : "null";
 
             context.Response.ContentType = "application/javascript";
 
@@ -106,6 +107,23 @@ namespace HotChocolate.AspNetCore.Playground
                 scheme, request.Host, uiPath + path)
                 .TrimEnd('/');
 #endif
+        }
+
+        private static string BuildUrl(Uri uri, HttpRequest request, bool websocket, string path)
+        {
+            if (uri == null)
+                return BuildUrl(request, websocket, path);
+
+            if (!websocket)
+                return uri.AbsoluteUri;
+
+
+            var builder = new UriBuilder(uri)
+            {
+                Scheme = uri.Scheme == Uri.UriSchemeHttps ? "wss" : "ws"
+            };
+
+            return builder.Uri.AbsoluteUri;
         }
 
         private static Uri UriFromPath(PathString path)

--- a/src/Server/AspNetCore.Tests/GraphiQL/GraphiQLMiddlewareTests.cs
+++ b/src/Server/AspNetCore.Tests/GraphiQL/GraphiQLMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Snapshooter.Xunit;
 using Xunit;
 using HotChocolate.AspNetCore.Tests.Utilities;
 using HotChocolate.AspNetCore.GraphiQL;
+using System;
 
 namespace HotChocolate.AspNetCore
 {
@@ -58,6 +59,43 @@ namespace HotChocolate.AspNetCore
 
             TestServer server = CreateServer(options);
             string settingsUri = "/foo/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new GraphiQLOptions();
+            options.EnableSubscription = false;
+            options.Path = "/foo-bar";
+            options.GraphQLEndpoint = new Uri("https://hotchocolate.io/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/foo-bar/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpointWithSubscriptions()
+        {
+            // arrange
+            var options = new GraphiQLOptions();
+            options.Path = "/bar";
+            options.GraphQLEndpoint = new Uri("https://microsoft.com/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/bar/settings.js";
 
             // act
             string settings_js = await GetSettingsAsync(server, settingsUri);

--- a/src/Server/AspNetCore.Tests/GraphiQL/GraphiQLOptionsTests.cs
+++ b/src/Server/AspNetCore.Tests/GraphiQL/GraphiQLOptionsTests.cs
@@ -17,6 +17,7 @@ namespace HotChocolate.AspNetCore
             Assert.Equal("/graphiql", options.Path);
             Assert.Equal("/", options.QueryPath);
             Assert.Equal("/", options.SubscriptionPath);
+            Assert.Null(options.GraphQLEndpoint);
         }
 
         [Fact]
@@ -32,6 +33,19 @@ namespace HotChocolate.AspNetCore
             Assert.Equal("/foo", options.Path);
             Assert.Equal("/", options.QueryPath);
             Assert.Equal("/", options.SubscriptionPath);
+        }
+
+        [Fact]
+        public void SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new GraphiQLOptions();
+
+            // act
+            options.GraphQLEndpoint = new Uri("https://localhost:5000/graphql");
+
+            // act
+            Assert.Equal("https://localhost:5000/graphql", options.GraphQLEndpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -165,6 +179,21 @@ namespace HotChocolate.AspNetCore
 
             // act
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void GraphQLEndpoint_Set_To_Null_Or_Invalid_Exceptions()
+        {
+            // arrange
+            var options = new GraphiQLOptions();
+
+            // act
+            Action invalidUriAction = () => options.GraphQLEndpoint = new Uri("not a uri");
+            Action nullUriAction = () => options.GraphQLEndpoint = new Uri(null);
+
+            // act
+            Assert.Throws<UriFormatException>(invalidUriAction);
+            Assert.Throws<ArgumentNullException>(nullUriAction);
         }
     }
 }

--- a/src/Server/AspNetCore.Tests/GraphiQL/__snapshots__/GraphiQLMiddlewareTests.SetGraphQLEndpoint.snap
+++ b/src/Server/AspNetCore.Tests/GraphiQL/__snapshots__/GraphiQLMiddlewareTests.SetGraphQLEndpoint.snap
@@ -1,0 +1,7 @@
+﻿
+                window.Settings = {
+                    url: "https://hotchocolate.io/graphql",
+                    subscriptionUrl: "wss://hotchocolate.io/graphql",
+                    enableSubscriptions: false
+                }
+            

--- a/src/Server/AspNetCore.Tests/GraphiQL/__snapshots__/GraphiQLMiddlewareTests.SetGraphQLEndpointWithSubscriptions.snap
+++ b/src/Server/AspNetCore.Tests/GraphiQL/__snapshots__/GraphiQLMiddlewareTests.SetGraphQLEndpointWithSubscriptions.snap
@@ -1,0 +1,7 @@
+﻿
+                window.Settings = {
+                    url: "https://microsoft.com/graphql",
+                    subscriptionUrl: "wss://microsoft.com/graphql",
+                    enableSubscriptions: true
+                }
+            

--- a/src/Server/AspNetCore.Tests/Playground/PlaygroundMiddlewareTests.cs
+++ b/src/Server/AspNetCore.Tests/Playground/PlaygroundMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Snapshooter.Xunit;
 using Xunit;
 using HotChocolate.AspNetCore.Playground;
 using HotChocolate.AspNetCore.Tests.Utilities;
+using System;
 
 namespace HotChocolate.AspNetCore
 {
@@ -58,6 +59,43 @@ namespace HotChocolate.AspNetCore
 
             TestServer server = CreateServer(options);
             string settingsUri = "/foo/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+            options.EnableSubscription = false;
+            options.Path = "/foo-bar";
+            options.GraphQLEndpoint = new Uri("https://hotchocolate.io/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/foo-bar/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpointWithSubscriptions()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+            options.Path = "/bar";
+            options.GraphQLEndpoint = new Uri("https://microsoft.com/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/bar/settings.js";
 
             // act
             string settings_js = await GetSettingsAsync(server, settingsUri);

--- a/src/Server/AspNetCore.Tests/Playground/PlaygroundOptionsTests.cs
+++ b/src/Server/AspNetCore.Tests/Playground/PlaygroundOptionsTests.cs
@@ -17,6 +17,7 @@ namespace HotChocolate.AspNetCore
             Assert.Equal("/playground", options.Path);
             Assert.Equal("/", options.QueryPath);
             Assert.Equal("/", options.SubscriptionPath);
+            Assert.Null(options.GraphQLEndpoint);
         }
 
         [Fact]
@@ -32,6 +33,19 @@ namespace HotChocolate.AspNetCore
             Assert.Equal("/foo", options.Path);
             Assert.Equal("/", options.QueryPath);
             Assert.Equal("/", options.SubscriptionPath);
+        }
+
+        [Fact]
+        public void SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+
+            // act
+            options.GraphQLEndpoint = new Uri("https://localhost:5000/graphql");
+
+            // act
+            Assert.Equal("https://localhost:5000/graphql", options.GraphQLEndpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -165,6 +179,21 @@ namespace HotChocolate.AspNetCore
 
             // act
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void GraphQLEndpoint_Set_To_Null_Or_Invalid_Exceptions()
+        {
+            // arrange
+            var options = new PlaygroundOptions();
+
+            // act
+            Action invalidUriAction = () => options.GraphQLEndpoint = new Uri("not a uri");
+            Action nullUriAction = () => options.GraphQLEndpoint = new Uri(null);
+
+            // act
+            Assert.Throws<UriFormatException>(invalidUriAction);
+            Assert.Throws<ArgumentNullException>(nullUriAction);
         }
     }
 }

--- a/src/Server/AspNetCore.Tests/Playground/__snapshots__/PlaygroundMiddlewareTests.SetGraphQLEndpoint.snap
+++ b/src/Server/AspNetCore.Tests/Playground/__snapshots__/PlaygroundMiddlewareTests.SetGraphQLEndpoint.snap
@@ -1,0 +1,6 @@
+﻿
+                window.Settings = {
+                    url: "https://hotchocolate.io/graphql",
+                    subscriptionUrl: null,
+                }
+            

--- a/src/Server/AspNetCore.Tests/Playground/__snapshots__/PlaygroundMiddlewareTests.SetGraphQLEndpointWithSubscriptions.snap
+++ b/src/Server/AspNetCore.Tests/Playground/__snapshots__/PlaygroundMiddlewareTests.SetGraphQLEndpointWithSubscriptions.snap
@@ -1,0 +1,6 @@
+﻿
+                window.Settings = {
+                    url: "https://microsoft.com/graphql",
+                    subscriptionUrl: "wss://microsoft.com/graphql",
+                }
+            

--- a/src/Server/AspNetCore.Tests/Voyager/VoyagerMiddlewareTests.cs
+++ b/src/Server/AspNetCore.Tests/Voyager/VoyagerMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Snapshooter.Xunit;
 using Xunit;
 using HotChocolate.AspNetCore.Tests.Utilities;
 using HotChocolate.AspNetCore.Voyager;
+using System;
 
 namespace HotChocolate.AspNetCore
 {
@@ -41,6 +42,24 @@ namespace HotChocolate.AspNetCore
 
             TestServer server = CreateServer(options);
             string settingsUri = "/foo/settings.js";
+
+            // act
+            string settings_js = await GetSettingsAsync(server, settingsUri);
+
+            // act
+            settings_js.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+            options.Path = "/foo-bar";
+            options.GraphQLEndpoint = new Uri("https://github.com/graphql");
+
+            TestServer server = CreateServer(options);
+            string settingsUri = "/foo-bar/settings.js";
 
             // act
             string settings_js = await GetSettingsAsync(server, settingsUri);

--- a/src/Server/AspNetCore.Tests/Voyager/VoyagerOptionsTests.cs
+++ b/src/Server/AspNetCore.Tests/Voyager/VoyagerOptionsTests.cs
@@ -16,6 +16,7 @@ namespace HotChocolate.AspNetCore
             // act
             Assert.Equal("/voyager", options.Path);
             Assert.Equal("/", options.QueryPath);
+            Assert.Null(options.GraphQLEndpoint);
         }
 
         [Fact]
@@ -30,6 +31,19 @@ namespace HotChocolate.AspNetCore
             // act
             Assert.Equal("/foo", options.Path);
             Assert.Equal("/", options.QueryPath);
+        }
+
+        [Fact]
+        public void SetGraphQLEndpoint()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+
+            // act
+            options.GraphQLEndpoint = new Uri("https://localhost:8081/graphql");
+
+            // act
+            Assert.Equal("https://localhost:8081/graphql", options.GraphQLEndpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -100,6 +114,21 @@ namespace HotChocolate.AspNetCore
 
             // act
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        public void GraphQLEndpoint_Set_To_Null_Or_Invalid_Exceptions()
+        {
+            // arrange
+            var options = new VoyagerOptions();
+
+            // act
+            Action invalidAction = () => options.GraphQLEndpoint = new Uri("not valid");
+            Action nullAction = () => options.GraphQLEndpoint = new Uri(null);
+
+            // act
+            Assert.Throws<UriFormatException>(invalidAction);
+            Assert.Throws<ArgumentNullException>(nullAction);
         }
     }
 }

--- a/src/Server/AspNetCore.Tests/Voyager/__snapshots__/VoyagerMiddlewareTests.SetGraphQLEndpoint.snap
+++ b/src/Server/AspNetCore.Tests/Voyager/__snapshots__/VoyagerMiddlewareTests.SetGraphQLEndpoint.snap
@@ -1,0 +1,5 @@
+﻿
+                window.Settings = {
+                    url: "https://github.com/graphql",
+                }
+            

--- a/src/Server/AspNetCore.Voyager/SettingsMiddleware.cs
+++ b/src/Server/AspNetCore.Voyager/SettingsMiddleware.cs
@@ -60,8 +60,9 @@ namespace HotChocolate.AspNetCore.Voyager
         public async Task InvokeAsync(HttpContext context)
 #endif
         {
-            string queryUrl = BuildUrl(context.Request, _queryPath);
-           
+            string queryUrl = _options.GraphQLEndpoint?.AbsoluteUri
+                 ?? BuildUrl(context.Request, _queryPath);
+
             context.Response.ContentType = "application/javascript";
 
             await context.Response.WriteAsync($@"

--- a/src/Server/AspNetCore.Voyager/VoyagerOptions.cs
+++ b/src/Server/AspNetCore.Voyager/VoyagerOptions.cs
@@ -18,6 +18,8 @@ namespace HotChocolate.AspNetCore.Voyager
         private PathString _path = new PathString("/voyager");
         private PathString _queryPath = new PathString("/");
 
+        public Uri GraphQLEndpoint { get; set; }
+
         public PathString Path
         {
             get => _path;


### PR DESCRIPTION
Adds ability to specify a GraphQL endpoint for GraphiQL, Playground and Voyager:

```
app.UseGraphiQL(new GraphiQLOptions() 
{
    GraphQLEndpoint = new Uri("https://hotchocolate.io/graphql")
});
```
```
app.UsePlayground(new PlaygroundOptions() 
{
    GraphQLEndpoint = new Uri( "https://hotchocolate.io/graphql"
});
```
```
app.UseVoyager(new VoyagerOptions() 
{
    GraphQLEndpoint = new Uri( "https://hotchocolate.io/graphql")
});
```

Addresses #906