### PR TITLE
Uses C# compiler's ability to refer to static data directly.

### DIFF
--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLRequestParser.Constants.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLRequestParser.Constants.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace HotChocolate.Language
 {
     public ref partial struct Utf8GraphQLRequestParser
@@ -11,7 +13,8 @@ namespace HotChocolate.Language
         private const byte _i = (byte)'i';
         private const byte _p = (byte)'p';
 
-        private static readonly byte[] _operationName = new[]
+        // This uses C# compiler's ability to refer to static data directly. For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
+        private static ReadOnlySpan<byte> OperationName => new byte[]
         {
             (byte)'o',
             (byte)'p',
@@ -28,7 +31,7 @@ namespace HotChocolate.Language
             (byte)'e'
         };
 
-        private static readonly byte[] _queryName = new[]
+        private static ReadOnlySpan<byte> QueryName => new byte[]
         {
             (byte)'n',
             (byte)'a',
@@ -42,7 +45,7 @@ namespace HotChocolate.Language
             (byte)'y'
         };
 
-        private static readonly byte[] _query = new[]
+        private static ReadOnlySpan<byte> Query => new byte[]
         {
             (byte)'q',
             (byte)'u',
@@ -51,7 +54,7 @@ namespace HotChocolate.Language
             (byte)'y'
         };
 
-        private static readonly byte[] _variables = new[]
+        private static ReadOnlySpan<byte> Variables => new byte[]
         {
             (byte)'v',
             (byte)'a',
@@ -64,7 +67,7 @@ namespace HotChocolate.Language
             (byte)'s'
         };
 
-        private static readonly byte[] _extensions = new[]
+        private static ReadOnlySpan<byte> Extensions => new byte[]
         {
             (byte)'e',
             (byte)'x',
@@ -78,7 +81,7 @@ namespace HotChocolate.Language
             (byte)'s'
         };
 
-        private static readonly byte[] _type = new[]
+        private static ReadOnlySpan<byte> Type => new byte[]
         {
             (byte)'t',
             (byte)'y',
@@ -86,13 +89,13 @@ namespace HotChocolate.Language
             (byte)'e'
         };
 
-        private static readonly byte[] _id = new[]
+        private static ReadOnlySpan<byte> Id => new byte[]
         {
             (byte)'i',
             (byte)'d'
         };
 
-        private static readonly byte[] _payload = new[]
+        private static ReadOnlySpan<byte> Payload => new byte[]
         {
             (byte)'p',
             (byte)'a',

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLRequestParser.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLRequestParser.cs
@@ -173,7 +173,7 @@ namespace HotChocolate.Language
             switch (fieldName[0])
             {
                 case _o:
-                    if (fieldName.SequenceEqual(_operationName))
+                    if (fieldName.SequenceEqual(OperationName))
                     {
                         request.OperationName = ParseStringOrNull();
                         return;
@@ -181,7 +181,7 @@ namespace HotChocolate.Language
                     break;
 
                 case _n:
-                    if (fieldName.SequenceEqual(_queryName))
+                    if (fieldName.SequenceEqual(QueryName))
                     {
                         if (request.QueryId is null)
                         {
@@ -196,7 +196,7 @@ namespace HotChocolate.Language
                     break;
 
                 case _i:
-                    if (fieldName.SequenceEqual(_id))
+                    if (fieldName.SequenceEqual(Id))
                     {
                         if (request.QueryId is null)
                         {
@@ -211,7 +211,7 @@ namespace HotChocolate.Language
                     break;
 
                 case _q:
-                    if (fieldName.SequenceEqual(_query))
+                    if (fieldName.SequenceEqual(Query))
                     {
                         request.HasQuery = !IsNullToken();
 
@@ -228,7 +228,7 @@ namespace HotChocolate.Language
                     break;
 
                 case _v:
-                    if (fieldName.SequenceEqual(_variables))
+                    if (fieldName.SequenceEqual(Variables))
                     {
                         request.Variables = ParseObjectOrNull();
                         return;
@@ -236,7 +236,7 @@ namespace HotChocolate.Language
                     break;
 
                 case _e:
-                    if (fieldName.SequenceEqual(_extensions))
+                    if (fieldName.SequenceEqual(Extensions))
                     {
                         request.Extensions = ParseObjectOrNull();
                         return;
@@ -257,7 +257,7 @@ namespace HotChocolate.Language
             switch (fieldName[0])
             {
                 case _t:
-                    if (fieldName.SequenceEqual(_type))
+                    if (fieldName.SequenceEqual(Type))
                     {
                         message.Type = ParseStringOrNull();
                         return;
@@ -265,7 +265,7 @@ namespace HotChocolate.Language
                     break;
 
                 case _i:
-                    if (fieldName.SequenceEqual(_id))
+                    if (fieldName.SequenceEqual(Id))
                     {
                         message.Id = ParseStringOrNull();
                         return;
@@ -273,7 +273,7 @@ namespace HotChocolate.Language
                     break;
 
                 case _p:
-                    if (fieldName.SequenceEqual(_payload))
+                    if (fieldName.SequenceEqual(Payload))
                     {
                         int start = _reader.Start;
                         message.HasPayload = !IsNullToken();


### PR DESCRIPTION
Very small optimization trick like [this](https://github.com/dotnet/aspnetcore/blob/9e67b7b22e92f3f4550d0efc2737d072405f0190/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsMessageParser.cs#L18)
For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static