### PR TITLE
Proposed fix for nested input values using Optional<T>

### DIFF
--- a/src/Core/Abstractions/IOptional.cs
+++ b/src/Core/Abstractions/IOptional.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+namespace HotChocolate
+{
+    /// <summary>
+    /// This interface represents a way to access optionals easier
+    /// without the need to know the actual value type.
+    /// </summary>
+    public interface IOptional
+    {
+        /// <summary>
+        /// The name value.
+        /// </summary>
+        object? Value { get; }
+
+        /// <summary>
+        /// <c>true</c> if the optional has a value.
+        /// </summary>
+        bool HasValue { get; }
+    }
+}

--- a/src/Core/Abstractions/Optional.cs
+++ b/src/Core/Abstractions/Optional.cs
@@ -8,9 +8,8 @@ namespace HotChocolate
     /// The optional type is used to differentiate between not set and set input values.
     /// </summary>
     public readonly struct Optional<T>
-        : IEquatable<Optional<T>>
+        : IEquatable<Optional<T>>, IOptional
     {
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Optional{T}"/> struct.
         /// </summary>
@@ -25,6 +24,8 @@ namespace HotChocolate
         /// The name value.
         /// </summary>
         public T Value { get; }
+
+        object? IOptional.Value => Value;
 
         /// <summary>
         /// <c>true</c> if the optional has a value.
@@ -84,6 +85,7 @@ namespace HotChocolate
             {
                 return IsEmpty;
             }
+
             return obj is Optional<T> n && Equals(n);
         }
 

--- a/src/Core/Abstractions/Optional.cs
+++ b/src/Core/Abstractions/Optional.cs
@@ -8,7 +8,8 @@ namespace HotChocolate
     /// The optional type is used to differentiate between not set and set input values.
     /// </summary>
     public readonly struct Optional<T>
-        : IEquatable<Optional<T>>, IOptional
+        : IEquatable<Optional<T>>
+        , IOptional
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Optional{T}"/> struct.

--- a/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
+++ b/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 using HotChocolate.Execution;
 using Xunit;
 
+#nullable enable
+
 namespace HotChocolate.Regressions
 {
     // Relates to issue https://github.com/ChilliCream/hotchocolate/issues/2114

--- a/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
+++ b/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
@@ -62,6 +62,11 @@ mutation a($input: ButterPickleInput!)
             {
                 return true;
             }
+
+            public bool Consume(ButterPickleInput input)
+            {
+                return true;
+            }
         }
 
         public class ToppingInput

--- a/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
+++ b/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HotChocolate.Execution;
+using Xunit;
+
+namespace HotChocolate.Regressions
+{
+    // Relates to issue https://github.com/ChilliCream/hotchocolate/issues/2114
+    public class NestedOptionalInt_2114
+    {
+        [Fact]
+        public async Task ShouldNotFailWithExplicitValues()
+        {
+            // arrange
+            IQueryExecutor executor = CreateSchema().MakeExecutable();
+            const string Query = @"
+mutation {
+  eat(topping: { pickles: [{ butterPickle: { size: 5 } }] })
+}";
+
+            // act
+            IExecutionResult result = await executor.ExecuteAsync(Query);
+
+            // assert
+            Assert.Empty(result.Errors);
+        }
+
+        [Fact]
+        public async Task ShouldNotFailWithVariables()
+        {
+            // arrange
+            IQueryExecutor executor = CreateSchema().MakeExecutable();
+            const string Query = @"
+mutation a($input: ButterPickleInput!)
+{
+  eat(topping: { pickles: [{ butterPickle: $input }] })
+}";
+
+            // act
+            IExecutionResult result = await executor.ExecuteAsync(Query,
+                new Dictionary<string, object> {{"input", new Dictionary<string, object> {{"size", 5}}}});
+
+            // assert
+            Assert.Empty(result.Errors);
+        }
+
+        private static Schema CreateSchema()
+        {
+            return Schema.Create(s => s
+                .RegisterQueryType<Query>()
+                .RegisterMutationType<Mutation>());
+        }
+
+        public class Query
+        {
+            public string Chocolate => "rain";
+        }
+
+        public class Mutation
+        {
+            public bool Eat(ToppingInput topping)
+            {
+                return true;
+            }
+        }
+
+        public class ToppingInput
+        {
+            public IEnumerable<PicklesInput>? Pickles { get; set; }
+        }
+
+        public class PicklesInput
+        {
+            public ButterPickleInput? ButterPickle { get; set; }
+        }
+
+        public class ButterPickleInput
+        {
+            public Optional<int> Size { get; set; }
+        }
+    }
+}

--- a/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
+++ b/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
@@ -16,9 +16,9 @@ namespace HotChocolate.Regressions
             // arrange
             IQueryExecutor executor = CreateSchema().MakeExecutable();
             const string Query = @"
