### PR TITLE
Fix link to Subscriptions docs

### DIFF
--- a/website/src/docs/hotchocolate/v10/index.md
+++ b/website/src/docs/hotchocolate/v10/index.md
@@ -237,7 +237,7 @@ query filterPersons {
 
 Subscriptions allow GraphQL clients to observe specific events and receive updates from the server in real-time.
 
-[Learn more](/docs/hotchocolate/v10/execution-engine/subscription)
+[Learn more](/docs/hotchocolate/v10/execution-engine/subscriptions)
 
 ## Schema Stitching
 


### PR DESCRIPTION
Fixed missing "s" in the "Learn more" link to subscriptions page.
