### PR TITLE
Fixed issue where the delegation was forced to queries instead of delegating to the proper root type.

### DIFF
--- a/src/Stitching/Stitching.Tests/Stitching.Tests.csproj
+++ b/src/Stitching/Stitching.Tests/Stitching.Tests.csproj
@@ -20,4 +20,8 @@
     <ProjectReference Include="..\..\Server\AspNetCore.Tests.Utilities\AspNetCore.Tests.Utilities.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Middleware\__snapshots__\__mismatch__\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Stitching/Stitching.Tests/__resources__/StitchingExtensions.graphql
+++ b/src/Stitching/Stitching.Tests/__resources__/StitchingExtensions.graphql
@@ -1,13 +1,13 @@
 extend type Customer {
   contracts: [Contract!]
-    @delegate(schema: "contract", path: "contracts(customerId:$fields:id)")
+    @delegate(schema: "contract", path: "contracts(customerId:$fields:id)", operation: QUERY)
   contractIds: [ID!]
-    @delegate(schema: "contract", path: "contracts(customerId:$fields:id).id")
+    @delegate(schema: "contract", path: "contracts(customerId:$fields:id).id", operation: QUERY)
   int: Int! @delegate(schema: "contract", path: "int(i:$fields:someInt)")
-  guid: Uuid! @delegate(schema: "contract", path: "guid(guid:$fields:someGuid)")
+  guid: Uuid! @delegate(schema: "contract", path: "guid(guid:$fields:someGuid)", operation: QUERY)
 }
 
 extend type Query {
   customer2(customerId: ID!): Customer
-    @delegate(schema: "customer", path: "customer(id:$arguments:customerId)")
+    @delegate(schema: "customer", path: "customer(id:$arguments:customerId)", operation: QUERY)
 }

--- a/src/Stitching/Stitching/Directives/DelegateDirective.cs
+++ b/src/Stitching/Stitching/Directives/DelegateDirective.cs
@@ -7,5 +7,7 @@ namespace HotChocolate.Stitching
         public string Path { get; set; }
 
         public NameString Schema { get; set; }
+
+        public OperationType Operation { get; set; } = OperationType.Mutation;
     }
 }

--- a/src/Stitching/Stitching/Directives/DelegateDirectiveType.cs
+++ b/src/Stitching/Stitching/Directives/DelegateDirectiveType.cs
@@ -1,3 +1,4 @@
+using HotChocolate.Language;
 using HotChocolate.Stitching.Properties;
 using HotChocolate.Types;
 
@@ -23,6 +24,10 @@ namespace HotChocolate.Stitching
                 .Type<NonNullType<NameType>>()
                 .Description(StitchingResources
                     .DelegateDirectiveType_Description);
+
+            descriptor.Argument(t => t.Operation)
+                .Name(DirectiveFieldNames.Delegate_Operation)
+                .Type<EnumType<OperationType>>();
         }
     }
 }

--- a/src/Stitching/Stitching/Directives/DirectiveFieldNames.cs
+++ b/src/Stitching/Stitching/Directives/DirectiveFieldNames.cs
@@ -10,6 +10,8 @@ namespace HotChocolate.Stitching
 
         public static NameString Delegate_Path { get; } = "path";
 
+        public static NameString Delegate_Operation { get; } = "operation";
+
         public static NameString Computed_DependantOn { get; } = "dependantOn";
     }
 }

--- a/src/Stitching/Stitching/Middleware/DelegateToRemoteSchemaMiddleware.cs
+++ b/src/Stitching/Stitching/Middleware/DelegateToRemoteSchemaMiddleware.cs
@@ -104,10 +104,7 @@ namespace HotChocolate.Stitching
                 context.Schema,
                 context.Service<IEnumerable<IQueryDelegationRewriter>>());
 
-            OperationType operationType =
-                context.Schema.IsRootType(context.ObjectType)
-                    ? context.Operation.Operation
-                    : OperationType.Query;
+            OperationType operationType = context.Operation.Operation;
 
             ExtractedField extractedField = fieldRewriter.ExtractField(
                 schemaName, context.Document, context.Operation,


### PR DESCRIPTION
Mutation stitching paths were forced to the query tree when not a root type.

Addresses #2087 