-mutation {
-  eat(topping: { pickles: [{ butterPickle: { size: 5 } }] })
-}";
+                mutation {
+                  eat(topping: { pickles: [{ butterPickle: { size: 5 } }] })
+                }";
 
             // act
             IExecutionResult result = await executor.ExecuteAsync(Query);
@@ -33,14 +33,17 @@ mutation {
             // arrange
             IQueryExecutor executor = CreateSchema().MakeExecutable();
             const string Query = @"
-mutation a($input: ButterPickleInput!)
-{
-  eat(topping: { pickles: [{ butterPickle: $input }] })
-}";
+                mutation a($input: ButterPickleInput!)
+                {
+                  eat(topping: { pickles: [{ butterPickle: $input }] })
+                }";
 
             // act
             IExecutionResult result = await executor.ExecuteAsync(Query,
-                new Dictionary<string, object> {{"input", new Dictionary<string, object> {{"size", 5}}}});
+                new Dictionary<string, object> 
+                { 
+                    {"input", new Dictionary<string, object> { {"size", 5} } } 
+                });
 
             // assert
             Assert.Empty(result.Errors);

--- a/src/Core/Types/Utilities/TypeConversion.OptionalTypes.cs
+++ b/src/Core/Types/Utilities/TypeConversion.OptionalTypes.cs
@@ -33,13 +33,14 @@ namespace HotChocolate.Utilities
             return null;
         }
 
-        private Type GetUnderlyingOptionalType(Type type)
+        private static Type GetUnderlyingOptionalType(Type type)
         {
             if (type.IsValueType && type.IsGenericType
                                  && type.GetGenericTypeDefinition() == typeof(Optional<>))
             {
                 return type.GetGenericArguments()[0];
             }
+
             return type;
         }
     }

--- a/src/Core/Types/Utilities/TypeConversion.OptionalTypes.cs
+++ b/src/Core/Types/Utilities/TypeConversion.OptionalTypes.cs
@@ -35,8 +35,9 @@ namespace HotChocolate.Utilities
 
         private static Type GetUnderlyingOptionalType(Type type)
         {
-            if (type.IsValueType && type.IsGenericType
-                                 && type.GetGenericTypeDefinition() == typeof(Optional<>))
+            if (type.IsValueType 
+                && type.IsGenericType
+                && type.GetGenericTypeDefinition() == typeof(Optional<>))
             {
                 return type.GetGenericArguments()[0];
             }

--- a/src/Core/Types/Utilities/TypeConversion.OptionalTypes.cs
+++ b/src/Core/Types/Utilities/TypeConversion.OptionalTypes.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace HotChocolate.Utilities
+{
+    public partial class TypeConversion
+    {
+        private bool TryCreateOptionalConverter(
+            Type from, Type to, out ChangeType converter)
+        {
+            Type innerFrom = GetUnderlyingOptionalType(from);
+            Type innerTo = GetUnderlyingOptionalType(to);
+
+            if ((innerFrom != from || innerTo != to)
+                && TryGetOrCreateConverter(innerFrom, innerTo, out converter))
+            {
+                ChangeType innerConverter = converter;
+                converter = source => GenericOptionalConverter((IOptional)source, innerConverter);
+                Register(from, to, converter);
+                return true;
+            }
+
+            converter = null;
+            return false;
+        }
+
+        private static object GenericOptionalConverter(IOptional source, ChangeType converter)
+        {
+            if (source.HasValue)
+            {
+                return converter(source.Value);
+            }
+
+            return null;
+        }
+
+        private Type GetUnderlyingOptionalType(Type type)
+        {
+            if (type.IsValueType && type.IsGenericType
+                                 && type.GetGenericTypeDefinition() == typeof(Optional<>))
+            {
+                return type.GetGenericArguments()[0];
+            }
+            return type;
+        }
+    }
+}

--- a/src/Core/Types/Utilities/TypeConversion.cs
+++ b/src/Core/Types/Utilities/TypeConversion.cs
@@ -119,6 +119,7 @@ namespace HotChocolate.Utilities
                 || TryCreateConverterFromFactory(from, to, out converter)
                 || TryCreateListTypeConverter(from, to, out converter)
                 || TryCreateNullableConverter(from, to, out converter)
+                || TryCreateOptionalConverter(from, to, out converter)
                 || TryCreateEnumConverter(from, to, out converter))
             {
                 return true;


### PR DESCRIPTION
This is a suggestion for a fix for #2114 

This is the flow of what happens during variable coercion as far as i could tell:
- The input type parses the variable correctly to the input object class, with the property set to the optional value.
- When `InputObjectType.ParseValue` is then called with the parsed value, it attempts to convert the object to an `IValueNode`
  - In `InputObjectToObjectValueConverter.VisitLeaf` it ends up wanting to map from `Optional<int>` to `int`
  - The added converter should take care of this scenario

The type system isn't the easiest code to understand when first looking at it, so I'm not sure this is the correct or best solution to the problem, but it does appear to fix the issue without breaking anything else 😄