### PR TITLE
Ignore optional fields without a value when converting input object to object value

### DIFF
--- a/src/Core/Types/Utilities/InputObjectToObjectValueConverter.cs
+++ b/src/Core/Types/Utilities/InputObjectToObjectValueConverter.cs
@@ -120,6 +120,11 @@ namespace HotChocolate.Utilities
         {
             if (type is IHasClrType hasClrType)
             {
+                if (obj is IOptional optional && !optional.HasValue)
+                {
+                    return;
+                }
+
                 Type currentType = obj.GetType();
                 object normalized = currentType == hasClrType.ClrType
                     ? obj


### PR DESCRIPTION
After starting to use the changes #2133 (#2114) we noticed that optional fields that were not assigned in the request ended up having a value.

This changes it to ignore those fields when converting the input object to an object value.