### PR TITLE
VariableUnquenessRule

### DIFF
--- a/src/HotChocolate/Core/src/Core/Validation/VariableUniquenessRule.cs
+++ b/src/HotChocolate/Core/src/Core/Validation/VariableUniquenessRule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using HotChocolate.Language;

--- a/src/HotChocolate/Core/src/Types/InternalsVisibleTo.cs
+++ b/src/HotChocolate/Core/src/Types/InternalsVisibleTo.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("HotChocolate.AspNetCore.Tests")]
 [assembly: InternalsVisibleTo("HotChocolate.AspNetClassic.Tests")]
-[assembly: InternalsVisibleTo("HotChocolate.Validation")]
 [assembly: InternalsVisibleTo("HotChocolate.Types.Filters")]
 [assembly: InternalsVisibleTo("HotChocolate.Types.Sorting")]
 [assembly: InternalsVisibleTo("HotChocolate.Types.Selections")]

--- a/src/HotChocolate/Core/src/Types/InternalsVisibleTo.cs
+++ b/src/HotChocolate/Core/src/Types/InternalsVisibleTo.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("HotChocolate.AspNetCore.Tests")]
 [assembly: InternalsVisibleTo("HotChocolate.AspNetClassic.Tests")]
+[assembly: InternalsVisibleTo("HotChocolate.Validation")]
 [assembly: InternalsVisibleTo("HotChocolate.Types.Filters")]
 [assembly: InternalsVisibleTo("HotChocolate.Types.Sorting")]
 [assembly: InternalsVisibleTo("HotChocolate.Types.Selections")]

--- a/src/HotChocolate/Core/src/Validation/Extensions/ValidationServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Validation/Extensions/ValidationServiceCollectionExtensions.cs
@@ -141,6 +141,5 @@ namespace HotChocolate.Validation
         {
             return services.AddValidationRule<VariableUniqueAndInputTypeVisitor>();
         }
-
     }
 }

--- a/src/HotChocolate/Core/src/Validation/Extensions/ValidationServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Validation/Extensions/ValidationServiceCollectionExtensions.cs
@@ -16,7 +16,8 @@ namespace HotChocolate.Validation
                 .AddAllVariablesUsedRule()
                 .AddAllVariableUsagesAreAllowedRule()
                 .AddDirectivesRule()
-                .AddExecutableDefinitionsRule();
+                .AddExecutableDefinitionsRule()
+                .AddVariableUniquenessRule();
 
             return services;
         }
@@ -119,6 +120,19 @@ namespace HotChocolate.Validation
             where T : DocumentValidatorVisitor, new()
         {
             return services.AddSingleton<IDocumentValidatorRule, DocumentValidatorRule<T>>();
+        }
+
+        /// <summary>
+        /// If any operation defines more than one variable with the same name,
+        /// it is ambiguous and invalid. It is invalid even if the type of the
+        /// duplicate variable is the same.
+        ///
+        /// http://spec.graphql.org/June2018/#sec-Validation.Variables
+        /// </summary>
+        public static IServiceCollection AddVariableUniquenessRule(
+            this IServiceCollection services)
+        {
+            return services.AddValidationRule<VariableUniquenessVisitor>();
         }
     }
 }

--- a/src/HotChocolate/Core/src/Validation/Extensions/ValidationServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Validation/Extensions/ValidationServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace HotChocolate.Validation
                 .AddAllVariableUsagesAreAllowedRule()
                 .AddDirectivesRule()
                 .AddExecutableDefinitionsRule()
-                .AddVariableUniquenessRule();
+                .AddVariableUniqueAndInputTypeRule();
 
             return services;
         }
@@ -122,17 +122,25 @@ namespace HotChocolate.Validation
             return services.AddSingleton<IDocumentValidatorRule, DocumentValidatorRule<T>>();
         }
 
-        /// <summary>
+        /// <summary> 
         /// If any operation defines more than one variable with the same name,
         /// it is ambiguous and invalid. It is invalid even if the type of the
         /// duplicate variable is the same.
         ///
         /// http://spec.graphql.org/June2018/#sec-Validation.Variables
