### PR TITLE
Fixed leaf type handling for included ByteArray type

### DIFF
--- a/src/StrawberryShake/CodeGeneration/src/Generators/CSharp/TypeLookup.cs
+++ b/src/StrawberryShake/CodeGeneration/src/Generators/CSharp/TypeLookup.cs
@@ -45,7 +45,7 @@ namespace StrawberryShake.Generators.CSharp
             {
                 new LeafTypeInfo("String", typeof(string), typeof(string)),
                 new LeafTypeInfo("Byte", typeof(byte), typeof(byte)),
-                //new LeafTypeInfo("ByteArray", typeof(byte[]), typeof(string)),
+                new LeafTypeInfo("ByteArray", typeof(byte[]), typeof(string)),
                 new LeafTypeInfo("Short", typeof(short), typeof(short)),
                 new LeafTypeInfo("Int", typeof(int), typeof(int)),
                 new LeafTypeInfo("Long", typeof(long), typeof(long)),

--- a/src/StrawberryShake/CodeGeneration/src/Generators/CSharp/TypeLookup.cs
+++ b/src/StrawberryShake/CodeGeneration/src/Generators/CSharp/TypeLookup.cs
@@ -45,6 +45,7 @@ namespace StrawberryShake.Generators.CSharp
             {
                 new LeafTypeInfo("String", typeof(string), typeof(string)),
                 new LeafTypeInfo("Byte", typeof(byte), typeof(byte)),
+                //new LeafTypeInfo("ByteArray", typeof(byte[]), typeof(string)),
                 new LeafTypeInfo("Short", typeof(short), typeof(short)),
                 new LeafTypeInfo("Int", typeof(int), typeof(int)),
                 new LeafTypeInfo("Long", typeof(long), typeof(long)),

--- a/src/StrawberryShake/CodeGeneration/src/Generators/ClientGenerator.cs
+++ b/src/StrawberryShake/CodeGeneration/src/Generators/ClientGenerator.cs
@@ -41,6 +41,7 @@ namespace StrawberryShake.Generators
                 new LeafTypeInfo(ScalarNames.Date, typeof(DateTime), typeof(string)),
                 new LeafTypeInfo(ScalarNames.DateTime, typeof(DateTimeOffset), typeof(string)),
                 new LeafTypeInfo(ScalarNames.Byte, typeof(byte) , typeof(byte)),
+                //new LeafTypeInfo(ScalarNames.ByteArray, typeof(byte[]) , typeof(string)),
                 new LeafTypeInfo(ScalarNames.Short, typeof(short)),
                 new LeafTypeInfo(ScalarNames.Long, typeof(long)),
                 new LeafTypeInfo(ScalarNames.Decimal, typeof(decimal), typeof(decimal)),

--- a/src/StrawberryShake/CodeGeneration/src/Generators/ClientGenerator.cs
+++ b/src/StrawberryShake/CodeGeneration/src/Generators/ClientGenerator.cs
@@ -41,7 +41,7 @@ namespace StrawberryShake.Generators
                 new LeafTypeInfo(ScalarNames.Date, typeof(DateTime), typeof(string)),
                 new LeafTypeInfo(ScalarNames.DateTime, typeof(DateTimeOffset), typeof(string)),
                 new LeafTypeInfo(ScalarNames.Byte, typeof(byte) , typeof(byte)),
-                //new LeafTypeInfo(ScalarNames.ByteArray, typeof(byte[]) , typeof(string)),
+                new LeafTypeInfo(ScalarNames.ByteArray, typeof(byte[]) , typeof(string)),
                 new LeafTypeInfo(ScalarNames.Short, typeof(short)),
                 new LeafTypeInfo(ScalarNames.Long, typeof(long)),
                 new LeafTypeInfo(ScalarNames.Decimal, typeof(decimal), typeof(decimal)),

--- a/src/StrawberryShake/CodeGeneration/test/Generators.Tests/ClientGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/Generators.Tests/ClientGeneratorTests.cs
@@ -97,7 +97,6 @@ namespace StrawberryShake.Generators
             outputHandler.Content.MatchSnapshot();
         }
 
-
         [Fact]
         public async Task Two_Nullable_Scalar_Arguments()
         {
@@ -480,6 +479,42 @@ namespace StrawberryShake.Generators
                 query getFoo($input1: FooInput! $input2: FooInput!) {
                     a: foo(input: $input1)
                     b: foo(input: $input2)
+                }
+                ";
+
+            // act
+            await ClientGenerator.New()
+                .AddQueryDocumentFromString("Queries", query)
+                .AddSchemaDocumentFromString("Schema", schema)
+                .SetOutput(outputHandler)
+                .BuildAsync();
+
+            // assert
+            outputHandler.Content.MatchSnapshot();
+        }
+        
+        [Fact]
+        public async Task Known_ByteArray_Scalar_Types()
+        {
+            // arrange
+            var outputHandler = new TestOutputHandler();
+
+            string schema = @"
+                type Query {
+                    foo: Foo
+                }
+
+                type Foo {
+                    bar: ByteArray
+                }
+                ";
+
+            string query =
+               @"
+                query getBars {
+                    foo {
+                        bar
+                    }
                 }
                 ";
 

--- a/src/StrawberryShake/CodeGeneration/test/Generators.Tests/__snapshots__/ClientGeneratorTests.Known_ByteArray_Scalar_Types.snap
+++ b/src/StrawberryShake/CodeGeneration/test/Generators.Tests/__snapshots__/ClientGeneratorTests.Known_ByteArray_Scalar_Types.snap
@@ -1,0 +1,295 @@
+﻿﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using StrawberryShake;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public partial class GetBars
+        : IGetBars
+    {
+        public GetBars(
+            global::StrawberryShake.Client.IFoo? foo)
+        {
+            Foo = foo;
+        }
+
+        public global::StrawberryShake.Client.IFoo? Foo { get; }
+    }
+}
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using StrawberryShake;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public partial class Foo
+        : IFoo
+    {
+        public Foo(
+            System.Byte[]? bar)
+        {
+            Bar = bar;
+        }
+
+        public System.Byte[]? Bar { get; }
+    }
+}
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using StrawberryShake;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public partial interface IGetBars
+    {
+        global::StrawberryShake.Client.IFoo? Foo { get; }
+    }
+}
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using StrawberryShake;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public partial interface IFoo
+    {
+        System.Byte[]? Bar { get; }
+    }
+}
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using StrawberryShake;
+using StrawberryShake.Configuration;
+using StrawberryShake.Http;
+using StrawberryShake.Http.Subscriptions;
+using StrawberryShake.Transport;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public partial class GetBarsResultParser
+        : JsonResultParserBase<IGetBars>
+    {
+        private readonly IValueSerializer _byteArraySerializer;
+
+        public GetBarsResultParser(IValueSerializerCollection serializerResolver)
+        {
+            if (serializerResolver is null)
+            {
+                throw new ArgumentNullException(nameof(serializerResolver));
+            }
+            _byteArraySerializer = serializerResolver.Get("ByteArray");
+        }
+
+        protected override IGetBars ParserData(JsonElement data)
+        {
+            return new GetBars
+            (
+                ParseGetBarsFoo(data, "foo")
+            );
+
+        }
+
+        private global::StrawberryShake.Client.IFoo? ParseGetBarsFoo(
+            JsonElement parent,
+            string field)
+        {
+            if (!parent.TryGetProperty(field, out JsonElement obj))
+            {
+                return null;
+            }
+
+            if (obj.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+
+            return new Foo
+            (
+                DeserializeNullableByteArray(obj, "bar")
+            );
+        }
+
+        private System.Byte[]? DeserializeNullableByteArray(JsonElement obj, string fieldName)
+        {
+            if (!obj.TryGetProperty(fieldName, out JsonElement value))
+            {
+                return null;
+            }
+
+            if (value.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+
+            return (System.Byte[]?)_byteArraySerializer.Deserialize(value.GetString())!;
+        }
+    }
+}
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using StrawberryShake;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public partial class GetBarsOperation
+        : IOperation<IGetBars>
+    {
+        public string Name => "getBars";
+
+        public IDocument Document => Queries.Default;
+
+        public OperationKind Kind => OperationKind.Query;
+
+        public Type ResultType => typeof(IGetBars);
+
+        public IReadOnlyList<VariableValue> GetVariableValues()
+        {
+            return Array.Empty<VariableValue>();
+        }
+    }
+}
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using StrawberryShake;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public partial interface ISchemaClient
+    {
+        Task<IOperationResult<global::StrawberryShake.Client.IGetBars>> GetBarsAsync(
+            CancellationToken cancellationToken = default);
+
+        Task<IOperationResult<global::StrawberryShake.Client.IGetBars>> GetBarsAsync(
+            GetBarsOperation operation,
+            CancellationToken cancellationToken = default);
+    }
+}
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using StrawberryShake;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public partial class SchemaClient
+        : ISchemaClient
+    {
+        private const string _clientName = "SchemaClient";
+
+        private readonly global::StrawberryShake.IOperationExecutor _executor;
+
+        public SchemaClient(global::StrawberryShake.IOperationExecutorPool executorPool)
+        {
+            _executor = executorPool.CreateExecutor(_clientName);
+        }
+
+        public global::System.Threading.Tasks.Task<global::StrawberryShake.IOperationResult<global::StrawberryShake.Client.IGetBars>> GetBarsAsync(
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+
+            return _executor.ExecuteAsync(
+                new GetBarsOperation(),
+                cancellationToken);
+        }
+
+        public global::System.Threading.Tasks.Task<global::StrawberryShake.IOperationResult<global::StrawberryShake.Client.IGetBars>> GetBarsAsync(
+            GetBarsOperation operation,
+            global::System.Threading.CancellationToken cancellationToken = default)
+        {
+            if (operation is null)
+            {
+                throw new ArgumentNullException(nameof(operation));
+            }
+
+            return _executor.ExecuteAsync(operation, cancellationToken);
+        }
+    }
+}
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using StrawberryShake;
+using StrawberryShake.Configuration;
+using StrawberryShake.Http;
+using StrawberryShake.Http.Pipelines;
+using StrawberryShake.Http.Subscriptions;
+using StrawberryShake.Serializers;
+using StrawberryShake.Transport;
+
+namespace StrawberryShake.Client
+{
+    [System.CodeDom.Compiler.GeneratedCode("StrawberryShake", "11.0.0")]
+    public static partial class SchemaClientServiceCollectionExtensions
+    {
+        private const string _clientName = "SchemaClient";
+
+        public static IOperationClientBuilder AddSchemaClient(
+            this IServiceCollection serviceCollection)
+        {
+            if (serviceCollection is null)
+            {
+                throw new ArgumentNullException(nameof(serviceCollection));
+            }
+
+            serviceCollection.AddSingleton<ISchemaClient, SchemaClient>();
+
+            serviceCollection.AddSingleton<IOperationExecutorFactory>(sp =>
+                new HttpOperationExecutorFactory(
+                    _clientName,
+                    sp.GetRequiredService<IHttpClientFactory>().CreateClient,
+                    sp.GetRequiredService<IClientOptions>().GetOperationPipeline<IHttpOperationContext>(_clientName),
+                    sp.GetRequiredService<IClientOptions>().GetOperationFormatter(_clientName),
+                    sp.GetRequiredService<IClientOptions>().GetResultParsers(_clientName)));
+
+            IOperationClientBuilder builder = serviceCollection.AddOperationClientOptions(_clientName)
+                .AddResultParser(serializers => new GetBarsResultParser(serializers))
+                .AddOperationFormatter(serializers => new JsonOperationFormatter(serializers))
+                .AddHttpOperationPipeline(builder => builder.UseHttpDefaultPipeline());
+
+            serviceCollection.TryAddSingleton<IOperationExecutorPool, OperationExecutorPool>();
+            return builder;
+        }
+
+    }
+}
+
+


### PR DESCRIPTION
Using the newly included ByteArray type caused an error when it was used as a leaf type.

Example:
```
    type Query {
        foo: Foo
    }
    type Foo {
        bar: ByteArray
    }
    query getBars {
        foo {
            bar
        }
    }
```

Caused error:
System.NotSupportedException : Leaf type `ByteArray` is not supported.

Summary of the changes:
- Added ByteArray to list of leaf types