### PR TITLE
Added overloads to Field methods with propertyOrMethod and name param…

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IObjectTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IObjectTypeDescriptor~1.cs
@@ -147,6 +147,19 @@ namespace HotChocolate.Types
         /// <summary>
         /// Specifies an object type field.
         /// </summary>
+        /// <param name="propertyOrMethod">
+        /// An expression selecting a property or method of
+        /// <typeparamref name="T"/>.
+        /// </param>
+        /// <param name="name">
+        /// The name that the field shall have.
+        /// </param>
+        IObjectFieldDescriptor Field<TValue>(
+            Expression<Func<T, TValue>> propertyOrMethod, NameString name);
+
+        /// <summary>
+        /// Specifies an object type field.
+        /// </summary>
         /// <param name="name">
         /// The name that the field shall have.
         /// </param>
@@ -162,6 +175,20 @@ namespace HotChocolate.Types
         /// </param>
         IObjectFieldDescriptor Field<TResolver>(
             Expression<Func<TResolver, object>> propertyOrMethod);
+
+        /// <summary>
+        /// Specifies an object type field which is bound to a resolver type.
+        /// </summary>
+        /// <param name="propertyOrMethod">
+        /// An expression selecting a property or method of
+        /// <typeparamref name="TResolver"/>.
+        /// The resolver type containing the property or method.
+        /// </param>
+        /// <param name="name">
+        /// The name that the field shall have.
+        /// </param>
+        IObjectFieldDescriptor Field<TResolver>(
+            Expression<Func<TResolver, object>> propertyOrMethod, NameString name);
 
         IObjectTypeDescriptor<T> Directive<TDirective>(
             TDirective directiveInstance)

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -250,8 +250,26 @@ namespace HotChocolate.Types.Descriptors
             Expression<Func<TResolver, object>> propertyOrMethod) =>
             Field<TResolver, object>(propertyOrMethod);
 
+        public IObjectFieldDescriptor Field<TResolver>(
+            Expression<Func<TResolver, object>> propertyOrMethod, NameString name) =>
+            Field<TResolver, object>(propertyOrMethod, name);
+
         public IObjectFieldDescriptor Field<TResolver, TPropertyType>(
             Expression<Func<TResolver, TPropertyType>> propertyOrMethod)
+        {
+            return FieldImpl(propertyOrMethod,
+                member => Fields.FirstOrDefault(t => t.Definition.Member == member));
+        }
+
+        public IObjectFieldDescriptor Field<TResolver, TPropertyType>(
+            Expression<Func<TResolver, TPropertyType>> propertyOrMethod, NameString name)
+        {
+            return FieldImpl(propertyOrMethod,
+                member => Fields.FirstOrDefault(t => t.Definition.Name.Equals(name)));
+        }
+
+        private IObjectFieldDescriptor FieldImpl<TResolver, TPropertyType>(
+            Expression<Func<TResolver, TPropertyType>> propertyOrMethod, Func<MemberInfo, ObjectFieldDescriptor> fieldDescriptorResolver)
         {
             if (propertyOrMethod == null)
             {
@@ -262,7 +280,7 @@ namespace HotChocolate.Types.Descriptors
             if (member is PropertyInfo || member is MethodInfo)
             {
                 ObjectFieldDescriptor fieldDescriptor =
-                    Fields.FirstOrDefault(t => t.Definition.Member == member);
+                    fieldDescriptorResolver(member);
                 if (fieldDescriptor is { })
                 {
                     return fieldDescriptor;

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptorBase~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptorBase~1.cs
@@ -129,6 +129,11 @@ namespace HotChocolate.Types.Descriptors
             return base.Field(propertyOrMethod);
         }
 
+        public IObjectFieldDescriptor Field<TValue>(Expression<Func<T, TValue>> propertyOrMethod, NameString name)
+        {
+            return base.Field(propertyOrMethod, name);
+        }
+
         public new IObjectTypeDescriptor<T> Directive<TDirective>(
             TDirective directiveInstance)
             where TDirective : class

--- a/src/HotChocolate/HotChocolate.sln
+++ b/src/HotChocolate/HotChocolate.sln
@@ -155,6 +155,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.AspNetCore.Voy
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.Server", "AspNetCore\src\Server\HotChocolate.Server.csproj", "{2C459591-6C38-43AB-A5D1-EF0A219C6488}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreenDonut", "..\GreenDonut\src\Core\GreenDonut.csproj", "{7FB675AE-6805-4A99-AC74-2E43836A2D0C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -789,6 +791,18 @@ Global
 		{2C459591-6C38-43AB-A5D1-EF0A219C6488}.Release|x64.Build.0 = Release|Any CPU
 		{2C459591-6C38-43AB-A5D1-EF0A219C6488}.Release|x86.ActiveCfg = Release|Any CPU
 		{2C459591-6C38-43AB-A5D1-EF0A219C6488}.Release|x86.Build.0 = Release|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Debug|x64.Build.0 = Debug|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Debug|x86.Build.0 = Debug|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Release|x64.ActiveCfg = Release|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Release|x64.Build.0 = Release|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Release|x86.ActiveCfg = Release|Any CPU
+		{7FB675AE-6805-4A99-AC74-2E43836A2D0C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Added some overloads to the Field method on the object type descriptors to allow using the same underlying property/method multiple times in a type configuration.

_This seemed like a simple, non intrusive way to get passed the issue I was having which was using the same method multiple times for different fields._