+        /// 
+        /// AND
+        /// 
+        /// Variables can only be input types. Objects,
+        /// unions, and interfaces cannot be used as inputs.
+        ///
+        /// http://spec.graphql.org/June2018/#sec-Variables-Are-Input-Types
         /// </summary>
-        public static IServiceCollection AddVariableUniquenessRule(
+        public static IServiceCollection AddVariableUniqueAndInputTypeRule(
             this IServiceCollection services)
         {
-            return services.AddValidationRule<VariableUniquenessVisitor>();
+            return services.AddValidationRule<VariableUniqueAndInputTypeVisitor>();
         }
+
     }
 }

--- a/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
@@ -34,7 +34,6 @@ namespace HotChocolate.Validation
             VariableDefinitionNode node,
             IDocumentValidatorContext context)
         {
-
             if (context.Schema.TryGetTypeFromAst(node.Type, out IType type) &&
                 !type.IsInputType())
             {

--- a/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
@@ -49,16 +49,10 @@ namespace HotChocolate.Validation
                        .SetPath(context.CreateErrorPath())
                        .SetExtension("variable", variableName)
                        .SetExtension("variableType", node.Type.ToString())
-                       .SetExtension("locationType", context.Types.Peek().Visualize())
-                       .SpecifiedBy("sec-Variables-Are-Input-Types")
                        .Build());
             }
 
-            if (!context.DeclaredVariables.Contains(variableName))
-            {
-                context.DeclaredVariables.Add(variableName);
-            }
-            else
+            if (!context.DeclaredVariables.Add(variableName))
             {
                 // TODO : Resources
                 context.Errors.Add(
@@ -71,7 +65,6 @@ namespace HotChocolate.Validation
                         .SetPath(context.CreateErrorPath())
                         .SetExtension("variable", variableName)
                         .SetExtension("variableType", node.Type.ToString())
-                        .SetExtension("locationType", context.Types.Peek().Visualize())
                         .SpecifiedBy("sec-Validation.Variables")
                         .Build());
             }

--- a/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
@@ -1,7 +1,6 @@
 using HotChocolate.Language;
 using HotChocolate.Language.Visitors;
 using HotChocolate.Types;
-using HotChocolate.Utilities;
 
 namespace HotChocolate.Validation
 {
@@ -34,7 +33,8 @@ namespace HotChocolate.Validation
             VariableDefinitionNode node,
             IDocumentValidatorContext context)
         {
-            if (context.Schema.TryGetTypeFromAst(node.Type, out IType type) &&
+            if (context.Schema.TryGetType(
+                    node.Type.NamedType().Name.Value, out INamedType type) &&
                 !type.IsInputType())
             {
                 context.Errors.Add(

--- a/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
@@ -33,6 +33,8 @@ namespace HotChocolate.Validation
             VariableDefinitionNode node,
             IDocumentValidatorContext context)
         {
+            string variableName = node.Variable.Name.Value;
+
             if (context.Schema.TryGetType(
                     node.Type.NamedType().Name.Value, out INamedType type) &&
                 !type.IsInputType())
@@ -41,21 +43,20 @@ namespace HotChocolate.Validation
                    ErrorBuilder.New()
                        .SetMessage(
                             "The type of variable " +
-                            $"`{node.Variable.Name.Value}` " +
+                            $"`{variableName}` " +
                             "is not an input type.")
                        .AddLocation(node)
                        .SetPath(context.CreateErrorPath())
-                       .SetExtension("variable", node.Variable.Name.Value)
+                       .SetExtension("variable", variableName)
                        .SetExtension("variableType", node.Type.ToString())
                        .SetExtension("locationType", context.Types.Peek().Visualize())
                        .SpecifiedBy("sec-Variables-Are-Input-Types")
                        .Build());
             }
 
-            string name = node.Variable.Name.Value;
-            if (!context.DeclaredVariables.Contains(name))
+            if (!context.DeclaredVariables.Contains(variableName))
             {
-                context.DeclaredVariables.Add(name);
+                context.DeclaredVariables.Add(variableName);
             }
             else
             {
@@ -68,7 +69,7 @@ namespace HotChocolate.Validation
                            "name is invalid for execution.")
                         .AddLocation(node)
                         .SetPath(context.CreateErrorPath())
-                        .SetExtension("variable", name)
+                        .SetExtension("variable", variableName)
                         .SetExtension("variableType", node.Type.ToString())
                         .SetExtension("locationType", context.Types.Peek().Visualize())
                         .SpecifiedBy("sec-Validation.Variables")

--- a/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/VariableUniqueAndInputTypeVisitor.cs
@@ -55,7 +55,7 @@ namespace HotChocolate.Validation
             string name = node.Variable.Name.Value;
             if (!context.DeclaredVariables.Contains(name))
             {
-                context.DeclaredVariables.Add(node.Variable.Name.Value);
+                context.DeclaredVariables.Add(name);
             }
             else
             {
@@ -68,6 +68,9 @@ namespace HotChocolate.Validation
                            "name is invalid for execution.")
                         .AddLocation(node)
                         .SetPath(context.CreateErrorPath())
+                        .SetExtension("variable", name)
+                        .SetExtension("variableType", node.Type.ToString())
+                        .SetExtension("locationType", context.Types.Peek().Visualize())
                         .SpecifiedBy("sec-Validation.Variables")
                         .Build());
             }

