### PR TITLE
Integrate Legacy Filters

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/TypeCompletionContext.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeCompletionContext.cs
@@ -67,6 +67,7 @@ namespace HotChocolate.Configuration
         public IDescriptorContext DescriptorContext => _initializationContext.DescriptorContext;
 
         public ITypeInterceptor Interceptor => _initializationContext.Interceptor;
+        
         public T GetType<T>(ITypeReference reference)
             where T : IType
         {

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IObjectField.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IObjectField.cs
@@ -11,6 +11,7 @@ namespace HotChocolate.Types
     /// </summary>
     public interface IObjectField
         : IOutputField
+        , IHasRuntimeType
     {
         /// <summary>
         /// Gets the type that declares this field.

--- a/src/HotChocolate/Filters2/src/Directory.Build.props
+++ b/src/HotChocolate/Filters2/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1; netstandard2.1; netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1; netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <!--Nullable>enable</Nullable-->
   </PropertyGroup>

--- a/src/HotChocolate/Filters2/src/Types.Filters/Array/ArrayFilterFieldDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/Array/ArrayFilterFieldDescriptor.cs
@@ -97,11 +97,10 @@ namespace HotChocolate.Types.Filters
 
         protected ClrTypeReference GetTypeReference()
         {
-            return new ClrTypeReference(
+            return TypeReference.Create(
                 typeof(FilterInputType<>).MakeGenericType(_type),
                     Definition.Type.Context,
-                    true,
-                    true);
+                    nullable: new [] { true, true });
         }
 
         private ArrayFilterOperationDescriptor GetOrCreateOperation(
@@ -137,10 +136,9 @@ namespace HotChocolate.Types.Filters
             var operation = GetFilterOperation(operationKind);
 
             var typeReference = RewriteTypeToNullableType(
-                new ClrTypeReference(typeof(bool),
+                TypeReference.Create(typeof(bool),
                     Definition.Type.Context,
-                    true,
-                    true));
+                    nullable: new [] { true, true }));
 
             return ArrayBooleanFilterOperationDescriptor.New(
                 Context,

--- a/src/HotChocolate/Filters2/src/Types.Filters/Array/ArrayFilterFieldDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/Array/ArrayFilterFieldDescriptor.cs
@@ -99,8 +99,7 @@ namespace HotChocolate.Types.Filters
         {
             return TypeReference.Create(
                 typeof(FilterInputType<>).MakeGenericType(_type),
-                    Definition.Type.Context,
-                    nullable: new [] { true, true });
+                Definition.Type.Context);
         }
 
         private ArrayFilterOperationDescriptor GetOrCreateOperation(
@@ -137,8 +136,7 @@ namespace HotChocolate.Types.Filters
 
             var typeReference = RewriteTypeToNullableType(
                 TypeReference.Create(typeof(bool),
-                    Definition.Type.Context,
-                    nullable: new [] { true, true }));
+                    Definition.Type.Context));
 
             return ArrayBooleanFilterOperationDescriptor.New(
                 Context,

--- a/src/HotChocolate/Filters2/src/Types.Filters/Extensions/FilterObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/Extensions/FilterObjectFieldDescriptorExtensions.cs
@@ -66,8 +66,7 @@ namespace HotChocolate.Types
             Type? filterType,
             ITypeSystemMember? filterTypeInstance = null)
         {
-            FieldMiddleware placeholder =
-                next => context => Task.CompletedTask;
+            FieldMiddleware placeholder = next => context => default;
 
             descriptor
                 .Use(placeholder)
@@ -92,7 +91,7 @@ namespace HotChocolate.Types
 
                     ITypeReference argumentTypeReference =
                         filterTypeInstance is null
-                            ? (ITypeReference)new ClrTypeReference(argumentType, TypeContext.Input)
+                            ? (ITypeReference)TypeReference.Create(argumentType, TypeContext.Input)
                             : new SchemaTypeReference(filterTypeInstance);
 
                     if (argumentType == typeof(object))
@@ -107,7 +106,7 @@ namespace HotChocolate.Types
 
                     var argumentDefinition = new ArgumentDefinition
                     {
-                        Type = new ClrTypeReference(argumentType, TypeContext.Input)
+                        Type = TypeReference.Create(argumentType, TypeContext.Input)
                     };
 
                     argumentDefinition.ConfigureArgumentName();
@@ -133,7 +132,7 @@ namespace HotChocolate.Types
         }
 
         private static void CompileMiddleware(
-            ICompletionContext context,
+            ITypeCompletionContext context,
             ObjectFieldDefinition definition,
             ITypeReference argumentTypeReference,
             FieldMiddleware placeholder)
@@ -155,7 +154,7 @@ namespace HotChocolate.Types
         {
             return descriptor.Argument(_whereArgumentNamePlaceholder, a =>
                 a.Extend().OnBeforeCreate(d =>
-                    d.ConfigureArgumentName().Type = new ClrTypeReference(
+                    d.ConfigureArgumentName().Type = TypeReference.Create(
                         filterType, TypeContext.Input)));
         }
 

--- a/src/HotChocolate/Filters2/src/Types.Filters/Fields/IAndField.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/Fields/IAndField.cs
@@ -2,7 +2,7 @@ namespace HotChocolate.Types.Filters
 {
     public interface IAndField
         : IInputField
-        , IHasClrType
+        , IHasRuntimeType
     {
     }
 }

--- a/src/HotChocolate/Filters2/src/Types.Filters/Fields/IFilterOperationField.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/Fields/IFilterOperationField.cs
@@ -2,7 +2,7 @@ namespace HotChocolate.Types.Filters
 {
     public interface IFilterOperationField
         : IInputField
-        , IHasClrType
+        , IHasRuntimeType
     {
         FilterOperation Operation { get; }
     }

--- a/src/HotChocolate/Filters2/src/Types.Filters/Fields/IOrField.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/Fields/IOrField.cs
@@ -2,7 +2,7 @@ namespace HotChocolate.Types.Filters
 {
     public interface IOrField
         : IInputField
-        , IHasClrType
+        , IHasRuntimeType
     {
     }
 }

--- a/src/HotChocolate/Filters2/src/Types.Filters/FilterFieldDescriptorBase.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/FilterFieldDescriptorBase.cs
@@ -32,7 +32,7 @@ namespace HotChocolate.Types.Filters
             _namingConvention = context.GetFilterNamingConvention();
         }
 
-        internal protected sealed override FilterFieldDefintion Definition { get; } =
+        internal protected sealed override FilterFieldDefintion Definition { get; protected set; } =
             new FilterFieldDefintion();
 
         protected ICollection<FilterOperationDescriptorBase> Filters { get; } =
@@ -175,7 +175,7 @@ namespace HotChocolate.Types.Filters
         {
             ITypeReference reference = Definition.Type;
 
-            if (reference is IClrTypeReference clrRef)
+            if (reference is ClrTypeReference clrRef)
             {
                 if (BaseTypes.IsSchemaType(clrRef.Type))
                 {
@@ -189,12 +189,12 @@ namespace HotChocolate.Types.Filters
                 }
             }
 
-            if (reference is ISchemaTypeReference schemaRef)
+            if (reference is SchemaTypeReference schemaRef)
             {
                 return schemaRef.WithType(new ListType((IType)schemaRef.Type));
             }
 
-            if (reference is ISyntaxTypeReference syntaxRef)
+            if (reference is SyntaxTypeReference syntaxRef)
             {
                 return syntaxRef.WithType(new ListTypeNode(syntaxRef.Type));
             }
@@ -211,7 +211,7 @@ namespace HotChocolate.Types.Filters
         protected static ITypeReference RewriteTypeToNullableType(ITypeReference reference)
         {
 
-            if (reference is IClrTypeReference clrRef
+            if (reference is ClrTypeReference clrRef
                 && TypeInspector.Default.TryCreate(
                     clrRef.Type,
                     out Utilities.TypeInfo typeInfo))
@@ -249,14 +249,14 @@ namespace HotChocolate.Types.Filters
                 }
             }
 
-            if (reference is ISchemaTypeReference schemaRef)
+            if (reference is SchemaTypeReference schemaRef)
             {
                 return schemaRef.Type is NonNullType nnt
                     ? schemaRef.WithType(nnt)
                     : schemaRef;
             }
 
-            if (reference is ISyntaxTypeReference syntaxRef)
+            if (reference is SyntaxTypeReference syntaxRef)
             {
                 return syntaxRef.Type is NonNullTypeNode nnt
                     ? syntaxRef.WithType(nnt)

--- a/src/HotChocolate/Filters2/src/Types.Filters/FilterInputType.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/FilterInputType.cs
@@ -29,7 +29,7 @@ namespace HotChocolate.Types.Filters
         #region Configuration
 
         protected override InputObjectTypeDefinition CreateDefinition(
-            IInitializationContext context)
+            ITypeDiscoveryContext context)
         {
             var descriptor = FilterInputTypeDescriptor<T>.New(
                 context.DescriptorContext,
@@ -39,7 +39,7 @@ namespace HotChocolate.Types.Filters
         }
 
         protected override void OnRegisterDependencies(
-            IInitializationContext context,
+            ITypeDiscoveryContext context,
             InputObjectTypeDefinition definition)
         {
             base.OnRegisterDependencies(context, definition);
@@ -53,7 +53,7 @@ namespace HotChocolate.Types.Filters
         }
 
         protected override void OnCompleteType(
-            ICompletionContext context,
+            ITypeCompletionContext context,
             InputObjectTypeDefinition definition)
         {
             base.OnCompleteType(context, definition);
@@ -66,7 +66,7 @@ namespace HotChocolate.Types.Filters
         }
 
         protected override void OnCompleteFields(
-            ICompletionContext context,
+            ITypeCompletionContext context,
             InputObjectTypeDefinition definition,
             ICollection<InputField> fields)
         {

--- a/src/HotChocolate/Filters2/src/Types.Filters/FilterInputTypeDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/FilterInputTypeDescriptor.cs
@@ -17,7 +17,6 @@ namespace HotChocolate.Types.Filters
         : DescriptorBase<FilterInputTypeDefinition>
         , IFilterInputTypeDescriptor<T>
     {
-
         protected FilterInputTypeDescriptor(
             IDescriptorContext context,
             Type entityType)
@@ -26,7 +25,7 @@ namespace HotChocolate.Types.Filters
             IFilterNamingConvention convention = context.GetFilterNamingConvention();
             Definition.EntityType = entityType
                 ?? throw new ArgumentNullException(nameof(entityType));
-            Definition.ClrType = typeof(object);
+            Definition.RuntimeType = typeof(object);
             Definition.Name = convention.GetFilterTypeName(context, entityType);
             // TODO : should we rework get type description?
             Definition.Description = context.Naming.GetTypeDescription(
@@ -35,7 +34,7 @@ namespace HotChocolate.Types.Filters
                 context.Options.DefaultBindingBehavior;
         }
 
-        protected internal sealed override FilterInputTypeDefinition Definition { get; } =
+        internal protected sealed override FilterInputTypeDefinition Definition { get; protected set; } =
             new FilterInputTypeDefinition();
 
         protected List<FilterFieldDescriptorBase> Fields { get; } =

--- a/src/HotChocolate/Filters2/src/Types.Filters/FilterOperationDescriptorBase.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/FilterOperationDescriptorBase.cs
@@ -11,7 +11,7 @@ namespace HotChocolate.Types.Filters
         {
         }
 
-        internal protected override FilterOperationDefintion Definition { get; } =
+        internal protected override FilterOperationDefintion Definition { get; protected set; } =
             new FilterOperationDefintion();
 
         protected void Name(NameString value)

--- a/src/HotChocolate/Filters2/src/Types.Filters/IQueryableFilterVisitorContext.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/IQueryableFilterVisitorContext.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.Types.Filters
 
         IReadOnlyList<IExpressionFieldHandler> FieldHandlers { get; }
 
-        ITypeConversion TypeConverter { get; }
+        ITypeConverter TypeConverter { get; }
 
         bool InMemory { get; }
 

--- a/src/HotChocolate/Filters2/src/Types.Filters/Object/ObjectFilterFieldDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/Object/ObjectFilterFieldDescriptor.cs
@@ -60,11 +60,10 @@ namespace HotChocolate.Types.Filters
                 Context,
                 this,
                 CreateFieldName(operationKind),
-                new ClrTypeReference(
+                TypeReference.Create(
                     typeof(FilterInputType<>).MakeGenericType(_type),
                     Definition.Type.Context,
-                    true,
-                    true),
+                    nullable: new[] { true, true }),
                 operation);
         }
 

--- a/src/HotChocolate/Filters2/src/Types.Filters/Object/ObjectFilterFieldDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/Object/ObjectFilterFieldDescriptor.cs
@@ -62,8 +62,7 @@ namespace HotChocolate.Types.Filters
                 CreateFieldName(operationKind),
                 TypeReference.Create(
                     typeof(FilterInputType<>).MakeGenericType(_type),
-                    Definition.Type.Context,
-                    nullable: new[] { true, true }),
+                    Definition.Type.Context),
                 operation);
         }
 

--- a/src/HotChocolate/Filters2/src/Types.Filters/QueryableFilterMiddleware.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/QueryableFilterMiddleware.cs
@@ -12,16 +12,17 @@ namespace HotChocolate.Types.Filters
     public class QueryableFilterMiddleware<T>
     {
         private readonly FieldDelegate _next;
-        private readonly ITypeConversion _converter;
+        private readonly ITypeConverter _converter;
         private readonly FilterMiddlewareContext _contextData;
 
         public QueryableFilterMiddleware(
             FieldDelegate next,
             FilterMiddlewareContext contextData,
-            ITypeConversion converter)
+            ITypeConverter converter)
         {
-            _next = next ?? throw new ArgumentNullException(nameof(next));
-            _converter = converter ?? TypeConversion.Default;
+            _next = next 
+                ?? throw new ArgumentNullException(nameof(next));
+            _converter = converter;
             _contextData = contextData
                  ?? throw new ArgumentNullException(nameof(contextData));
         }
@@ -30,7 +31,7 @@ namespace HotChocolate.Types.Filters
         {
             await _next(context).ConfigureAwait(false);
 
-            IValueNode filter = context.Argument<IValueNode>(_contextData.ArgumentName);
+            IValueNode filter = context.ArgumentLiteral<IValueNode>(_contextData.ArgumentName);
 
             if (filter is null || filter is NullValueNode)
             {

--- a/src/HotChocolate/Filters2/src/Types.Filters/QueryableFilterVisitor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/QueryableFilterVisitor.cs
@@ -12,7 +12,6 @@ namespace HotChocolate.Types.Filters
     {
         protected QueryableFilterVisitor()
         {
-
         }
 
         #region Object Value

--- a/src/HotChocolate/Filters2/src/Types.Filters/QueryableVisitorContext.cs
+++ b/src/HotChocolate/Filters2/src/Types.Filters/QueryableVisitorContext.cs
@@ -6,13 +6,14 @@ using HotChocolate.Utilities;
 namespace HotChocolate.Types.Filters
 {
     public class QueryableFilterVisitorContext
-        : FilterVisitorContextBase, IQueryableFilterVisitorContext
+        : FilterVisitorContextBase
+        , IQueryableFilterVisitorContext
     {
 
         public QueryableFilterVisitorContext(
             InputObjectType initialType,
             Type source,
-            ITypeConversion converter,
+            ITypeConverter converter,
             bool inMemory)
             : this(
                 initialType,
@@ -29,7 +30,7 @@ namespace HotChocolate.Types.Filters
             Type source,
             IReadOnlyList<IExpressionOperationHandler> operationHandlers,
             IReadOnlyList<IExpressionFieldHandler> fieldHandlers,
-            ITypeConversion typeConverter,
+            ITypeConverter typeConverter,
             bool inMemory)
             : base(initialType)
         {
@@ -52,7 +53,7 @@ namespace HotChocolate.Types.Filters
 
         public IReadOnlyList<IExpressionFieldHandler> FieldHandlers { get; }
 
-        public ITypeConversion TypeConverter { get; }
+        public ITypeConverter TypeConverter { get; }
 
         public bool InMemory { get; }
 

--- a/src/HotChocolate/Filters2/src/Types.Selections/Extensions/SelectionObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Filters2/src/Types.Selections/Extensions/SelectionObjectFieldDescriptorExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using HotChocolate.Configuration;
 using HotChocolate.Resolvers;
 using HotChocolate.Types.Descriptors;
@@ -40,8 +39,7 @@ namespace HotChocolate.Types
             IObjectFieldDescriptor descriptor,
             Type? objectType)
         {
-            FieldMiddleware placeholder =
-                next => context => Task.CompletedTask;
+            FieldMiddleware placeholder = next => context => default;
 
             descriptor
                 .Use(placeholder)
@@ -86,7 +84,7 @@ namespace HotChocolate.Types
             Type type,
             ObjectFieldDefinition definition,
             FieldMiddleware placeholder,
-            ICompletionContext context)
+            ITypeCompletionContext context)
         {
             string filterConventionArgumentName =
                 context.DescriptorContext.GetFilterNamingConvention().ArgumentName;

--- a/src/HotChocolate/Filters2/src/Types.Selections/Extensions/SingleOrDefaultObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Filters2/src/Types.Selections/Extensions/SingleOrDefaultObjectFieldDescriptorExtensions.cs
@@ -108,7 +108,7 @@ namespace HotChocolate.Types
                             .Build());
                 }
 
-                return new ClrTypeReference(rewritten, TypeContext.Output);
+                return TypeReference.Create(rewritten, TypeContext.Output);
             }
 
             throw new NotSupportedException();

--- a/src/HotChocolate/Filters2/src/Types.Selections/Extensions/SingleOrDefaultObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Filters2/src/Types.Selections/Extensions/SingleOrDefaultObjectFieldDescriptorExtensions.cs
@@ -32,7 +32,7 @@ namespace HotChocolate.Types
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            FieldMiddleware placeholder = next => context => Task.CompletedTask;
+            FieldMiddleware placeholder = next => context => default;
 
             descriptor
                 .Use(placeholder)
@@ -90,7 +90,7 @@ namespace HotChocolate.Types
 
         private static ITypeReference RewriteToNonNullableType(ITypeReference type)
         {
-            if (type is IClrTypeReference clrTypeRef)
+            if (type is ClrTypeReference clrTypeRef)
             {
                 Type rewritten = Unwrap(UnwrapNonNull(Unwrap(clrTypeRef.Type)));
 

--- a/src/HotChocolate/Filters2/src/Types.Selections/Handlers/TakeHandlerBase.cs
+++ b/src/HotChocolate/Filters2/src/Types.Selections/Handlers/TakeHandlerBase.cs
@@ -23,7 +23,7 @@ namespace HotChocolate.Types.Selections.Handlers
             IFieldSelection selection,
             Expression expression)
         {
-            ObjectField field = context.FieldSelection.Field;
+            IObjectField field = context.FieldSelection.Field;
             if (field.ContextData.ContainsKey(_contextDataKey) &&
                 field.Member is PropertyInfo propertyInfo)
             {

--- a/src/HotChocolate/Filters2/src/Types.Selections/SelectionMiddleware~1.cs
+++ b/src/HotChocolate/Filters2/src/Types.Selections/SelectionMiddleware~1.cs
@@ -11,15 +11,15 @@ namespace HotChocolate.Types.Selections
     {
         private readonly FieldDelegate _next;
         private readonly SelectionMiddlewareContext _context;
-        private readonly ITypeConversion _converter;
+        private readonly ITypeConverter _converter;
         public SelectionMiddleware(
             FieldDelegate next,
             SelectionMiddlewareContext context,
-            ITypeConversion converter)
+            ITypeConverter converter)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _context = context ?? throw new ArgumentNullException(nameof(context));
-            _converter = converter ?? TypeConversion.Default;
+            _converter = converter ?? throw new ArgumentNullException(nameof(context));
         }
 
         public async Task InvokeAsync(IMiddlewareContext context)

--- a/src/HotChocolate/Filters2/src/Types.Selections/SelectionVisitor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Selections/SelectionVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using HotChocolate.Execution;
+using HotChocolate.Execution.Utilities;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using HotChocolate.Types.Selections.Handlers;
@@ -13,13 +14,13 @@ namespace HotChocolate.Types.Selections
     public class SelectionVisitor
         : SelectionVisitorBase
     {
-        private readonly ITypeConversion _converter;
+        private readonly ITypeConverter _converter;
         private readonly SelectionMiddlewareContext _selectionMiddlewareContext;
         private readonly IReadOnlyList<IListHandler> _listHandler = ListHandlers.All;
 
         public SelectionVisitor(
             IResolverContext context,
-            ITypeConversion converter,
+            ITypeConverter converter,
             SelectionMiddlewareContext selectionMiddlewareContext)
             : base(context)
         {
@@ -30,7 +31,7 @@ namespace HotChocolate.Types.Selections
         protected Stack<SelectionClosure> Closures { get; } =
             new Stack<SelectionClosure>();
 
-        public void Accept(ObjectField field)
+        public void Accept(IObjectField field)
         {
             IOutputType type = field.Type;
             SelectionSetNode? selectionSet = Context.FieldSelection.SelectionSet;
@@ -99,7 +100,7 @@ namespace HotChocolate.Types.Selections
                     Expression.Property(
                         Closures.Peek().Instance.Peek(), propertyInfo);
 
-                if (selection is FieldSelection fieldSelection)
+                if (selection is IPreparedSelection fieldSelection)
                 {
                     var context = new SelectionVisitorContext(
                         Context,
@@ -157,7 +158,7 @@ namespace HotChocolate.Types.Selections
             {
                 var nextClosure =
                     new SelectionClosure(
-                        selection.Field.ClrType, "e" + Closures.Count);
+                        selection.Field.RuntimeType, "e" + Closures.Count);
 
                 nextClosure.Instance.Push(
                     Expression.Property(

--- a/src/HotChocolate/Filters2/src/Types.Selections/SelectionVisitorBase.cs
+++ b/src/HotChocolate/Filters2/src/Types.Selections/SelectionVisitorBase.cs
@@ -19,8 +19,8 @@ namespace HotChocolate.Types.Selections
                 ?? throw new ArgumentNullException(nameof(context));
         }
 
-        protected Stack<ObjectField> Fields { get; } =
-            new Stack<ObjectField>();
+        protected Stack<IObjectField> Fields { get; } =
+            new Stack<IObjectField>();
 
         protected readonly IResolverContext Context;
 
@@ -175,7 +175,7 @@ namespace HotChocolate.Types.Selections
             if (outputType.ToClrType() == typeof(IConnection) &&
                outputType.NamedType() is ObjectType type)
             {
-                foreach (IFieldSelection selection in Context.CollectFields(type, selectionSet))
+                foreach (IFieldSelection selection in Context.GetSelections(type, selectionSet))
                 {
                     IFieldSelection? currentSelection = GetPagingFieldOrDefault(selection);
 
@@ -208,7 +208,7 @@ namespace HotChocolate.Types.Selections
                 selection.Field.Type.NamedType() is ObjectType edgeType)
             {
                 return Context
-                    .CollectFields(edgeType, selection.Selection.SelectionSet)
+                    .GetSelections(edgeType, selection.Selection.SelectionSet)
                     .FirstOrDefault(x => x.Field.Name == "node");
             }
             return default;
@@ -236,7 +236,7 @@ namespace HotChocolate.Types.Selections
             ObjectType type,
             SelectionSetNode selectionSet)
         {
-            IReadOnlyList<IFieldSelection> selections = Context.CollectFields(type, selectionSet);
+            IReadOnlyList<IFieldSelection> selections = Context.GetSelections(type, selectionSet);
             if (HasNonProjectableField(selections))
             {
                 var fieldSelections = new List<ISelectionNode>();
@@ -248,7 +248,7 @@ namespace HotChocolate.Types.Selections
                     }
                 }
                 selectionSet = selectionSet.AddSelections(fieldSelections.ToArray());
-                selections = Context.CollectFields(type, selectionSet);
+                selections = Context.GetSelections(type, selectionSet);
             }
             return selections;
         }

--- a/src/HotChocolate/Filters2/src/Types.Selections/SelectionVisitorContext.cs
+++ b/src/HotChocolate/Filters2/src/Types.Selections/SelectionVisitorContext.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using HotChocolate.Execution;
+using HotChocolate.Execution.Utilities;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using HotChocolate.Utilities;
@@ -9,56 +10,63 @@ namespace HotChocolate.Types.Selections
 {
     public class SelectionVisitorContext
     {
-        private readonly IReadOnlyDictionary<NameString, ArgumentValue> _arguments;
+        private readonly IReadOnlyDictionary<NameString, PreparedArgument> _arguments;
         private readonly IResolverContext _context;
 
         public SelectionVisitorContext(
             IResolverContext context,
-            ITypeConversion conversion,
-            FieldSelection fieldSelection,
+            ITypeConverter conversion,
+            IPreparedSelection fieldSelection,
             SelectionMiddlewareContext selectionMiddlewareContext)
         {
             Conversion = conversion;
             FieldSelection = fieldSelection;
             SelectionContext = selectionMiddlewareContext;
             _context = context;
-            _arguments = fieldSelection.CoerceArguments(context.Variables, conversion);
-
+            _arguments = CoerceArguments(
+                fieldSelection.Arguments,
+                context.Variables,
+                context.Path);
         }
 
-        public ITypeConversion Conversion { get; }
+        public ITypeConverter Conversion { get; }
 
-        public FieldSelection FieldSelection { get; }
+        public IPreparedSelection FieldSelection { get; }
 
         public SelectionMiddlewareContext SelectionContext { get; }
 
-        public bool TryGetValueNode(string key, [NotNullWhen(true)] out IValueNode? arg)
+        public bool TryGetValueNode(string key, [NotNullWhen(true)] out IValueNode? value)
         {
-            if (_arguments.TryGetValue(key, out ArgumentValue argumentValue) &&
-                argumentValue.Literal != null &&
-                !(argumentValue.Literal is NullValueNode))
+            if (_arguments.TryGetValue(key, out PreparedArgument? argument) &&
+                argument.ValueLiteral is { } &&
+                argument.ValueLiteral.Kind != NodeKind.NullValue)
             {
-                EnsureNoError(argumentValue);
-
-                IValueNode literal = argumentValue.Literal;
-
-                arg = VariableToValueRewriter.Rewrite(
-                    literal,
-                    argumentValue.Type,
-                     _context.Variables, Conversion);
-
+                value = argument.ValueLiteral;
                 return true;
             }
-            arg = null;
+            value = null;
             return false;
         }
 
-        protected void EnsureNoError(ArgumentValue argumentValue)
+        private static IReadOnlyDictionary<NameString, PreparedArgument> CoerceArguments(
+            IPreparedArgumentMap arguments,
+            IVariableValueCollection variables,
+            Path path)
         {
-            if (argumentValue.Error != null)
+            List<IError>? errors = null;
+
+            void ReportError(IError c) =>
+                (errors ??= new List<IError>()).Add(c);
+
+            if (arguments.TryCoerceArguments(
+                variables,
+                ReportError,
+                out IReadOnlyDictionary<NameString, PreparedArgument>? coercedArgs))
             {
-                throw new QueryException(argumentValue.Error);
+                return coercedArgs;
             }
+
+            throw new GraphQLException(errors);
         }
     }
 }

--- a/src/HotChocolate/Filters2/src/Types.Sorting/Extensions/SortObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/Extensions/SortObjectFieldDescriptorExtensions.cs
@@ -64,8 +64,7 @@ namespace HotChocolate.Types
             Type? sortType,
             ITypeSystemMember? sortTypeInstance = null)
         {
-            FieldMiddleware placeholder =
-                next => context => Task.CompletedTask;
+            FieldMiddleware placeholder = next => context => default;
 
             descriptor
                 .Use(placeholder)
@@ -76,13 +75,13 @@ namespace HotChocolate.Types
 
                     ITypeReference argumentTypeReference =
                         sortTypeInstance is null
-                            ? (ITypeReference)new ClrTypeReference(
+                            ? (ITypeReference)TypeReference.Create(
                                 argumentType, TypeContext.Input)
                             : new SchemaTypeReference(sortTypeInstance);
 
                     var argumentDefinition = new ArgumentDefinition
                     {
-                        Type = new ClrTypeReference(
+                        Type = TypeReference.Create(
                             argumentType, TypeContext.Input)
                     };
 
@@ -159,7 +158,7 @@ namespace HotChocolate.Types
         }
 
         private static void CompileMiddleware(
-            ICompletionContext context,
+            ITypeCompletionContext context,
             ObjectFieldDefinition definition,
             ITypeReference argumentTypeReference,
             FieldMiddleware placeholder)

--- a/src/HotChocolate/Filters2/src/Types.Sorting/IgnoredSortingFieldDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/IgnoredSortingFieldDescriptor.cs
@@ -30,7 +30,7 @@ namespace HotChocolate.Types.Sorting
             IDescriptorContext context)
         {
             var operation = new SortOperation(property);
-            var typeReference = new ClrTypeReference(
+            var typeReference = TypeReference.Create(
                 typeof(SortOperationKindType),
                 TypeContext.Input);
             NameString name = context.Naming.GetMemberName(

--- a/src/HotChocolate/Filters2/src/Types.Sorting/SortInputType.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/SortInputType.cs
@@ -26,10 +26,8 @@ namespace HotChocolate.Types.Sorting
 
         public Type EntityType { get; private set; } = typeof(object);
 
-        #region Configuration
-
         protected override InputObjectTypeDefinition CreateDefinition(
-            IInitializationContext context)
+            ITypeDiscoveryContext context)
         {
             SortInputTypeDescriptor<T> descriptor =
                 SortInputTypeDescriptor<T>.New(
@@ -40,7 +38,7 @@ namespace HotChocolate.Types.Sorting
         }
 
         protected override void OnRegisterDependencies(
-            IInitializationContext context,
+            ITypeDiscoveryContext context,
             InputObjectTypeDefinition definition)
         {
             base.OnRegisterDependencies(context, definition);
@@ -54,7 +52,7 @@ namespace HotChocolate.Types.Sorting
         }
 
         protected override void OnCompleteType(
-            ICompletionContext context,
+            ITypeCompletionContext context,
             InputObjectTypeDefinition definition)
         {
             base.OnCompleteType(context, definition);
@@ -67,7 +65,7 @@ namespace HotChocolate.Types.Sorting
         }
 
         protected override void OnCompleteFields(
-            ICompletionContext context,
+            ITypeCompletionContext context,
             InputObjectTypeDefinition definition,
             ICollection<InputField> fields)
         {
@@ -78,10 +76,6 @@ namespace HotChocolate.Types.Sorting
             }
         }
 
-        #endregion
-
-        #region Disabled
-
         // we are disabling the default configure method so
         // that this does not lead to confusion.
         protected sealed override void Configure(
@@ -89,7 +83,5 @@ namespace HotChocolate.Types.Sorting
         {
             throw new NotSupportedException();
         }
-
-        #endregion
     }
 }

--- a/src/HotChocolate/Filters2/src/Types.Sorting/SortInputTypeDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/SortInputTypeDescriptor.cs
@@ -24,13 +24,13 @@ namespace HotChocolate.Types.Sorting
             ISortingNamingConvention convention = context.GetSortingNamingConvention();
             Definition.EntityType = entityType
                 ?? throw new ArgumentNullException(nameof(entityType));
-            Definition.ClrType = typeof(object);
+            Definition.RuntimeType = typeof(object);
             Definition.Name = convention.GetSortingTypeName(context, entityType);
             Definition.Description = context.Naming.GetTypeDescription(
                 entityType, TypeKind.Object);
         }
 
-        internal protected sealed override SortInputTypeDefinition Definition { get; } =
+        internal protected sealed override SortInputTypeDefinition Definition { get; protected set; } =
             new SortInputTypeDefinition();
 
         protected ICollection<SortOperationDescriptorBase> Fields { get; } =

--- a/src/HotChocolate/Filters2/src/Types.Sorting/SortObjectOperationDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/SortObjectOperationDescriptor.cs
@@ -80,7 +80,7 @@ namespace HotChocolate.Types.Sorting
             var operation = new SortOperation(property, true);
             NameString name = context.Naming.GetMemberName(
                property, MemberKind.InputObjectField);
-            var typeReference = new ClrTypeReference(
+            var typeReference = TypeReference.Create(
                 typeof(SortInputType<>).MakeGenericType(type),
                 TypeContext.Input);
 

--- a/src/HotChocolate/Filters2/src/Types.Sorting/SortObjectOperationDescriptor~1.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/SortObjectOperationDescriptor~1.cs
@@ -86,7 +86,7 @@ namespace HotChocolate.Types.Sorting
         {
             var operation = new SortOperation(property, true);
             NameString name = context.Naming.GetMemberName(property, MemberKind.InputObjectField);
-            var typeReference = new ClrTypeReference(
+            var typeReference = TypeReference.Create(
                 typeof(SortInputType<>).MakeGenericType(typeof(TObject)),
                 TypeContext.Input);
 

--- a/src/HotChocolate/Filters2/src/Types.Sorting/SortOperationDescriptor.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/SortOperationDescriptor.cs
@@ -18,7 +18,7 @@ namespace HotChocolate.Types.Sorting
         {
         }
 
-        internal protected sealed override SortOperationDefintion Definition { get; } =
+        internal protected sealed override SortOperationDefintion Definition { get; protected set; } =
             new SortOperationDefintion();
 
         protected override void OnCreateDefinition(
@@ -83,7 +83,7 @@ namespace HotChocolate.Types.Sorting
             IDescriptorContext context)
         {
             var operation = new SortOperation(property);
-            var typeReference = new ClrTypeReference(
+            var typeReference = TypeReference.Create(
                 typeof(SortOperationKindType),
                 TypeContext.Input);
             NameString name = context.Naming.GetMemberName(

--- a/src/HotChocolate/Filters2/src/Types.Sorting/SortOperationDescriptorBase.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/SortOperationDescriptorBase.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Reflection;
-using HotChocolate.Language;
 using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Types.Sorting
@@ -22,7 +20,7 @@ namespace HotChocolate.Types.Sorting
                 ?? throw new ArgumentNullException(nameof(operation));
         }
 
-        internal protected override SortOperationDefintion Definition { get; } =
+        internal protected override SortOperationDefintion Definition { get; protected set; } =
             new SortOperationDefintion();
 
         protected void Name(NameString value)

--- a/src/HotChocolate/Filters2/src/Types.Sorting/SortOperationKindType.cs
+++ b/src/HotChocolate/Filters2/src/Types.Sorting/SortOperationKindType.cs
@@ -13,14 +13,14 @@ namespace HotChocolate.Types.Sorting
             descriptor.Value(SortOperationKind.Desc);
         }
 
-        protected override EnumTypeDefinition CreateDefinition(IInitializationContext context)
+        protected override EnumTypeDefinition CreateDefinition(ITypeDiscoveryContext context)
         {
             EnumTypeDefinition definition = base.CreateDefinition(context);
             ISortingNamingConvention convention =
                 context.DescriptorContext.GetSortingNamingConvention();
 
             definition.Name = convention.GetSortingOperationKindTypeName(
-                context.DescriptorContext, definition.ClrType);
+                context.DescriptorContext, definition.RuntimeType);
 
             foreach (EnumValueDefinition value in definition.Values)
             {

--- a/src/HotChocolate/Filters2/test/Directory.Build.props
+++ b/src/HotChocolate/Filters2/test/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -14,7 +14,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.2" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.5" />
   </ItemGroup>
 
 </Project>

--- a/src/HotChocolate/Filters2/test/Types.Filters.Mongo.Tests/ArrayFilterTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Mongo.Tests/ArrayFilterTests.cs
@@ -50,7 +50,7 @@ namespace HotChocolate.Types.Filters
                 .BindClrType<ObjectId, IdType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -95,7 +95,7 @@ namespace HotChocolate.Types.Filters
                 .BindClrType<ObjectId, IdType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -140,7 +140,7 @@ namespace HotChocolate.Types.Filters
                 .BindClrType<ObjectId, IdType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -185,7 +185,7 @@ namespace HotChocolate.Types.Filters
                 .BindClrType<ObjectId, IdType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(

--- a/src/HotChocolate/Filters2/test/Types.Filters.Mongo.Tests/MongoFilterTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Mongo.Tests/MongoFilterTests.cs
@@ -45,7 +45,7 @@ namespace HotChocolate.Types.Filters
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items { foo } }")
@@ -81,7 +81,7 @@ namespace HotChocolate.Types.Filters
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items(where: { foo: \"abc\" }) { foo } }")
@@ -143,7 +143,7 @@ namespace HotChocolate.Types.Filters
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -181,7 +181,7 @@ namespace HotChocolate.Types.Filters
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ paging(where: { foo: \"abc\" }) { nodes { foo } } }")
@@ -217,7 +217,7 @@ namespace HotChocolate.Types.Filters
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ paging(where: { baz: true }) { nodes { foo } } }")
@@ -253,7 +253,7 @@ namespace HotChocolate.Types.Filters
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ paging(where: { baz_not: false }) { nodes { foo } } }")
@@ -289,7 +289,7 @@ namespace HotChocolate.Types.Filters
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items(where: { time_gt: \"2001-01-01\" }) { time } }")
@@ -325,7 +325,7 @@ namespace HotChocolate.Types.Filters
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items(where: { date_gt: \"2001-01-01\" }) { date } }")

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/FilterFieldCollectionExtensionTest.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/FilterFieldCollectionExtensionTest.cs
@@ -245,7 +245,7 @@ namespace HotChocolate.Types.Filters
         {
             var descirptor = new BooleanFilterFieldDescriptor(
                 _descriptorContext, _propertyInfo);
-            var typeReference = new ClrTypeReference(typeof(Foo), TypeContext.Input);
+            var typeReference = TypeReference.Create(typeof(Foo), TypeContext.Input);
             var definition = new FilterOperationDefintion()
             {
                 Name = "Foo",
@@ -273,7 +273,7 @@ namespace HotChocolate.Types.Filters
         {
             var descirptor = new ComparableFilterFieldDescriptor(
                 _descriptorContext, _propertyInfo);
-            var typeReference = new ClrTypeReference(typeof(Foo), TypeContext.Input);
+            var typeReference = TypeReference.Create(typeof(Foo), TypeContext.Input);
             var definition = new FilterOperationDefintion()
             {
                 Name = "Foo",

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/FilterInputTypeTest.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/FilterInputTypeTest.cs
@@ -1,7 +1,5 @@
-using System.Linq;
-using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using HotChocolate.Language;
 using Snapshooter.Xunit;
 using Xunit;
@@ -11,45 +9,37 @@ namespace HotChocolate.Types.Filters
     public class FilterInputTypeTest
         : TypeTestBase
     {
-
         [Fact]
         public void FilterInputType_DynamicName()
         {
             // arrange
             // act
-            ISchema schema = CreateSchema(s => s.AddType(new FilterInputType<Foo>(
-                 d => d
-                     .Name(dep => dep.Name + "Foo")
-                     .DependsOn<StringType>()
-                     .Filter(x => x.Bar)
-                     .BindFiltersExplicitly()
-                     .AllowEquals()
-                     )
-                 )
-             );
-
+            ISchema schema = CreateSchema(
+                s => s.AddType(
+                    new FilterInputType<Foo>(d => d
+                        .Name(dep => dep.Name + "Foo")
+                        .DependsOn<StringType>()
+                        .Filter(x => x.Bar)
+                        .BindFiltersExplicitly()
+                        .AllowEquals())));
 
             // assert
             schema.ToString().MatchSnapshot();
         }
-
 
         [Fact]
         public void FilterInputType_DynamicName_NonGeneric()
         {
             // arrange
             // act
-            ISchema schema = CreateSchema(s => s.AddType(new FilterInputType<Foo>(
-                 d => d
-                     .Name(dep => dep.Name + "Foo")
-                     .DependsOn(typeof(StringType))
-                     .Filter(x => x.Bar)
-                     .BindFiltersExplicitly()
-                     .AllowEquals()
-                     )
-                 )
-             );
-
+            ISchema schema = CreateSchema(
+                s => s.AddType(
+                    new FilterInputType<Foo>(d => d
+                        .Name(dep => dep.Name + "Foo")
+                        .DependsOn(typeof(StringType))
+                        .Filter(x => x.Bar)
+                        .BindFiltersExplicitly()
+                        .AllowEquals())));
 
             // assert
             schema.ToString().MatchSnapshot();
@@ -60,15 +50,15 @@ namespace HotChocolate.Types.Filters
         {
             // arrange
             // act
-            ISchema schema = CreateSchema(s => s.AddDirectiveType<FooDirectiveType>()
-             .AddType(new FilterInputType<Foo>(
-                 d => d.Directive("foo")
-                     .Filter(x => x.Bar)
-                     .BindFiltersExplicitly()
-                     .AllowEquals()
-                     )
-                )
-            );
+            ISchema schema = CreateSchema(
+                s => s
+                    .AddDirectiveType<FooDirectiveType>()
+                    .AddType(new FilterInputType<Foo>(
+                        d => d
+                            .Directive("foo")
+                            .Filter(x => x.Bar)
+                            .BindFiltersExplicitly()
+                            .AllowEquals())));
 
             // assert
             schema.ToString().MatchSnapshot();
@@ -218,17 +208,21 @@ namespace HotChocolate.Types.Filters
 
         public class Query
         {
-            [GraphQLNonNullType]
+            [GraphQLNonNullType(false, false)]
             public IQueryable<Book> Books() => new List<Book>().AsQueryable();
         }
 
         public class Book
         {
             public int Id { get; set; }
+
             [GraphQLNonNullType]
             public string Title { get; set; }
+
             public int Pages { get; set; }
+
             public int Chapters { get; set; }
+
             [GraphQLNonNullType]
             public Author Author { get; set; }
         }

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/NoNullQueryFilterTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/NoNullQueryFilterTests.cs
@@ -30,7 +30,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<QueryType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterTests.cs
@@ -50,7 +50,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<QueryType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -68,7 +68,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<QueryType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -95,7 +95,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<QueryType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -125,7 +125,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<QueryType>()
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -155,7 +155,7 @@ namespace HotChocolate.Types.Filters
                     )
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ list(where: { fooNested: { bar: \"a\" } }) { fooNested { bar } } }")
@@ -187,7 +187,7 @@ namespace HotChocolate.Types.Filters
                     )
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ list(where: { fooNested: {bar: \"a\"} }) { fooNested { bar } } }")
@@ -208,7 +208,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -226,7 +226,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -244,7 +244,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -262,7 +262,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -280,7 +280,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -298,7 +298,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -316,7 +316,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -334,7 +334,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -353,7 +353,7 @@ namespace HotChocolate.Types.Filters
                 .AddQueryType<Query>(d => d.Field(t => t.Foos).UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -375,7 +375,7 @@ namespace HotChocolate.Types.Filters
                     .UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ foo(where: { foo_gte: \"2019-06-01\"}) { foo } }")
@@ -399,7 +399,7 @@ namespace HotChocolate.Types.Filters
                     .UseFiltering())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorArrayTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorArrayTests.cs
@@ -29,7 +29,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(FooSimple),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<FooSimple, bool> func = filter.CreateFilter<FooSimple>().Compile();
@@ -58,7 +58,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(FooSimple),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<FooSimple, bool> func = filter.CreateFilter<FooSimple>().Compile();
@@ -94,7 +94,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(FooSimple),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<FooSimple, bool> func = filter.CreateFilter<FooSimple>().Compile();
@@ -130,7 +130,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
@@ -178,7 +178,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
@@ -240,7 +240,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
@@ -300,7 +300,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
@@ -379,7 +379,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
@@ -418,7 +418,7 @@ namespace HotChocolate.Types.Filters
             var filter = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorBooleanTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorBooleanTests.cs
@@ -20,7 +20,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var filter = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
 
@@ -44,7 +44,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var filter = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
 
@@ -68,7 +68,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var filter = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
 
@@ -95,7 +95,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var filter = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<FooNullable, bool> func = filter.CreateFilter<FooNullable>().Compile();
 

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorComparableTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorComparableTests.cs
@@ -22,7 +22,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -46,7 +46,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -71,7 +71,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -98,7 +98,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -126,7 +126,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -153,7 +153,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var filter = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
 
@@ -182,7 +182,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var filter = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, filter);
             Func<Foo, bool> func = filter.CreateFilter<Foo>().Compile();
 
@@ -209,7 +209,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -237,7 +237,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -264,7 +264,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -296,7 +296,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooType, typeof(Foo), TypeConversion.Default, true);
+                fooType, typeof(Foo), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
 
@@ -323,7 +323,7 @@ namespace HotChocolate.Types.Filters
             // act
             var context = new QueryableFilterVisitorContext(
                 fooType, typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<Foo, bool> func = context.CreateFilter<Foo>().Compile();
@@ -348,7 +348,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -375,7 +375,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -403,7 +403,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -433,7 +433,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -464,7 +464,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -494,7 +494,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -526,7 +526,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -556,7 +556,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -587,7 +587,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -617,7 +617,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -652,7 +652,7 @@ namespace HotChocolate.Types.Filters
 
             // act
             var context = new QueryableFilterVisitorContext(
-                fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+                fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 
@@ -680,7 +680,7 @@ namespace HotChocolate.Types.Filters
             FooNullableFilterType fooNullableType = CreateType(new FooNullableFilterType());
 
             // act
-            var context = new QueryableFilterVisitorContext(fooNullableType, typeof(FooNullable), TypeConversion.Default, true);
+            var context = new QueryableFilterVisitorContext(fooNullableType, typeof(FooNullable), DefaultTypeConverter.Default, true);
             QueryableFilterVisitor.Default.Visit(value, context);
             Func<FooNullable, bool> func = context.CreateFilter<FooNullable>().Compile();
 

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorObjectTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorObjectTests.cs
@@ -28,7 +28,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -61,7 +61,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -98,7 +98,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(EvenDeeper),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<EvenDeeper, bool> func = filterContext.CreateFilter<EvenDeeper>().Compile();
@@ -135,7 +135,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Recursive),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Recursive, bool> func = filterContext.CreateFilter<Recursive>().Compile();
@@ -174,7 +174,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(EvenDeeper),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<EvenDeeper, bool> func = filterContext.CreateFilter<EvenDeeper>().Compile();
@@ -227,7 +227,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(EvenDeeper),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<EvenDeeper, bool> func = filterContext.CreateFilter<EvenDeeper>().Compile();

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorStringTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorStringTests.cs
@@ -22,7 +22,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -49,7 +49,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -80,7 +80,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -107,7 +107,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -138,7 +138,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -165,7 +165,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -192,7 +192,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -219,7 +219,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -246,7 +246,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -273,7 +273,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();
@@ -300,7 +300,7 @@ namespace HotChocolate.Types.Filters
             var filterContext = new QueryableFilterVisitorContext(
                 fooType,
                 typeof(Foo),
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             QueryableFilterVisitor.Default.Visit(value, filterContext);
             Func<Foo, bool> func = filterContext.CreateFilter<Foo>().Compile();

--- a/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorTest.cs
+++ b/src/HotChocolate/Filters2/test/Types.Filters.Tests/QueryableFilterVisitorTest.cs
@@ -22,7 +22,7 @@ namespace HotChocolate.Types.Filters
                 typeof(Foo),
                 null,
                 ExpressionFieldHandlers.All,
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             };
 
@@ -45,7 +45,7 @@ namespace HotChocolate.Types.Filters
                 typeof(Foo),
                 ExpressionOperationHandlers.All,
                 null,
-                TypeConversion.Default,
+                DefaultTypeConverter.Default,
                 true);
             };
 
@@ -82,7 +82,7 @@ namespace HotChocolate.Types.Filters
             Action action = () =>
             {
                 new QueryableFilterVisitorContext(
-                fooType, null, TypeConversion.Default, true);
+                fooType, null, DefaultTypeConverter.Default, true);
             };
 
             // act
@@ -98,7 +98,7 @@ namespace HotChocolate.Types.Filters
             Action action = () =>
             {
                 new QueryableFilterVisitorContext(
-                null, typeof(Foo), TypeConversion.Default, true);
+                null, typeof(Foo), DefaultTypeConverter.Default, true);
             };
 
             // act

--- a/src/HotChocolate/Filters2/test/Types.Selections.InMemory.Tests/SelectionAttributeTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.InMemory.Tests/SelectionAttributeTests.cs
@@ -41,7 +41,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as IQueryable<Foo>;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.InMemory.Tests/SelectionTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.InMemory.Tests/SelectionTests.cs
@@ -46,7 +46,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -92,7 +92,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -138,7 +138,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -184,7 +184,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -234,7 +234,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -283,7 +283,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -335,7 +335,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -384,7 +384,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -434,7 +434,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -484,7 +484,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -534,7 +534,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -584,7 +584,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -635,7 +635,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -686,7 +686,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -737,7 +737,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -793,7 +793,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -837,7 +837,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -898,7 +898,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -948,7 +948,7 @@ namespace HotChocolate.Types.Selections
                         .UseFiltering()
                         .UseSorting())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -991,7 +991,7 @@ namespace HotChocolate.Types.Selections
                         .UseFiltering()
                         .UseSorting())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1041,7 +1041,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1091,7 +1091,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute("{ foos { totalCount pageInfo {startCursor}}}")
@@ -1152,7 +1152,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1205,7 +1205,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1254,7 +1254,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1306,7 +1306,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1361,7 +1361,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1403,7 +1403,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1458,7 +1458,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.InMemory.Tests/SingleOrDefaultAttributeTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.InMemory.Tests/SingleOrDefaultAttributeTests.cs
@@ -41,7 +41,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as Foo;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -73,7 +73,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foos { bar baz} }");
@@ -98,7 +98,7 @@ namespace HotChocolate.Types.Selections
                     d.Field(t => t.FoosMultiple)
                         .Resolver(resolver))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -129,7 +129,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as Foo;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -159,7 +159,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foosAsync { bar baz} }");
@@ -190,7 +190,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as Foo;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.InMemory.Tests/SingleOrDefaultTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.InMemory.Tests/SingleOrDefaultTests.cs
@@ -40,7 +40,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foos { bar baz} }");
@@ -71,7 +71,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute("{ foos { bar  } }");
@@ -106,7 +106,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -142,7 +142,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -178,7 +178,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -214,7 +214,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -250,7 +250,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.Mongo.Tests/SelectionAttributeTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.Mongo.Tests/SelectionAttributeTests.cs
@@ -42,7 +42,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as IQueryable<Foo>;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.Mongo.Tests/SelectionTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.Mongo.Tests/SelectionTests.cs
@@ -47,7 +47,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -93,7 +93,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -139,7 +139,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -185,7 +185,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -235,7 +235,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -285,7 +285,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -341,7 +341,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -388,7 +388,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -438,7 +438,7 @@ namespace HotChocolate.Types.Selections
                         .UseFiltering()
                         .UseSorting())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -481,7 +481,7 @@ namespace HotChocolate.Types.Selections
                         .UseFiltering()
                         .UseSorting())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -531,7 +531,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -584,7 +584,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -633,7 +633,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.Mongo.Tests/SingleOrDefaultAttributeTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.Mongo.Tests/SingleOrDefaultAttributeTests.cs
@@ -42,7 +42,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as Foo;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -74,7 +74,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foos { bar baz} }");
@@ -99,7 +99,7 @@ namespace HotChocolate.Types.Selections
                     d.Field(t => t.FoosMultiple)
                         .Resolver(resolver))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -130,7 +130,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as Foo;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -160,7 +160,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foosAsync { bar baz} }");
@@ -191,7 +191,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as Foo;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.Mongo.Tests/SingleOrDefaultTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.Mongo.Tests/SingleOrDefaultTests.cs
@@ -41,7 +41,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foos { bar baz} }");
@@ -72,7 +72,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute("{ foos { bar  } }");
@@ -107,7 +107,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -143,7 +143,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -179,7 +179,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -215,7 +215,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");

--- a/src/HotChocolate/Filters2/test/Types.Selections.PostgreSql.Tests/SelectionAttributeTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.PostgreSql.Tests/SelectionAttributeTests.cs
@@ -42,7 +42,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as IQueryable<Foo>;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.PostgreSql.Tests/SelectionTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.PostgreSql.Tests/SelectionTests.cs
@@ -47,7 +47,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -93,7 +93,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -139,7 +139,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -186,7 +186,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -236,7 +236,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -285,7 +285,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -337,7 +337,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -386,7 +386,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -436,7 +436,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -486,7 +486,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -536,7 +536,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -587,7 +587,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -638,7 +638,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -689,7 +689,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -745,7 +745,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -792,7 +792,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -842,7 +842,7 @@ namespace HotChocolate.Types.Selections
                         .UseFiltering()
                         .UseSorting())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -885,7 +885,7 @@ namespace HotChocolate.Types.Selections
                         .UseFiltering()
                         .UseSorting())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -935,7 +935,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -985,7 +985,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute("{ foos { totalCount pageInfo {startCursor}}}")
@@ -1046,7 +1046,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1099,7 +1099,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1148,7 +1148,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1200,7 +1200,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1255,7 +1255,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1297,7 +1297,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1352,7 +1352,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.PostgreSql.Tests/SingleOrDefaultAttributeTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.PostgreSql.Tests/SingleOrDefaultAttributeTests.cs
@@ -42,7 +42,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as Foo;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -74,7 +74,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foos { bar baz} }");
@@ -99,7 +99,7 @@ namespace HotChocolate.Types.Selections
                     d.Field(t => t.FoosMultiple)
                         .Resolver(resolver))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.PostgreSql.Tests/SingleOrDefaultTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.PostgreSql.Tests/SingleOrDefaultTests.cs
@@ -41,7 +41,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foos { bar baz} }");
@@ -72,7 +72,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute("{ foos { bar  } }");
@@ -107,7 +107,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -143,7 +143,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -179,7 +179,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -215,7 +215,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -294,7 +294,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.SqlServer.Tests/SelectionAttributeTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.SqlServer.Tests/SelectionAttributeTests.cs
@@ -41,7 +41,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as IQueryable<Foo>;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.SqlServer.Tests/SelectionTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.SqlServer.Tests/SelectionTests.cs
@@ -46,7 +46,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -90,7 +90,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -134,7 +134,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -178,7 +178,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -227,7 +227,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -279,7 +279,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute(
@@ -328,7 +328,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -376,7 +376,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -426,7 +426,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -476,7 +476,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -527,7 +527,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -578,7 +578,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -629,7 +629,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -683,7 +683,7 @@ namespace HotChocolate.Types.Selections
                         })
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -730,7 +730,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -778,7 +778,7 @@ namespace HotChocolate.Types.Selections
                         .UseFiltering()
                         .UseSorting())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -820,7 +820,7 @@ namespace HotChocolate.Types.Selections
                         .UseFiltering()
                         .UseSorting())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -868,7 +868,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -916,7 +916,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             var result = executor.Execute("{ foos { totalCount pageInfo {startCursor}}}")
@@ -975,7 +975,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1026,7 +1026,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1073,7 +1073,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1123,7 +1123,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1175,7 +1175,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1216,7 +1216,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(
@@ -1268,7 +1268,7 @@ namespace HotChocolate.Types.Selections
                         .UseSorting()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.SqlServer.Tests/SingleOrDefaultAttributeTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.SqlServer.Tests/SingleOrDefaultAttributeTests.cs
@@ -41,7 +41,7 @@ namespace HotChocolate.Types.Selections
                             resultCtx = ctx.Result as Foo;
                         }))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute(
@@ -73,7 +73,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foos { bar baz} }");
@@ -98,7 +98,7 @@ namespace HotChocolate.Types.Selections
                     d.Field(t => t.FoosMultiple)
                         .Resolver(resolver))
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute(

--- a/src/HotChocolate/Filters2/test/Types.Selections.SqlServer.Tests/SingleOrDefaultTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Selections.SqlServer.Tests/SingleOrDefaultTests.cs
@@ -40,7 +40,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult result = executor.Execute("{ foos { bar baz} }");
@@ -71,7 +71,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             executor.Execute("{ foos { bar  } }");
@@ -106,7 +106,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -142,7 +142,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -178,7 +178,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");
@@ -214,7 +214,7 @@ namespace HotChocolate.Types.Selections
                         .UseSingleOrDefault()
                         .UseSelection())
                 .Create();
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             // act
             IExecutionResult executionResult = executor.Execute("{ foos { fakeBar } }");

