### PR TITLE
Fix an issue with nullable reference type inference in certain scenarios

### DIFF
--- a/src/HotChocolate/Core/src/Types/Utilities/NullableHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/NullableHelper.cs
@@ -118,9 +118,16 @@ namespace HotChocolate.Utilities
             else
             {
                 Nullable state = context;
-                if (!flags.IsEmpty && flags.Length > position)
+                if (!flags.IsEmpty)
                 {
-                    state = (Nullable)flags[position++];
+                    if (flags.Length > position)
+                    {
+                        state = (Nullable) flags[position++];
+                    }
+                    else if (flags.Length == 1)
+                    {
+                        state = (Nullable) flags[0];
+                    }
                 }
 
                 if (type.IsGenericType)

--- a/src/HotChocolate/Core/test/Types.Tests/CodeFirstTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/CodeFirstTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using HotChocolate.Types;
 using Snapshooter.Xunit;
@@ -15,6 +16,17 @@ namespace HotChocolate
         {
             SchemaBuilder.New()
                 .AddQueryType<Query>()
+                .AddType<Dog>()
+                .Create()
+                .ToString()
+                .MatchSnapshot();
+        }
+
+        [Fact]
+        public void InferSchemaWithNonNullRefTypesAndGenerics()
+        {
+            SchemaBuilder.New()
+                .AddQueryType<QueryWithGenerics>()
                 .AddType<Dog>()
                 .Create()
                 .ToString()
@@ -75,6 +87,26 @@ namespace HotChocolate
 
             public Task<IPet?> GetPetOrNull() =>
                 throw new NotImplementedException();
+        }
+
+        public class QueryWithGenerics
+        {
+            public Task<IPet?> GetPet(int id, CancellationToken cancellationToken) =>
+                throw new NotImplementedException();
+
+            // The arguments are needed to make the compiler apply attributes as expected for this use case
+            // It's not entirely clear what combination of arguments for this and other fields on the class makes it behave this way
+            // We want the compiler to apply these attributes to the GetPets method
+            // [NullableContext(2)]
+            // [return: Nullable(1)]
+            public Task<GenericWrapper<IPet>> GetPets(int? arg1, bool? arg2, bool? arg3, string? arg4,
+                GenericWrapper<string>? arg5, Greetings? arg6, CancellationToken cancellationToken) =>
+                throw new NotImplementedException();
+        }
+
+        public class GenericWrapper<T>
+        {
+            public T Value { get; set; }
         }
 
         public class Greetings

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/CodeFirstTests.InferSchemaWithNonNullRefTypesAndGenerics.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/CodeFirstTests.InferSchemaWithNonNullRefTypesAndGenerics.snap
@@ -1,0 +1,37 @@
+﻿schema {
+  query: QueryWithGenerics
+}
+
+interface IPet {
+  name: String
+}
+
+type Dog implements IPet {
+  name: String
+}
+
+type GenericWrapperOfIPet {
+  value: IPet!
+}
+
+type QueryWithGenerics {
+  pet(id: Int!): IPet
+  pets(arg1: Int arg2: Boolean arg3: Boolean arg4: String arg5: GenericWrapperOfStringInput arg6: GreetingsInput): GenericWrapperOfIPet!
+}
+
+input GenericWrapperOfStringInput {
+  value: String!
+}
+
+input GreetingsInput {
+  name: String!
+}
+
+"The `Boolean` scalar type represents `true` or `false`."
+scalar Boolean
+
+"The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
+scalar Int
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String


### PR DESCRIPTION
It appears the compiler applies Nullable/NullableContext attributes differently depending on usage within the class.

As noted by John Skeet here https://codeblog.jonskeet.uk/2019/02/10/nullableattribute-and-c-8/
> The compiler has one more trick up its sleeve. When all the elements in the tree are “not null” or all elements in the tree are “nullable”, it simply uses the constructor with the single-byte parameter instead. So Dictionary<List<string>, string[]> would be decorated with Nullable[(byte) 1] and Dictionary<List<string?>?, string?[]?>? would be decorated with Nullable[(byte) 2].

The specific problem I'm experiencing is that `Task<ListSlice<User>>` is being infered to a nullable field, which is not correct.
In my specific scenario, with the combination of arguments and so on, the method is decorated with
```
[NullableContext(2)]
[return: Nullable(1)]
```
but the current code would expect something like `[Nullable(new byte[] { 1, 1, 1 })]`

This change makes it work for the scenario where only one byte is present.
I also managed to produce a test that replicates my specific scenario.