--- a/src/HotChocolate/Core/src/Validation/Rules/VariableUniquenessVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/VariableUniquenessVisitor.cs
@@ -1,0 +1,50 @@
+using HotChocolate.Language;
+using HotChocolate.Language.Visitors;
+
+namespace HotChocolate.Validation
+{
+    /// <summary>
+    /// If any operation defines more than one variable with the same name,
+    /// it is ambiguous and invalid. It is invalid even if the type of the
+    /// duplicate variable is the same.
+    ///
+    /// http://spec.graphql.org/June2018/#sec-Validation.Variables
+    /// </summary>
+    internal sealed class VariableUniquenessVisitor
+        : DocumentValidatorVisitor
+    {
+        protected override ISyntaxVisitorAction Enter(
+            OperationDefinitionNode node,
+            IDocumentValidatorContext context)
+        {
+            context.DeclaredVariables.Clear();
+            return Continue;
+        }
+
+        protected override ISyntaxVisitorAction Enter(
+            VariableDefinitionNode node,
+            IDocumentValidatorContext context)
+        {
+            string name = node.Variable.Name.Value;
+            if (!context.DeclaredVariables.Contains(name))
+            {
+                context.DeclaredVariables.Add(node.Variable.Name.Value);
+            }
+            else
+            {
+                // TODO : Resources
+                context.Errors.Add(
+                    ErrorBuilder.New()
+                        .SetMessage(
+                           "A document containing operations that " +
+                           "define more than one variable with the same " +
+                           "name is invalid for execution.")
+                        .AddLocation(node)
+                        .SetPath(context.CreateErrorPath())
+                        .SpecifiedBy("sec-Validation.Variables")
+                        .Build());
+            }
+            return Skip;
+        }
+    }
+}

--- a/src/HotChocolate/Core/test/Validation.Tests/VariableUniquenessRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/VariableUniquenessRuleTests.cs
@@ -61,5 +61,33 @@ namespace HotChocolate.Validation
             Assert.Empty(context.Errors);
         }
 
+        [Fact]
+        public void TwoOperationsThatShareVariableName()
+        {
+            // arrange
+            IDocumentValidatorContext context = ValidationUtils.CreateContext();
+            DocumentNode query = Utf8GraphQLParser.Parse(@"
+                query A($atOtherHomes: Boolean) {
+                  ...HouseTrainedFragment
+                }
+
+                query B($atOtherHomes: Boolean) {
+                  ...HouseTrainedFragment
+                }
+
+                fragment HouseTrainedFragment on Query {
+                  dog {
+                    isHousetrained(atOtherHomes: $atOtherHomes)
+                  }
+                }
+            ");
+            context.Prepare(query);
+
+            // act
+            Rule.Validate(context, query);
+
+            // assert
+            Assert.Empty(context.Errors);
+        }
     }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/VariableUniquenessRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/VariableUniquenessRuleTests.cs
