### PR TITLE
bump snapshooter to version 0.5.8

### DIFF
--- a/src/GreenDonut/test/Directory.Build.props
+++ b/src/GreenDonut/test/Directory.Build.props
@@ -17,10 +17,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 </Project>

--- a/src/HotChocolate/ApolloFederation/test/Directory.Build.props
+++ b/src/HotChocolate/ApolloFederation/test/Directory.Build.props
@@ -14,7 +14,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/HotChocolate/AspNetCore/test/Directory.Build.props
+++ b/src/HotChocolate/AspNetCore/test/Directory.Build.props
@@ -20,7 +20,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 
 </Project>

--- a/src/HotChocolate/AzureFunctions/test/Directory.Build.props
+++ b/src/HotChocolate/AzureFunctions/test/Directory.Build.props
@@ -17,10 +17,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 </Project>

--- a/src/HotChocolate/Core/test/Directory.Build.props
+++ b/src/HotChocolate/Core/test/Directory.Build.props
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/HotChocolate/Data/test/Directory.Build.props
+++ b/src/HotChocolate/Data/test/Directory.Build.props
@@ -21,7 +21,7 @@
     <PackageReference Include="Moq" Version="4.13.1"/>
     <PackageReference Include="xunit" Version="2.4.1"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.5"/>
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.7"/>
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0"/>
   </ItemGroup>
 

--- a/src/HotChocolate/Data/test/Directory.Build.props
+++ b/src/HotChocolate/Data/test/Directory.Build.props
@@ -21,7 +21,7 @@
     <PackageReference Include="Moq" Version="4.13.1"/>
     <PackageReference Include="xunit" Version="2.4.1"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.7"/>
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8"/>
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0"/>
   </ItemGroup>
 

--- a/src/HotChocolate/Filters/test/Directory.Build.props
+++ b/src/HotChocolate/Filters/test/Directory.Build.props
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 
 </Project>

--- a/src/HotChocolate/Language/test/Directory.Build.props
+++ b/src/HotChocolate/Language/test/Directory.Build.props
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.2" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 
 </Project>

--- a/src/HotChocolate/PersistedQueries/test/Directory.Build.props
+++ b/src/HotChocolate/PersistedQueries/test/Directory.Build.props
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 
 </Project>

--- a/src/HotChocolate/Spatial/test/Directory.Build.props
+++ b/src/HotChocolate/Spatial/test/Directory.Build.props
@@ -18,11 +18,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.5" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/HotChocolate/Stitching/test/Directory.Build.props
+++ b/src/HotChocolate/Stitching/test/Directory.Build.props
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/HotChocolate/Utilities/test/Directory.Build.props
+++ b/src/HotChocolate/Utilities/test/Directory.Build.props
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 
 </Project>

--- a/src/HotChocolate/__remove/Stitching2/test/Directory.Build.props
+++ b/src/HotChocolate/__remove/Stitching2/test/Directory.Build.props
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/HotChocolate/__remove/test/Directory.Build.props
+++ b/src/HotChocolate/__remove/test/Directory.Build.props
@@ -18,11 +18,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 
 </Project>

--- a/src/MarshmallowPie/test/Directory.Build.props
+++ b/src/MarshmallowPie/test/Directory.Build.props
@@ -17,12 +17,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="Squadron.Mongo" Version="0.8.1" />
   </ItemGroup>
 

--- a/src/StrawberryShake/Client/test/Directory.Build.props
+++ b/src/StrawberryShake/Client/test/Directory.Build.props
@@ -16,10 +16,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 </Project>

--- a/src/StrawberryShake/CodeGeneration/test/Directory.Build.props
+++ b/src/StrawberryShake/CodeGeneration/test/Directory.Build.props
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
   </ItemGroup>
 
 </Project>

--- a/src/StrawberryShake/Tooling/test/Directory.Build.props
+++ b/src/StrawberryShake/Tooling/test/Directory.Build.props
@@ -12,11 +12,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="Squadron.Mongo" Version="0.8.1" />
   </ItemGroup>
 </Project>

--- a/src/StrawberryShake/VisualStudioWin/test/Directory.Build.props
+++ b/src/StrawberryShake/VisualStudioWin/test/Directory.Build.props
@@ -12,11 +12,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.4" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="Squadron.Mongo" Version="0.8.1" />
   </ItemGroup>
 </Project>

--- a/src/StrawberryShake/VisualStudioWin/test/StrawberryShake.VisualStudio.Language.Tests/StrawberryShake.VisualStudio.Language.Tests.csproj
+++ b/src/StrawberryShake/VisualStudioWin/test/StrawberryShake.VisualStudio.Language.Tests/StrawberryShake.VisualStudio.Language.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="Snapshooter.Xunit" Version="0.5.1" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.5.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
All projects  in this repo now use the latest version of [Snapshooter](https://github.com/SwissLife-OSS/snapshooter)
