### PR TITLE
Add support for execution result errors

### DIFF
--- a/src/HotChocolate/Core/src/Core/Execution/ExecutionStrategyBase.Resolver.cs
+++ b/src/HotChocolate/Core/src/Core/Execution/ExecutionStrategyBase.Resolver.cs
@@ -18,13 +18,17 @@ namespace HotChocolate.Execution
             await ExecuteMiddlewareAsync(resolverContext, errorHandler)
                 .ConfigureAwait(false);
 
-            if (resolverContext.Result is IError singleError)
+            switch (resolverContext.Result)
             {
-                resolverContext.ResolverError(singleError);
-            }
-            else if (resolverContext.Result is IEnumerable<IError> errors)
-            {
-                resolverContext.ResolverError(errors);
+                case IError singleError:
+                    resolverContext.ResolverError(singleError);
+                    break;
+                case IEnumerable<IError> errors:
+                    resolverContext.ResolverError(errors);
+                    break;
+                case IExecutionResult executionResult when executionResult.Errors != null:
+                    resolverContext.ResolverError(executionResult.Errors);
+                    break;
             }
 
             resolverContext.EndResolveField(activity);
@@ -45,7 +49,7 @@ namespace HotChocolate.Execution
                 {
                     resolverContext.Result =
                         await Task.Run(() =>
-                        { 
+                        {
                             var items = new List<object>();
                             foreach (object o in q)
                             {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Is working in middleware
```cs
context.Result = ErrorBuilder.New().Build();
// or
context.Result = new[] { ErrorBuilder.New().Build() };
```
- Is not working in middleware
```cs
context.Result = QueryResultBuilder.CreateError(ErrorBuilder.New().Build());
// or
context.Result = QueryResultBuilder.CreateError(new[] { ErrorBuilder.New().Build() });
```

I didn't find tests for that code(method, type, inheritors) to copy-paste arranges, so didn't write any tests, can you help me to find something?

Addresses #bugnumber (in this specific format)
