### PR TITLE
Update ITopicEventReceiver to include a class constraint for TMessage

### DIFF
--- a/src/HotChocolate/Core/src/Subscriptions/ITopicEventReceiver.cs
+++ b/src/HotChocolate/Core/src/Subscriptions/ITopicEventReceiver.cs
@@ -27,6 +27,7 @@ namespace HotChocolate.Subscriptions
         ValueTask<ISourceStream<TMessage>> SubscribeAsync<TTopic, TMessage>(
             TTopic topic,
             CancellationToken cancellationToken = default)
-            where TTopic : notnull;
+            where TTopic : notnull
+            where TMessage: class;
     }
 }


### PR DESCRIPTION
This is preparation for a MassTransit implementation to support Subscriptions. MassTransit enforces the use of class constraint when handling messages.