### PR TITLE
AddTypesFromAssembly helper methods

### DIFF
--- a/src/HotChocolate/Core/src/Types/Extensions/SchemaBuilderExtensions.Types.cs
+++ b/src/HotChocolate/Core/src/Types/Extensions/SchemaBuilderExtensions.Types.cs
@@ -2,6 +2,7 @@ using System;
 using HotChocolate.Language;
 using HotChocolate.Properties;
 using HotChocolate.Types;
+using System.Reflection;
 
 namespace HotChocolate
 {
@@ -597,6 +598,31 @@ namespace HotChocolate
             }
 
             return builder.BindClrType(typeof(TClrType), typeof(TSchemaType));
+        }
+        
+        public static ISchemaBuilder AddSchemaTypesFromAssembly(this ISchemaBuilder builder, Assembly assembly)
+        {
+            if (builder is null)
+                throw new ArgumentNullException(nameof(builder));
+
+            return builder.AddTypesFromAssembly<ObjectType>(assembly);
+        }
+        
+        public static ISchemaBuilder AddTypesFromAssembly<TBaseType>(this ISchemaBuilder builder, Assembly assembly)
+        {
+            if (builder is null)
+                throw new ArgumentNullException(nameof(builder));
+
+            if (assembly is null)
+                throw new ArgumentNullException(nameof(assembly));
+
+            foreach (Type type in assembly.GetTypes())
+            {
+                if (type.IsSubclassOf(typeof(TBaseType)))
+                    builder.AddType(type);
+            }
+
+            return builder;
         }
     }
 }


### PR DESCRIPTION
Adding 2 helper extension methods:

1. `AddTypesFromAssembly<TBaseType>(ISchemaBuilder builder, Assembly assembly)`
For every type in the assembly that derives from `TBaseType`, it calls `builder.AddType()` and returns `builder`.

2. `AddSchemaTypesFromAssembly(this ISchemaBuilder builder, Assembly assembly)`
Calls `AddTypesFromAssembly<ObjectType>(assembly)`

### Why?
Often times you have to add your schema types one by one:
```csharp
SchemaBuilder.New()
    .AddQueryType<QueryType>()
    .AddType<BookType>()
    .AddType<AuthorType>()
    .AddType<PublisherType>()
    .AddType<RatingType>()
    .AddType<UserType()
    ...
    .Create()
```
now you can just:
```csharp
SchemaBuilder.New()
    .AddSchemaTypesFromAssembly(Assembly.GetExecutingAssembly())
    .Create()
```
And you're done.