### PR TITLE
unseal auth atribute

### DIFF
--- a/src/Server/AspNetCore.Authorization/AuthorizeAttribute.cs
+++ b/src/Server/AspNetCore.Authorization/AuthorizeAttribute.cs
@@ -20,7 +20,7 @@ namespace HotChocolate.AspNetCore.Authorization
         | AttributeTargets.Method,
         Inherited = true,
         AllowMultiple = true)]
-    public sealed class AuthorizeAttribute : DescriptorAttribute
+    public class AuthorizeAttribute : DescriptorAttribute
     {
         public string Policy { get; set; }
 


### PR DESCRIPTION
Unsealed auth attribute to keep it consistent with ver. 11.x