### PR TITLE
Reversed null check logic for auth token

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-chilli/Http/DefaultHttpClientFactory.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-chilli/Http/DefaultHttpClientFactory.cs
@@ -16,7 +16,7 @@ namespace StrawberryShake.Tools.Http
                         "StrawberryShake",
                         typeof(Program).Assembly!.GetName()!.Version!.ToString())));
 
-            if (token is { })
+            if (!(token is { }))
             {
                 httpClient.DefaultRequestHeaders.Authorization =
                     new AuthenticationHeaderValue(scheme ?? "bearer", token);


### PR DESCRIPTION
- Reverses the logic of the null check for the token in DefaultHttpClientFactory.cs
- Adds the token if it is not null (rather than if it is null)

Addresses #2584 
