### PR TITLE
Changing type="solution" to type="project" in template.json

### DIFF
--- a/templates/StarWars/content/.template.config/template.json
+++ b/templates/StarWars/content/.template.config/template.json
@@ -10,6 +10,7 @@
   "name": "HotChocolate GraphQL Star Wars Demo",
   "shortName": "starwars",
   "tags": {
-    "type": "Solution"
+    "language": "C#",
+    "type": "project"
   }
 }


### PR DESCRIPTION
Updating the template.json file because `type="solution"` is not correct. The only two real values that should be used here are 'item' and 'project'. The field is free text so anything can be specified. Without changing this to project, this template will not appear in Visual Studio when we add the feature to show all templates, see https://devblogs.microsoft.com/dotnet/net-cli-templates-in-visual-studio/ for more info on that.

FYI I'll be coming back with more guidance for templates in VS in a week or two.