--- a/src/HotChocolate/Filters2/test/Types.Sorting.Mongo.Tests/MongoSortingObjectTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Sorting.Mongo.Tests/MongoSortingObjectTests.cs
@@ -42,7 +42,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items { model { foo } } }")
@@ -85,7 +85,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -127,7 +127,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -165,7 +165,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items(order_by: { model: { foo: DESC } }) { model { foo } } }")
@@ -201,7 +201,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery(
@@ -240,7 +240,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items(order_by: { model: { qux: DESC } }) { model { bar } } }")

--- a/src/HotChocolate/Filters2/test/Types.Sorting.Mongo.Tests/MongoSortingTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Sorting.Mongo.Tests/MongoSortingTests.cs
@@ -45,7 +45,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items { foo } }")
@@ -82,7 +82,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items(order_by: { foo: DESC }) { foo } }")
@@ -119,7 +119,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ paging(order_by: { foo: DESC }) { nodes { foo } } }")
@@ -157,7 +157,7 @@ namespace HotChocolate.Types.Sorting
                 .AddServices(serviceCollection.BuildServiceProvider())
                 .Create();
 
-            IQueryExecutor executor = schema.MakeExecutable();
+            IRequestExecutor executor = schema.MakeExecutable();
 
             IReadOnlyQueryRequest request = QueryRequestBuilder.New()
                 .SetQuery("{ items(order_by: { qux: DESC }) { bar } }")

--- a/src/HotChocolate/Filters2/test/Types.Sorting.Tests/ObjectFieldDescriptorExtensionsTests.cs
+++ b/src/HotChocolate/Filters2/test/Types.Sorting.Tests/ObjectFieldDescriptorExtensionsTests.cs
@@ -16,8 +16,7 @@ namespace HotChocolate.Types.Sorting
             // arrange
             ObjectFieldDescriptor descriptor =
                 ObjectFieldDescriptor.New(Context, "field");
-            FieldMiddleware placeholder =
-                next => context => Task.CompletedTask;
+            FieldMiddleware placeholder = next => context => default;
 
             // act
             descriptor.UseSorting();
@@ -33,7 +32,7 @@ namespace HotChocolate.Types.Sorting
             ObjectFieldDescriptor descriptor =
                 ObjectFieldDescriptor.New(Context, "field");
             FieldMiddleware placeholder =
-                next => context => Task.CompletedTask;
+                next => context => default;
 
             // act
             descriptor.UseSorting<object>();


### PR DESCRIPTION
This PR integrates the legacy Filter API from Hot Chocolate 10 into Hot Chocolate 11. 

> The Filters legacy Filter API will be frozen after it is migrated and new projects should use the new HotChocolate.Data API.