### PR TITLE
Fixed issue where the node id field name was not correctly named.

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Relay/Descriptors/NodeResolverDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Descriptors/NodeResolverDescriptor.cs
@@ -44,7 +44,8 @@ namespace HotChocolate.Types.Relay.Descriptors
                 });
 
             return _typeDescriptor.Field(_propertyOrMethod)
-                .Type<NonNullType<IdType>>();
+                .Type<NonNullType<IdType>>()
+                .Name("id");
         }
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Detail 1
- Detail 2

Addresses #bugnumber (in this specific format)