@@ -7,7 +7,7 @@ namespace HotChocolate.Validation
         : DocumentValidatorVisitorTestBase
     {
         public VariableUniquenessRuleTests()
-            : base(services => services.AddVariableUniquenessRule())
+            : base(services => services.AddVariableUniqueAndInputTypeRule())
         {
         }
 

--- a/src/HotChocolate/Core/test/Validation.Tests/VariableUniquenessRuleTests_Old.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/VariableUniquenessRuleTests_Old.cs
@@ -58,5 +58,33 @@ namespace HotChocolate.Validation
             // assert
             Assert.False(result.HasErrors);
         }
+
+        [Fact]
+        public void TwoOperationsThatShareVariableName()
+        {
+            // arrange
+            Schema schema = ValidationUtils.CreateSchema();
+            DocumentNode query = Utf8GraphQLParser.Parse(@"
+                query A($atOtherHomes: Boolean) {
+                  ...HouseTrainedFragment
+                }
+
+                query B($atOtherHomes: Boolean) {
+                  ...HouseTrainedFragment
+                }
+
+                fragment HouseTrainedFragment on Query {
+                  dog {
+                    isHousetrained(atOtherHomes: $atOtherHomes)
+                  }
+                }
+            ");
+
+            // act
+            QueryValidationResult result = Rule.Validate(schema, query);
+
+            // assert
+            Assert.False(result.HasErrors);
+        }
     }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/VariableUniquenessRuleTests_Old.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/VariableUniquenessRuleTests_Old.cs
@@ -3,11 +3,11 @@ using Xunit;
 
 namespace HotChocolate.Validation
 {
-    public class VariableUniquenessRuleTests
-        : DocumentValidatorVisitorTestBase
+    public class VariableUniquenessRuleTests_Old
+        : ValidationTestBase
     {
-        public VariableUniquenessRuleTests()
-            : base(services => services.AddVariableUniquenessRule())
+        public VariableUniquenessRuleTests_Old()
+            : base(new VariableUniquenessRule())
         {
         }
 
@@ -15,7 +15,7 @@ namespace HotChocolate.Validation
         public void OperationWithTwoVariablesThatHaveTheSameName()
         {
             // arrange
-            IDocumentValidatorContext context = ValidationUtils.CreateContext();
+            Schema schema = ValidationUtils.CreateSchema();
             DocumentNode query = Utf8GraphQLParser.Parse(@"
                 query houseTrainedQuery($atOtherHomes: Boolean, $atOtherHomes: Boolean) {
                     dog {
@@ -23,14 +23,13 @@ namespace HotChocolate.Validation
                     }
                 }
             ");
-            context.Prepare(query);
 
             // act
-            Rule.Validate(context, query);
+            QueryValidationResult result = Rule.Validate(schema, query);
 
             // assert
-            Assert.Single(context.Errors);
-            Assert.Collection(context.Errors,
+            Assert.True(result.HasErrors);
+            Assert.Collection(result.Errors,
                 t => Assert.Equal(
                     "A document containing operations that " +
                     "define more than one variable with the same " +
@@ -41,7 +40,7 @@ namespace HotChocolate.Validation
         public void NoOperationHasVariablesThatShareTheSameName()
         {
             // arrange
-            IDocumentValidatorContext context = ValidationUtils.CreateContext();
+            Schema schema = ValidationUtils.CreateSchema();
             DocumentNode query = Utf8GraphQLParser.Parse(@"
                 query ($foo: Boolean = true, $bar: Boolean = false) {
                     field @skip(if: $foo) {
@@ -52,14 +51,12 @@ namespace HotChocolate.Validation
                     }
                 }
             ");
-            context.Prepare(query);
 
             // act
-            Rule.Validate(context, query);
+            QueryValidationResult result = Rule.Validate(schema, query);
 
             // assert
-            Assert.Empty(context.Errors);
+            Assert.False(result.HasErrors);
         }
-
     }
 }


### PR DESCRIPTION
Implements  
> If any operation defines more than one variable with the same name, it is ambiguous and invalid. It is invalid even if the type of the  duplicate variable is the same.

http://facebook.github.io/graphql/June2018/#sec-Validation.Variables
