### PR TITLE
Avoid Scoping Of Scalars

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/ClrTypeReferenceHandler.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/ClrTypeReferenceHandler.cs
@@ -28,6 +28,11 @@ namespace HotChocolate.Configuration
                     {
                         ClrTypeReference namedTypeReference = typeReference.With(type);
 
+                        if (typeReference.Scope is { } && IsScalar(typeInfo.ClrType))
+                        {
+                            namedTypeReference = namedTypeReference.WithScope(null);
+                        }
+
                         if (!typeRegistrar.IsResolved(namedTypeReference))
                         {
                             typeRegistrar.Register(
@@ -79,5 +84,8 @@ namespace HotChocolate.Configuration
 
         private static bool IsTypeSystemObject(Type type) =>
             typeof(TypeSystemObjectBase).IsAssignableFrom(type);
+
+        private static bool IsScalar(Type type) =>
+            typeof(ScalarType).IsAssignableFrom(type);
     }
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/SchemaTypeReferenceHandler.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/SchemaTypeReferenceHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
+using System;
 
 #nullable enable
 
@@ -17,13 +18,21 @@ namespace HotChocolate.Configuration
             foreach (SchemaTypeReference typeReference in
                 typeReferences.OfType<SchemaTypeReference>())
             {
-                if (!typeRegistrar.IsResolved(typeReference))
+                SchemaTypeReference scopedReference = typeReference;
+                if (typeReference.Scope is { } && IsScalar(typeReference.Type.GetType()))
+                {
+                    scopedReference = scopedReference.WithScope(null);
+                }
+                if (!typeRegistrar.IsResolved(scopedReference))
                 {
                     typeRegistrar.Register(
-                        (TypeSystemObjectBase)typeReference.Type,
-                        typeReference.Scope);
+                        (TypeSystemObjectBase)scopedReference.Type,
+                        scopedReference.Scope);
                 }
             }
         }
+
+        private static bool IsScalar(Type type) =>
+            typeof(ScalarType).IsAssignableFrom(type);
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscovererTests.Scalars_Should_BeEqual_When_DifferentScope.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscovererTests.Scalars_Should_BeEqual_When_DifferentScope.snap
@@ -1,0 +1,29 @@
+﻿{
+  "registered": {
+    "HotChocolate.Types.StringType": "System.String",
+    "HotChocolate.Types.Introspection.__Directive": "System.Object",
+    "HotChocolate.Types.Introspection.__DirectiveLocation": "HotChocolate.Types.DirectiveLocation",
+    "HotChocolate.Types.Introspection.__EnumValue": "HotChocolate.Types.EnumValue",
+    "HotChocolate.Types.Introspection.__Field": "HotChocolate.Types.IOutputField",
+    "HotChocolate.Types.Introspection.__InputValue": "HotChocolate.Types.IInputField",
+    "HotChocolate.Types.Introspection.__Schema": "HotChocolate.ISchema",
+    "HotChocolate.Types.Introspection.__Type": "HotChocolate.Types.IType",
+    "HotChocolate.Types.Introspection.__TypeKind": "HotChocolate.Types.TypeKind",
+    "HotChocolate.Types.SkipDirectiveType": "System.Object",
+    "HotChocolate.Types.IncludeDirectiveType": "System.Object",
+    "HotChocolate.Types.BooleanType": "System.Boolean",
+    "HotChocolate.Types.DeprecatedDirectiveType": "HotChocolate.Types.DeprecatedDirective"
+  },
+  "clr": {
+    "None: System.String": "None: HotChocolate.Types.StringType",
+    "None: HotChocolate.Types.DirectiveLocation": "None: HotChocolate.Types.Introspection.__DirectiveLocation",
+    "Output: HotChocolate.Types.EnumValue": "Output: HotChocolate.Types.Introspection.__EnumValue",
+    "Output: HotChocolate.Types.IOutputField": "Output: HotChocolate.Types.Introspection.__Field",
+    "Output: HotChocolate.Types.IInputField": "Output: HotChocolate.Types.Introspection.__InputValue",
+    "Output: HotChocolate.ISchema": "Output: HotChocolate.Types.Introspection.__Schema",
+    "Output: HotChocolate.Types.IType": "Output: HotChocolate.Types.Introspection.__Type",
+    "None: HotChocolate.Types.TypeKind": "None: HotChocolate.Types.Introspection.__TypeKind",
+    "None: System.Boolean": "None: HotChocolate.Types.BooleanType",
+    "None: HotChocolate.Types.DeprecatedDirective": "None: HotChocolate.Types.DeprecatedDirectiveType"
+  }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeScopeInterceptorTests.Scalars_Should_BeEqual_WhenDifferentScope.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeScopeInterceptorTests.Scalars_Should_BeEqual_WhenDifferentScope.snap
@@ -1,0 +1,12 @@
+﻿schema {
+  query: FooScalar
+}
+
+type FooScalar {
+  bar1: String
+  bar2: String
+  Bar3: String
+}
+
+"The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+scalar String


### PR DESCRIPTION
This PR prohibits scoping of scalars down in the type discoverer & initializer. 

When a user starts scoping scalars this can lead to a duplicated name of the scalar. As scoping of scalars is something we do not want to allow anyway, it is now handled by the type discovery and we never have to worry again