### PR TITLE
Fixed GetExtensions method to return correct field

### DIFF
--- a/src/HotChocolate/Core/src/Abstractions/Execution/QueryRequestBuilder.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/QueryRequestBuilder.cs
@@ -301,7 +301,7 @@ namespace HotChocolate.Execution
 
         private IReadOnlyDictionary<string, object?> GetExtensions()
         {
-            return _extensions ?? _readOnlyProperties;
+            return _extensions ?? _readOnlyExtensions;
         }
 
         private void InitializeExtensions()

--- a/src/HotChocolate/Core/test/Abstractions.Tests/Execution/__snapshots__/QueryRequestBuilderTests.BuildRequest_QueryAndSetExtensions_RequestIsCreated_2.snap
+++ b/src/HotChocolate/Core/test/Abstractions.Tests/Execution/__snapshots__/QueryRequestBuilderTests.BuildRequest_QueryAndSetExtensions_RequestIsCreated_2.snap
@@ -6,7 +6,9 @@
   "QueryHash": null,
   "OperationName": null,
   "VariableValues": null,
-  "Extensions": null,
+  "Extensions": {
+    "three": "baz"
+  },
   "ContextData": null,
   "Services": null,
   "InitialValue": null,


### PR DESCRIPTION
GetExtensions() method changed to return correct _readonlyExtensions field. 