### PR TITLE
Fixing paths in examples csproj. Added sollution so it can be ran independently

### DIFF
--- a/examples/AspNetCore.StarWars/AspNetCore.StarWars.csproj
+++ b/examples/AspNetCore.StarWars/AspNetCore.StarWars.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -19,11 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Core\Subscriptions.InMemory\Subscriptions.InMemory.csproj" />
-    <ProjectReference Include="..\..\src\Server\AspNetCore\AspNetCore.csproj" />
-    <ProjectReference Include="..\..\src\Server\AspNetCore.Authorization\AspNetCore.Authorization.csproj" />
-    <ProjectReference Include="..\..\src\Server\AspNetCore.Playground\AspNetCore.Playground.csproj" />
-    <ProjectReference Include="..\..\src\Server\AspNetCore.Voyager\AspNetCore.Voyager.csproj" />
+    <ProjectReference Include="..\..\src\HotChocolate\AspNetCore\src\AspNetCore.Authorization\HotChocolate.AspNetCore.Authorization.csproj" />
+    <ProjectReference Include="..\..\src\HotChocolate\AspNetCore\src\AspNetCore.Playground\HotChocolate.AspNetCore.Playground.csproj" />
+    <ProjectReference Include="..\..\src\HotChocolate\AspNetCore\src\AspNetCore.Voyager\HotChocolate.AspNetCore.Voyager.csproj" />
+    <ProjectReference Include="..\..\src\HotChocolate\AspNetCore\src\AspNetCore\HotChocolate.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\HotChocolate\Core\src\Subscriptions.InMemory\HotChocolate.Subscriptions.InMemory.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/AspNetCore.StarWars/AspNetCore.StarWars.sln
+++ b/examples/AspNetCore.StarWars/AspNetCore.StarWars.sln
@@ -1,0 +1,67 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29926.136
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore.StarWars", "AspNetCore.StarWars.csproj", "{8DD8A1F3-5488-4DE9-97C1-169FDA0615A0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.Subscriptions.InMemory", "..\..\src\HotChocolate\Core\src\Subscriptions.InMemory\HotChocolate.Subscriptions.InMemory.csproj", "{DD54E176-5A7C-459E-B164-26315C8222BF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.AspNetCore", "..\..\src\HotChocolate\AspNetCore\src\AspNetCore\HotChocolate.AspNetCore.csproj", "{B2154E8B-22FC-4D75-894F-AECE60391931}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.AspNetCore.Authorization", "..\..\src\HotChocolate\AspNetCore\src\AspNetCore.Authorization\HotChocolate.AspNetCore.Authorization.csproj", "{C0D1D86A-2402-44EF-ADCE-897D232E025C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.AspNetCore.Playground", "..\..\src\HotChocolate\AspNetCore\src\AspNetCore.Playground\HotChocolate.AspNetCore.Playground.csproj", "{B414A002-31B3-4392-AC2D-13A121907131}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.AspNetCore.Voyager", "..\..\src\HotChocolate\AspNetCore\src\AspNetCore.Voyager\HotChocolate.AspNetCore.Voyager.csproj", "{DF9A5C5F-CD4C-42DC-B650-D4D484506056}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.AspNetCore.Subscriptions", "..\..\src\HotChocolate\AspNetCore\src\AspNetCore.Subscriptions\HotChocolate.AspNetCore.Subscriptions.csproj", "{7CB666F2-FB0B-41F0-B7E0-E06255ECC951}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotChocolate.AspNetCore.Abstractions", "..\..\src\HotChocolate\AspNetCore\src\AspNetCore.Abstractions\HotChocolate.AspNetCore.Abstractions.csproj", "{56AD54D5-FC49-42BB-85AC-ED2BA87E2D12}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8DD8A1F3-5488-4DE9-97C1-169FDA0615A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DD8A1F3-5488-4DE9-97C1-169FDA0615A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DD8A1F3-5488-4DE9-97C1-169FDA0615A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DD8A1F3-5488-4DE9-97C1-169FDA0615A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD54E176-5A7C-459E-B164-26315C8222BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD54E176-5A7C-459E-B164-26315C8222BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD54E176-5A7C-459E-B164-26315C8222BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD54E176-5A7C-459E-B164-26315C8222BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2154E8B-22FC-4D75-894F-AECE60391931}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2154E8B-22FC-4D75-894F-AECE60391931}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2154E8B-22FC-4D75-894F-AECE60391931}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2154E8B-22FC-4D75-894F-AECE60391931}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0D1D86A-2402-44EF-ADCE-897D232E025C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0D1D86A-2402-44EF-ADCE-897D232E025C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0D1D86A-2402-44EF-ADCE-897D232E025C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0D1D86A-2402-44EF-ADCE-897D232E025C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B414A002-31B3-4392-AC2D-13A121907131}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B414A002-31B3-4392-AC2D-13A121907131}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B414A002-31B3-4392-AC2D-13A121907131}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B414A002-31B3-4392-AC2D-13A121907131}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF9A5C5F-CD4C-42DC-B650-D4D484506056}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF9A5C5F-CD4C-42DC-B650-D4D484506056}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF9A5C5F-CD4C-42DC-B650-D4D484506056}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF9A5C5F-CD4C-42DC-B650-D4D484506056}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7CB666F2-FB0B-41F0-B7E0-E06255ECC951}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7CB666F2-FB0B-41F0-B7E0-E06255ECC951}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CB666F2-FB0B-41F0-B7E0-E06255ECC951}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7CB666F2-FB0B-41F0-B7E0-E06255ECC951}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56AD54D5-FC49-42BB-85AC-ED2BA87E2D12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56AD54D5-FC49-42BB-85AC-ED2BA87E2D12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56AD54D5-FC49-42BB-85AC-ED2BA87E2D12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56AD54D5-FC49-42BB-85AC-ED2BA87E2D12}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A040F113-40A0-42B5-893A-40F1E5AFA053}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- AspNetCore.StarWars.csproj had wrong paths so it couldn't build
- Added solution so example can be ran independently
