### PR TITLE
Issue 2031 Resolved by removing a redundant line.

### DIFF
--- a/templates/Server/content/Startup.cs
+++ b/templates/Server/content/Startup.cs
@@ -1,4 +1,3 @@
-using HotChocolate;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
A redundant line ("using HotChocolate;") has been removed. This line triggered the compiler warning.

Merging shall resolve this issue
https://github.com/ChilliCream/hotchocolate/issues/2031


