### PR TITLE
Don't remove DiagnosticsListener or DiagnosticSource unless TracingPr…

### DIFF
--- a/src/HotChocolate/Core/src/Core/Execution/Extensions/QueryExecutionBuilderExtensions.cs
+++ b/src/HotChocolate/Core/src/Core/Execution/Extensions/QueryExecutionBuilderExtensions.cs
@@ -175,9 +175,12 @@ namespace HotChocolate.Execution
 
             var listener = new DiagnosticListener(DiagnosticNames.Listener);
 
-            builder
-                .RemoveService<DiagnosticListener>()
-                .RemoveService<DiagnosticSource>();
+            if (tracingPreference != TracingPreference.Never)
+            {
+                builder.RemoveService<DiagnosticListener>()
+                    .RemoveService<DiagnosticSource>();
+            }
+
             builder.Services
                 .AddSingleton(listener)
                 .AddSingleton<DiagnosticSource>(listener)


### PR DESCRIPTION
This change avoid removing DiagnoticsListener and DianosticsSource unless TracingPreference is set to a value different from TracingPreference.Never. This change is made to avoid problems with other libraries that already use and need DiagnosticsListener and DiagnosticsSource, for example, Microsoft Application Insights, specifically Request Telemetry.

Summary of the changes

- Avoid removing DiagnosticsListener and DiagnosticSource when TracingPreference is different from Never.

Addresses #2029
