### PR TITLE
Add support for raw JSON in StrawberryShake

### DIFF
--- a/src/StrawberryShake/CodeGeneration/src/Generators/CSharp/ResultParserDeserializeMethodGenerator.cs
+++ b/src/StrawberryShake/CodeGeneration/src/Generators/CSharp/ResultParserDeserializeMethodGenerator.cs
@@ -37,7 +37,8 @@ namespace StrawberryShake.Generators.CSharp
                 { typeof(ulong?), "GetUInt64" },
                 { typeof(decimal?), "GetDecimal" },
                 { typeof(float?), "GetSingle" },
-                { typeof(double?), "GetDouble" }
+                { typeof(double?), "GetDouble" },
+                { typeof(object), "GetRawText" }
             };
 
         private readonly LanguageVersion _languageVersion;

--- a/src/StrawberryShake/CodeGeneration/test/Generators.Tests/ClientGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/Generators.Tests/ClientGeneratorTests.cs
@@ -540,22 +540,26 @@ namespace StrawberryShake.Generators
                     foo: Bar
                     baz: Qux
                     abc: String
+                    obj: Foo
                 }
 
                 scalar String
                 scalar Bar
                 scalar Qux
+                scalar Foo
                 ";
 
             string extensions = @"
                 extend scalar Bar @runtimeType(name: ""System.String"")
-                extend scalar Qux @runtimeType(name: ""System.Int32"")";
+                extend scalar Qux @runtimeType(name: ""System.Int32"")
+                extend scalar Foo @runtimeType(name: ""System.Object"")";
 
             string query =
                @"
                 query getFoo {
                     foo
                     baz
+                    obj
                 }
                 ";
 


### PR DESCRIPTION
My scheme exposes a scalar named JSONObject that is transported as a JSON structure with no predefined scheme. On the C# end I would like to have it as a `dynamic` or an `object` or something similar.

I don't think this is possible at this moment because `ResultParserDeserializeMethodGenerator` requires the serialization types to be one of the predefined values listed in the `_jsonMethod` dictionary.

In this patch I've added `{ typeof(object), "GetRawText" }` to this list such that custom `IValueSerializer` implementations can access the JSON text and convert it as the application requires.