### PR TITLE
Invalid GraphQL requests lead to System.IndexOutOfRangeException.

### DIFF
--- a/src/HotChocolate/Language/src/Language/Parser/ThrowHelper.cs
+++ b/src/HotChocolate/Language/src/Language/Parser/ThrowHelper.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Globalization;
+
+namespace HotChocolate.Language
+{
+    public static class ThrowHelper
+    {
+        // TODO : resources
+        public static void InvalidRequestStructure(Utf8GraphQLReader reader) =>
+            throw new SyntaxException(
+                reader,
+                "Expected `{` or `[` as first syntax token.");
+
+        // TODO : resources
+        public static void NoIdAndNoQuery(Utf8GraphQLReader reader) =>
+            throw new SyntaxException(
+                reader,
+                "The request is missing the `query` property and the `id` property.");
+
+        // TODO : resources
+        public static void QueryMustBeStringOrNull(Utf8GraphQLReader reader) =>
+            throw new SyntaxException(
+                reader,
+                "The query field must be a string or null.");
+
+
+        // TODO : resources
+        public static void UnexpectedProperty(
+            Utf8GraphQLReader reader,
+            ReadOnlySpan<byte> fieldName) =>
+            throw new SyntaxException(
+                reader,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Unexpected request property name `{0}` found.",
+                    Utf8GraphQLReader.GetString(fieldName, false)));
+    }
+}

--- a/src/HotChocolate/Language/src/Language/Parser/ThrowHelper.cs
+++ b/src/HotChocolate/Language/src/Language/Parser/ThrowHelper.cs
@@ -23,7 +23,6 @@ namespace HotChocolate.Language
                 reader,
                 "The query field must be a string or null.");
 
