### PR TITLE
Clear the completion context more aggressively

### DIFF
--- a/src/HotChocolate/Core/src/Core/Execution/Utilities/ValueCompletion.cs
+++ b/src/HotChocolate/Core/src/Core/Execution/Utilities/ValueCompletion.cs
@@ -37,6 +37,8 @@ namespace HotChocolate.Execution
             {
                 resolverContext.SetCompletedValue(completionContext.Value);
             }
+            
+            completionContext.Clear();
         }
 
         private static void CompleteValue(


### PR DESCRIPTION
This change enables the GC to collect stored resolver values that are sitting in the static `completionContext` earlier without waiting for the next time something wants to rent the shared object. When sending large result objects this helps with memory pressure as old results are not kept alive.
