### PR TITLE
Handle conversion of complex objects inside Optional<T>

### DIFF
--- a/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
+++ b/src/Core/Core.Tests/Regressions/NestedOptionalInt_2114.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using HotChocolate.Execution;
 using HotChocolate.Types;
-using Moq;
 using Xunit;
 
 #nullable enable
@@ -18,11 +17,13 @@ namespace HotChocolate.Regressions
         public async Task ShouldNotFailWithExplicitValues()
         {
             // arrange
-            var onEatMock = new Mock<Func<ToppingInput, bool>>();
             ToppingInput? input = null;
-            onEatMock.Setup(x => x.Invoke(It.IsAny<ToppingInput>())).Callback<ToppingInput>(x => input = x);
 
-            IQueryExecutor executor = CreateSchema(onEatMock.Object).MakeExecutable();
+            IQueryExecutor executor = CreateSchema(value =>
+            {
+                input = value;
+                return true;
+            }).MakeExecutable();
             const string Query = @"
                 mutation {
                   eat(topping: { pickles: [{ butterPickle: { size: 5, complexAssigned: { value: 3 }, complexAssignedNull: null, complexList: [{ value: 2 }] } }] })
@@ -40,11 +41,13 @@ namespace HotChocolate.Regressions
         public async Task ShouldNotFailWithVariables()
         {
             // arrange
-            var onEatMock = new Mock<Func<ToppingInput, bool>>();
             ToppingInput? input = null;
-            onEatMock.Setup(x => x.Invoke(It.IsAny<ToppingInput>())).Callback<ToppingInput>(x => input = x);
+            IQueryExecutor executor = CreateSchema(value =>
+            {
+                input = value;
+                return true;
+            }).MakeExecutable();
 
-            IQueryExecutor executor = CreateSchema(onEatMock.Object).MakeExecutable();
             const string Query = @"
                 mutation a($input: ButterPickleInput!)
                 {

--- a/src/Core/Types/Utilities/InputObjectToObjectValueConverter.cs
+++ b/src/Core/Types/Utilities/InputObjectToObjectValueConverter.cs
@@ -75,6 +75,17 @@ namespace HotChocolate.Utilities
             Action<IValueNode> setValue,
             ISet<object> processed)
         {
+            if (obj is IOptional outerOptional)
+            {
+                if (outerOptional.HasValue && outerOptional.Value is null)
+                {
+                    setValue(NullValueNode.Default);
+                    return;
+                }
+
+                obj = outerOptional.Value;
+            }
+
             if (processed.Add(obj))
             {
                 var fields = new List<ObjectFieldNode>();
@@ -83,6 +94,11 @@ namespace HotChocolate.Utilities
                 {
                     if(field.TryGetValue(obj, out object fieldValue))
                     {
+                        if (fieldValue is IOptional optional && !optional.HasValue)
+                        {
+                            continue;
+                        }
+
                         Action<IValueNode> setField = value =>
                             fields.Add(new ObjectFieldNode(field.Name, value));
                         VisitValue(field.Type, fieldValue, setField, processed);

--- a/src/Core/Types/Utilities/InputObjectToObjectValueConverter.cs
+++ b/src/Core/Types/Utilities/InputObjectToObjectValueConverter.cs
@@ -114,6 +114,11 @@ namespace HotChocolate.Utilities
             Action<IValueNode> setValue,
             ISet<object> processed)
         {
+            if (obj is IOptional optional && optional.HasValue)
+            {
+                obj = optional.Value;
+            }
+
             if (obj is IEnumerable sourceList)
             {
                 var list = new List<IValueNode>();


### PR DESCRIPTION
When converting an input object to object value, complex input objects nested in Optional<T> would cause an exception.

This change adds tests and fixes for both scenarios where a complex object value is defined and undefined.

Relates to #2114 #2133 #2153