### PR TITLE
Track the types that are dependant on unresolvable references

### DIFF
--- a/src/HotChocolate/Core/src/Types/SchemaException.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaException.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+using HotChocolate.Utilities;
 
 namespace HotChocolate
 {
@@ -49,7 +50,16 @@ namespace HotChocolate
 
             for (int i = 0; i < errors.Count; i++)
             {
-                message.AppendLine($"{i + 1}. {errors[i].Message}");
+                ISchemaError error = errors[i];
+
+                message.Append($"{i + 1}. {error.Message}");
+
+                if (error.TypeSystemObject is not null)
+                {
+                    message.Append($" ({error.TypeSystemObject.GetType().GetTypeName()})");
+                }
+
+                message.AppendLine();
             }
 
             return message.ToString();

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeDiscovererTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeDiscovererTests.cs
@@ -217,6 +217,8 @@ namespace HotChocolate.Configuration
                     Assert.IsType<ObjectType<QueryWithInferError>>(error.TypeSystemObject);
                     Assert.False(error.Extensions.ContainsKey("involvedTypes"));
                 });
+
+            new SchemaException(errors).Message.MatchSnapshot();
         }
 
         [Fact]

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeDiscovererTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeDiscovererTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using HotChocolate.Types;
@@ -43,8 +44,8 @@ namespace HotChocolate.Configuration
                     .Select(t => new
                     {
                         type = t.Type.GetType().GetTypeName(),
-                        runtimeType = t.Type is IHasRuntimeType hr 
-                            ? hr.RuntimeType.GetTypeName() 
+                        runtimeType = t.Type is IHasRuntimeType hr
+                            ? hr.RuntimeType.GetTypeName()
                             : null,
                         references = t.References.Select(t => t.ToString()).ToList()
                     }).ToList(),
@@ -86,8 +87,8 @@ namespace HotChocolate.Configuration
                     .Select(t => new
                     {
                         type = t.Type.GetType().GetTypeName(),
-                        runtimeType = t.Type is IHasRuntimeType hr 
-                            ? hr.RuntimeType.GetTypeName() 
+                        runtimeType = t.Type is IHasRuntimeType hr
+                            ? hr.RuntimeType.GetTypeName()
                             : null,
                         references = t.References.Select(t => t.ToString()).ToList()
                     }).ToList(),
@@ -129,8 +130,8 @@ namespace HotChocolate.Configuration
                     .Select(t => new
                     {
                         type = t.Type.GetType().GetTypeName(),
-                        runtimeType = t.Type is IHasRuntimeType hr 
-                            ? hr.RuntimeType.GetTypeName() 
+                        runtimeType = t.Type is IHasRuntimeType hr
+                            ? hr.RuntimeType.GetTypeName()
                             : null,
                         references = t.References.Select(t => t.ToString()).ToList()
                     }).ToList(),
@@ -173,8 +174,8 @@ namespace HotChocolate.Configuration
                     .Select(t => new
                     {
                         type = t.Type.GetType().GetTypeName(),
-                        runtimeType = t.Type is IHasRuntimeType hr 
-                            ? hr.RuntimeType.GetTypeName() 
+                        runtimeType = t.Type is IHasRuntimeType hr
+                            ? hr.RuntimeType.GetTypeName()
                             : null,
                         references = t.References.Select(t => t.ToString()).ToList()
                     }).ToList(),
@@ -184,6 +185,33 @@ namespace HotChocolate.Configuration
                     t => t.Value.ToString())
 
             }.MatchSnapshot();
+        }
+
+        [Fact]
+        public void Cannot_Infer_Input_Type()
+        {
+            // arrange
+            var context = DescriptorContext.Create();
+            var typeRegistry = new TypeRegistry();
+            var typeLookup = new TypeLookup(context.TypeInspector, typeRegistry);
+
+            var typeDiscoverer = new TypeDiscoverer(
+                context,
+                typeRegistry,
+                typeLookup,
+                new HashSet<ITypeReference>
+                {
+                    _typeInspector.GetTypeRef(typeof(QueryWithInferError), TypeContext.Output),
+                },
+                new AggregateTypeInitializationInterceptor());
+
+            // act
+            IReadOnlyList<ISchemaError> errors = typeDiscoverer.DiscoverTypes();
+
+            // assert
+            Assert.Collection(
+                errors,
+                e => Assert.NotNull(e.TypeSystemObject));
         }
 
         public class FooType
@@ -208,6 +236,11 @@ namespace HotChocolate.Configuration
         public class Bar
         {
             public string Baz { get; }
+        }
+
+        public class QueryWithInferError
+        {
+            public string Foo(object o) => throw new NotImplementedException();
         }
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscovererTests.Cannot_Infer_Input_Type.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscovererTests.Cannot_Infer_Input_Type.snap
@@ -1,0 +1,3 @@
+﻿For more details look at the `Errors` property.
+
+1. Unable to infer or resolve a schema type from the type reference `Input: IMyArg`. (HotChocolate.Types.ObjectType<HotChocolate.Configuration.TypeDiscovererTests.QueryWithInferError>)

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.ObjectFieldDoesNotMatchInterfaceDefinitionArgTypeInvalid.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.ObjectFieldDoesNotMatchInterfaceDefinitionArgTypeInvalid.snap
@@ -1,4 +1,4 @@
 ﻿For more details look at the `Errors` property.
 
