### PR TITLE
Fixed typo

### DIFF
--- a/src/HotChocolate/Core/src/Types/Utilities/Serialization/InputObjectConstructorResolver.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/Serialization/InputObjectConstructorResolver.cs
@@ -55,7 +55,7 @@ namespace HotChocolate.Utilities.Serialization
                 $"No compatible constructor found for input type type `{type.FullName}`.\r\n" +
                 "Either you have to provide a public constructor with settable properties or " +
                 "a public constructor that allows to pass in values for read-only properties." +
-                $"There was now way to set the following properties: {string.Join(", ", required)}.");
+                $"There was no way to set the following properties: {string.Join(", ", required)}.");
         }
 
         private static bool IsCompatibleConstructor(


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- replace `now` with `no`