-
         // TODO : resources
         public static void UnexpectedProperty(
             Utf8GraphQLReader reader,

--- a/src/HotChocolate/Language/src/Language/Parser/Utf8GraphQLRequestParser.Request.cs
+++ b/src/HotChocolate/Language/src/Language/Parser/Utf8GraphQLRequestParser.Request.cs
@@ -9,7 +9,7 @@ namespace HotChocolate.Language
         {
             public string? OperationName { get; set; }
 
-            public string? QueryName { get; set; }
+            public string? QueryId { get; set; }
 
             public string? QueryHash { get; set; }
 

--- a/src/HotChocolate/Language/src/Language/Parser/Utf8Helper.cs
+++ b/src/HotChocolate/Language/src/Language/Parser/Utf8Helper.cs
@@ -19,7 +19,8 @@ namespace HotChocolate.Language
             int writePosition = 0;
             int eofPosition = escapedString.Length - 1;
 
-            if (escapedString.Length > 0) {
+            if (escapedString.Length > 0)
+            {
                 do
                 {
                     byte code = escapedString[++readPosition];
@@ -28,21 +29,15 @@ namespace HotChocolate.Language
                     {
                         code = escapedString[++readPosition];
 
-                        if (isBlockString
-                             && code == GraphQLConstants.Quote)
+                        if (isBlockString && code == GraphQLConstants.Quote)
                         {
-                            if (escapedString[readPosition + 1] ==
-                                GraphQLConstants.Quote
-                                && escapedString[readPosition + 2] ==
-                                GraphQLConstants.Quote)
+                            if (escapedString[readPosition + 1] == GraphQLConstants.Quote
+                                && escapedString[readPosition + 2] == GraphQLConstants.Quote)
                             {
                                 readPosition += 2;
-                                unescapedString[writePosition++] =
-                                    GraphQLConstants.Quote;
-                                unescapedString[writePosition++] =
-                                    GraphQLConstants.Quote;
-                                unescapedString[writePosition++] =
-                                    GraphQLConstants.Quote;
+                                unescapedString[writePosition++] = GraphQLConstants.Quote;
+                                unescapedString[writePosition++] = GraphQLConstants.Quote;
+                                unescapedString[writePosition++] = GraphQLConstants.Quote;
                             }
                             else
                             {
@@ -61,7 +56,6 @@ namespace HotChocolate.Language
                                     escapedString[++readPosition],
                                     ref writePosition,
                                     ref unescapedString);
-
                             }
                             else
                             {

--- a/src/HotChocolate/Language/src/Language/Parser/Utf8Helper.cs
+++ b/src/HotChocolate/Language/src/Language/Parser/Utf8Helper.cs
@@ -19,66 +19,68 @@ namespace HotChocolate.Language
             int writePosition = 0;
             int eofPosition = escapedString.Length - 1;
 
-            do
-            {
-                byte code = escapedString[++readPosition];
-
-                if (code == GraphQLConstants.Backslash)
+            if (escapedString.Length > 0) {
+                do
                 {
-                    code = escapedString[++readPosition];
+                    byte code = escapedString[++readPosition];
 
-                    if (isBlockString
-                         && code == GraphQLConstants.Quote)
+                    if (code == GraphQLConstants.Backslash)
                     {
-                        if (escapedString[readPosition + 1] ==
-                            GraphQLConstants.Quote
-                            && escapedString[readPosition + 2] ==
-                            GraphQLConstants.Quote)
+                        code = escapedString[++readPosition];
+
+                        if (isBlockString
+                             && code == GraphQLConstants.Quote)
                         {
-                            readPosition += 2;
-                            unescapedString[writePosition++] =
-                                GraphQLConstants.Quote;
-                            unescapedString[writePosition++] =
-                                GraphQLConstants.Quote;
-                            unescapedString[writePosition++] =
-                                GraphQLConstants.Quote;
+                            if (escapedString[readPosition + 1] ==
+                                GraphQLConstants.Quote
+                                && escapedString[readPosition + 2] ==
+                                GraphQLConstants.Quote)
+                            {
+                                readPosition += 2;
+                                unescapedString[writePosition++] =
+                                    GraphQLConstants.Quote;
+                                unescapedString[writePosition++] =
+                                    GraphQLConstants.Quote;
+                                unescapedString[writePosition++] =
+                                    GraphQLConstants.Quote;
+                            }
+                            else
+                            {
+                                throw new Utf8EncodingException(
+                                    LangResources.Utf8Helper_InvalidQuoteEscapeCount);
+                            }
+                        }
+                        else if (GraphQLConstants.IsValidEscapeCharacter(code))
+                        {
+                            if (code == GraphQLConstants.U)
+                            {
+                                UnescapeUtf8Hex(
+                                    escapedString[++readPosition],
+                                    escapedString[++readPosition],
+                                    escapedString[++readPosition],
+                                    escapedString[++readPosition],
+                                    ref writePosition,
+                                    ref unescapedString);
+
+                            }
+                            else
+                            {
+                                unescapedString[writePosition++] =
+                                    GraphQLConstants.EscapeCharacter(code);
+                            }
                         }
                         else
                         {
                             throw new Utf8EncodingException(
-                                LangResources.Utf8Helper_InvalidQuoteEscapeCount);
-                        }
-                    }
-                    else if (GraphQLConstants.IsValidEscapeCharacter(code))
-                    {
-                        if (code == GraphQLConstants.U)
-                        {
-                            UnescapeUtf8Hex(
-                                escapedString[++readPosition],
-                                escapedString[++readPosition],
-                                escapedString[++readPosition],
-                                escapedString[++readPosition],
-                                ref writePosition,
-                                ref unescapedString);
-
-                        }
-                        else
-                        {
-                            unescapedString[writePosition++] =
-                                GraphQLConstants.EscapeCharacter(code);
+                                LangResources.Utf8Helper_InvalidEscapeChar);
                         }
                     }
                     else
                     {
-                        throw new Utf8EncodingException(
-                            LangResources.Utf8Helper_InvalidEscapeChar);
+                        unescapedString[writePosition++] = code;
                     }
-                }
-                else
-                {
-                    unescapedString[writePosition++] = code;
-                }
-            } while (readPosition < eofPosition);
+                } while (readPosition < eofPosition);
+            }
 
             int length = unescapedString.Length - writePosition;
             if (length > 0)

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8GraphQLRequestParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8GraphQLRequestParserTests.cs
@@ -464,6 +464,26 @@ namespace HotChocolate.Language
         }
 
         [Fact]
+        public void Parse_Invalid_Query()
+        {
+            // arrange
+            byte[] source = Encoding.UTF8.GetBytes("{\"query\":\"\"}"
+                    .NormalizeLineBreaks());
+
+            var parserOptions = new ParserOptions();
+            var requestParser = new Utf8GraphQLRequestParser(
+                source,
+                parserOptions,
+                new DocumentCache(),
+                new Sha256DocumentHashProvider());
+
+            // act
+            requestParser.Parse();
+            
+            // assert
+        }
+
+        [Fact]
         public void Parse_Apollo_AQP_SignatureQuery_Variables_Without_Values()
         {
             // arrange

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8GraphQLRequestParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8GraphQLRequestParserTests.cs
@@ -548,11 +548,77 @@ namespace HotChocolate.Language
         public void Parse_Invalid_Query()
         {
             // assert
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<SyntaxException>(
                 () =>
                 {
                     // arrange
                     byte[] source = Encoding.UTF8.GetBytes("{\"query\":\"\"}"
+                        .NormalizeLineBreaks());
+                    var parserOptions = new ParserOptions();
+                    var requestParser = new Utf8GraphQLRequestParser(
+                        source,
+                        parserOptions,
+                        new DocumentCache(),
+                        new Sha256DocumentHashProvider());
+
+                    // act
+                    requestParser.Parse();
+                });
+        }
+
+        [Fact]
+        public void Parse_Empty_Json()
+        {
+            // assert
+            Assert.Throws<SyntaxException>(
+                () =>
+                {
+                    // arrange
+                    byte[] source = Encoding.UTF8.GetBytes("{ }"
+                        .NormalizeLineBreaks());
+                    var parserOptions = new ParserOptions();
+                    var requestParser = new Utf8GraphQLRequestParser(
+                        source,
+                        parserOptions,
+                        new DocumentCache(),
+                        new Sha256DocumentHashProvider());
+
+                    // act
+                    requestParser.Parse();
+                });
+        }
+
+        [Fact]
+        public void Parse_Empty_String()
+        {
+            // assert
+            Assert.Throws<ArgumentException>(
+                () =>
+                {
+                    // arrange
+                    byte[] source = Encoding.UTF8.GetBytes(""
+                        .NormalizeLineBreaks());
+                    var parserOptions = new ParserOptions();
+                    var requestParser = new Utf8GraphQLRequestParser(
+                        source,
+                        parserOptions,
+                        new DocumentCache(),
+                        new Sha256DocumentHashProvider());
+
+                    // act
+                    requestParser.Parse();
+                });
+        }
+
+        [Fact]
+        public void Parse_Space_String()
+        {
+            // assert
+            Assert.Throws<SyntaxException>(
+                () =>
+                {
+                    // arrange
+                    byte[] source = Encoding.UTF8.GetBytes(" "
                         .NormalizeLineBreaks());
                     var parserOptions = new ParserOptions();
                     var requestParser = new Utf8GraphQLRequestParser(

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8GraphQLRequestParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8GraphQLRequestParserTests.cs
@@ -464,26 +464,6 @@ namespace HotChocolate.Language
         }
 
         [Fact]
-        public void Parse_Invalid_Query()
-        {
-            // arrange
-            byte[] source = Encoding.UTF8.GetBytes("{\"query\":\"\"}"
-                    .NormalizeLineBreaks());
-
-            var parserOptions = new ParserOptions();
-            var requestParser = new Utf8GraphQLRequestParser(
-                source,
-                parserOptions,
-                new DocumentCache(),
-                new Sha256DocumentHashProvider());
-
-            // act
-            requestParser.Parse();
-            
-            // assert
-        }
-
-        [Fact]
         public void Parse_Apollo_AQP_SignatureQuery_Variables_Without_Values()
         {
             // arrange
@@ -562,6 +542,28 @@ namespace HotChocolate.Language
 
             // assert
             obj.MatchSnapshot();
+        }
+
+        [Fact]
+        public void Parse_Invalid_Query()
+        {
+            // assert
+            Assert.Throws<ArgumentException>(
+                () =>
+                {
+                    // arrange
+                    byte[] source = Encoding.UTF8.GetBytes("{\"query\":\"\"}"
+                        .NormalizeLineBreaks());
+                    var parserOptions = new ParserOptions();
+                    var requestParser = new Utf8GraphQLRequestParser(
+                        source,
+                        parserOptions,
+                        new DocumentCache(),
+                        new Sha256DocumentHashProvider());
+
+                    // act
+                    requestParser.Parse();
+                });
         }
 
         private class GraphQLRequestDto


### PR DESCRIPTION
Just stumbled upon this one.
Posting the invalid  query `{"query":""}` causes the following exception:
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at HotChocolate.Language.Utf8Helper.Unescape(ReadOnlySpan`1& escapedString, Span`1& unescapedString, Boolean isBlockString)
   at HotChocolate.Language.Utf8GraphQLRequestParser.ParseQuery(Request& request)
   at HotChocolate.Language.Utf8GraphQLRequestParser.ParseRequest()
   at HotChocolate.Language.Utf8GraphQLRequestParser.Parse()
   at HotChocolate.Server.RequestHelper.ParseRequest(Byte[] buffer, Int32 bytesBuffered)
   at HotChocolate.Server.RequestHelper.<>c__DisplayClass8_0.<ReadAsync>b__0(Byte[] buffer, Int32 bytesBuffered)
   at HotChocolate.Utilities.BufferHelper.ReadAsync[T](Stream stream, Func`3 handle, Action`1 checkSize, CancellationToken cancellationToken)
   at HotChocolate.AspNetCore.HttpPostMiddleware.ReadRequestAsync(HttpContext context)
   at HotChocolate.AspNetCore.HttpPostMiddleware.ExecuteRequestAsync(HttpContext context, IServiceProvider services)
   at HotChocolate.AspNetCore.QueryMiddlewareBase.HandleRequestAsync(HttpContext context)
   at HotChocolate.AspNetCore.QueryMiddlewareBase.InvokeAsync(HttpContext context)
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
```
I'm not sure what the correct behaviour should be here, but the `IndexOutOfRangeException` is probably not optimal. Maybe this is also an "only on my machine" problem.

- Check for `escapedString.Length > 0` in `Utf8Helper.cs`
- Add a test case `Parse_Invalid_Query` with the failing query

The fix is only to make the test pass, I don't  know at which stage during parsing the actual problem occurs.

I won't have time to pursue this any further, so feel free to reject this PR and handle it correctly.
Best regards, Robin

**Edit**: For clarification , this is what the Request looks like:
```
POST /api HTTP/2
Host: localhost:5001
user-agent: insomnia/7.1.1
content-type: application/json
accept: */*
content-length: 12

{"query":""}`
```