### PR TITLE
Fixed executor eviction

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/EvictSchemaTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/EvictSchemaTests.cs
@@ -1,0 +1,56 @@
+using System.Threading.Tasks;
+using HotChocolate.AspNetCore.Utilities;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace HotChocolate.AspNetCore
+{
+    public class EvictSchemaTests : ServerTestBase
+    {
+        public EvictSchemaTests(TestServerFactory serverFactory)
+            : base(serverFactory)
+        {
+        }
+
+        [Fact]
+        public async Task Evict_Default_Schema()
+        {
+            // arrange
+            TestServer server = CreateStarWarsServer();
+
+            ClientQueryResult time1 = await server.GetAsync(
+                new ClientQueryRequest { Query = "{ time }" });
+
+            // act
+            await server.GetAsync(
+                new ClientQueryRequest { Query = "{ evict }" });
+
+            // assert
+            ClientQueryResult time2 = await server.GetAsync(
+                new ClientQueryRequest { Query = "{ time }" });
+            Assert.False(((long)time1.Data["time"]).Equals((long)time2.Data["time"]));
+        }
+
+        [Fact]
+        public async Task Evict_Named_Schema()
+        {
+            // arrange
+            TestServer server = CreateStarWarsServer();
+
+            ClientQueryResult time1 = await server.GetAsync(
+                new ClientQueryRequest { Query = "{ time }" },
+                "/evict");
+
+            // act
+            await server.GetAsync(
+                new ClientQueryRequest { Query = "{ evict }" },
+                "/evict");
+
+            // assert
+            ClientQueryResult time2 = await server.GetAsync(
+                new ClientQueryRequest { Query = "{ time }" },
+                "/evict");
+            Assert.False(((long)time1.Data["time"]).Equals((long)time2.Data["time"]));
+        }
+    }
+}

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Utilities/QueryExtension.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Utilities/QueryExtension.cs
@@ -1,0 +1,20 @@
+using System;
+using HotChocolate.Types;
+using HotChocolate.Execution;
+
+namespace HotChocolate.AspNetCore.Utilities
+{
+    [ExtendObjectType("Query")]
+    public class QueryExtension
+    {
+        private readonly DateTime _time = DateTime.UtcNow;
+
+        public long Time() => _time.Ticks;
+
+        public bool Evict([Service]IRequestExecutorResolver executorResolver, ISchema schema)
+        {
+            executorResolver.EvictRequestExecutor(schema.Name);
+            return true;
+        }
+    }
+}

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Utilities/ServerTestBase.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Utilities/ServerTestBase.cs
@@ -21,12 +21,20 @@ namespace HotChocolate.AspNetCore.Utilities
                     .AddRouting()
                     .AddGraphQLServer()
                         .AddStarWarsTypes()
+                        .AddTypeExtension<QueryExtension>()
                         .AddExportDirectiveType()
                         .AddStarWarsRepositories()
-                        .AddInMemorySubscriptions(),
+                        .AddInMemorySubscriptions()
+                    .AddGraphQLServer("evict")
+                        .AddQueryType(d => d.Name("Query"))
+                        .AddTypeExtension<QueryExtension>(),
                 app => app
                     .UseWebSockets()
                     .UseRouting()
-                    .UseEndpoints(endpoints => endpoints.MapGraphQL(pattern)));
+                    .UseEndpoints(endpoints => 
+                    {
+                        endpoints.MapGraphQL(pattern);
+                        endpoints.MapGraphQL("evict", "evict");
+                    }));
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Attributes/ExtendObjectTypeAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Attributes/ExtendObjectTypeAttribute.cs
@@ -12,6 +12,11 @@ namespace HotChocolate.Types
     public sealed class ExtendObjectTypeAttribute
         : ObjectTypeDescriptorAttribute
     {
+        public ExtendObjectTypeAttribute(string? name = null)
+        {
+            Name = name;
+        }
+
         public string? Name { get; set; }
 
         public override void OnConfigure(


### PR DESCRIPTION
This PR fixes an issue that prevents executors from being evicted and thus preventing dynamic schema reloads.