### PR TITLE
Fixed active persisted query

### DIFF
--- a/src/Core/Abstractions.Tests/Execution/__snapshots__/QueryRequestBuilderTests.BuildRequest_QueryAndSetExtensions_RequestIsCreated_2.snap
+++ b/src/Core/Abstractions.Tests/Execution/__snapshots__/QueryRequestBuilderTests.BuildRequest_QueryAndSetExtensions_RequestIsCreated_2.snap
@@ -9,5 +9,7 @@
   "InitialValue": null,
   "Properties": {},
   "Services": null,
-  "Extensions": {}
+  "Extensions": {
+    "three": "baz"
+  }
 }

--- a/src/Core/Abstractions/Execution/QueryRequestBuilder.cs
+++ b/src/Core/Abstractions/Execution/QueryRequestBuilder.cs
@@ -313,7 +313,7 @@ namespace HotChocolate.Execution
             {
                 return _extensions;
             }
-            return _readOnlyProperties ?? _empty;
+            return _readOnlyExtensions ?? _empty;
         }
 
         private void InitializeExtensions()


### PR DESCRIPTION
GetExtensions() method changed to return correct _readonlyExtensions field. This was a cause of active persisted queries not working