-1. The named argument `a` on field `a` must accept the same type `String` (invariant) as that named argument on the interface `A`.
-2. The named argument `a` on field `a` must accept the same type `String` (invariant) as that named argument on the interface `B`.
+1. The named argument `a` on field `a` must accept the same type `String` (invariant) as that named argument on the interface `A`. (HotChocolate.Types.ObjectType)
+2. The named argument `a` on field `a` must accept the same type `String` (invariant) as that named argument on the interface `B`. (HotChocolate.Types.ObjectType)

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.ObjectFieldDoesNotMatchInterfaceDefinitionReturnTypeInvalid.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.ObjectFieldDoesNotMatchInterfaceDefinitionReturnTypeInvalid.snap
@@ -1,4 +1,4 @@
 ﻿For more details look at the `Errors` property.
 
-1. Field `a` must return a type which is equal to or a sub‐type of (covariant) the return type `String` of the interface field.
-2. Field `a` must return a type which is equal to or a sub‐type of (covariant) the return type `String` of the interface field.
+1. Field `a` must return a type which is equal to or a sub‐type of (covariant) the return type `String` of the interface field. (HotChocolate.Types.ObjectType)
+2. Field `a` must return a type which is equal to or a sub‐type of (covariant) the return type `String` of the interface field. (HotChocolate.Types.ObjectType)

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.TwoInterfacesProvideFieldAWithDifferentArguments1.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.TwoInterfacesProvideFieldAWithDifferentArguments1.snap
@@ -1,3 +1,3 @@
 ﻿For more details look at the `Errors` property.
 
-1. The argument `b` of the implemented field `a` must be defined. The field `a` must include an argument of the same name for every argument defined on the implemented field of the interface type `B`.
+1. The argument `b` of the implemented field `a` must be defined. The field `a` must include an argument of the same name for every argument defined on the implemented field of the interface type `B`. (HotChocolate.Types.ObjectType)

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.TwoInterfacesProvideFieldAWithDifferentArguments2.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.TwoInterfacesProvideFieldAWithDifferentArguments2.snap
@@ -1,3 +1,3 @@
 ﻿For more details look at the `Errors` property.
 
-1. The named argument `a` on field `a` must accept the same type `Int` (invariant) as that named argument on the interface `B`.
+1. The named argument `a` on field `a` must accept the same type `Int` (invariant) as that named argument on the interface `B`. (HotChocolate.Types.ObjectType)

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.TwoInterfacesProvideFieldAWithDifferentArguments3.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.TwoInterfacesProvideFieldAWithDifferentArguments3.snap
@@ -1,3 +1,3 @@
 ﻿For more details look at the `Errors` property.
 
-1. The argument `b` of the implemented field `a` must be defined. The field `a` must include an argument of the same name for every argument defined on the implemented field of the interface type `B`.
+1. The argument `b` of the implemented field `a` must be defined. The field `a` must include an argument of the same name for every argument defined on the implemented field of the interface type `B`. (HotChocolate.Types.ObjectType)

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.TwoInterfacesProvideFieldAWithDifferentOutputType.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.TwoInterfacesProvideFieldAWithDifferentOutputType.snap
@@ -1,3 +1,3 @@
 ﻿For more details look at the `Errors` property.
 
-1. Field `a` must return a type which is equal to or a sub‐type of (covariant) the return type `Int` of the interface field.
+1. Field `a` must return a type which is equal to or a sub‐type of (covariant) the return type `Int` of the interface field. (HotChocolate.Types.ObjectType)

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/SubscriptionTypeTests.Subscribe_Attribute_With_Two_Topic_Attributes_Error.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/SubscriptionTypeTests.Subscribe_Attribute_With_Two_Topic_Attributes_Error.snap
@@ -3,4 +3,4 @@
 1. For more details look at the `Errors` property.
 
 1. The topic is declared multiple times on HotChocolate.Types.SubscriptionTypeTests+InvalidSubscription_TwoTopicAttributes.OnMessage. (TopicAttribute)
-
+ (HotChocolate.Types.ObjectType<HotChocolate.Types.SubscriptionTypeTests.InvalidSubscription_TwoTopicAttributes>)

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/SchemaBuilderTests.Could_Not_Resolve_Type.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/SchemaBuilderTests.Could_Not_Resolve_Type.snap
@@ -1,3 +1,3 @@
 ﻿For more details look at the `Errors` property.
 
-1. Unable to resolve type reference `Output: Bar`.
+1. Unable to resolve type reference `Output: Bar`. (HotChocolate.Types.ObjectType)

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/SchemaBuilderTests.DuplicateName.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/SchemaBuilderTests.DuplicateName.snap
@@ -1,3 +1,3 @@
 ﻿For more details look at the `Errors` property.
 
-1. The name `MyFoo` was already registered by another type.
+1. The name `MyFoo` was already registered by another type. (HotChocolate.SchemaBuilderTests.DynamicFooType)

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/SchemaBuilderTests.Interface_Without_Implementation.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/SchemaBuilderTests.Interface_Without_Implementation.snap
@@ -1,3 +1,3 @@
 ﻿For more details look at the `Errors` property.
 
-1. There is no object type implementing interface `Bar`.
+1. There is no object type implementing interface `Bar`. (HotChocolate.Types.InterfaceType)

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/Convention/__snapshots__/SortConventionTests.SortConvention_Should_Fail_When_OperationsIsNotNamed.snap
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/Convention/__snapshots__/SortConventionTests.SortConvention_Should_Fail_When_OperationsIsNotNamed.snap
@@ -3,4 +3,4 @@
 1. For more details look at the `Errors` property.
 
 1. Unable to create field handler `0` for sort provider `HotChocolate.Data.Sorting.SortConvention`.
-
+ (HotChocolate.Data.Sorting.SortConventionTests.FooSortType)


### PR DESCRIPTION
This PR aims to make it easier to debug when types cannot be inferred and a type discovery error is raised.
