### PR TITLE
Use invariant culture when parsing numbers in AnyType

### DIFF
--- a/src/Core/Types/Types/Scalars/AnyType.cs
+++ b/src/Core/Types/Types/Scalars/AnyType.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using HotChocolate.Configuration;
 using HotChocolate.Language;
 using HotChocolate.Properties;
@@ -73,10 +74,10 @@ namespace HotChocolate.Types
                     return svn.Value;
 
                 case IntValueNode ivn:
-                    return long.Parse(ivn.Value);
+                    return long.Parse(ivn.Value, CultureInfo.InvariantCulture);
 
                 case FloatValueNode fvn:
-                    return decimal.Parse(fvn.Value);
+                    return decimal.Parse(fvn.Value, CultureInfo.InvariantCulture);
 
                 case BooleanValueNode bvn:
                     return bvn.Value;


### PR DESCRIPTION
I noticed this bug while looking into another issue, because the tests were failing on my machine.

You may have not noticed it because you've been developing/testing on a machine that uses a culture with . as the decimal separator.