### PR TITLE
Bugfix/querysyntaxserializer

### DIFF
--- a/src/Core/Language.Tests/Visitors/QuerySyntaxSerializerTests.cs
+++ b/src/Core/Language.Tests/Visitors/QuerySyntaxSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System.IO;
 using System.Text;
 using ChilliCream.Testing;
@@ -201,6 +201,48 @@ namespace HotChocolate.Language
             Assert.Equal(
                 query,
                 content.ToString());
+        }
+
+        [Fact]
+        public void Serialize_WithNameAndVariable()
+        {
+            // arrange
+            var documentString = "query name($id: String!) { a }";
+            DocumentNode document = Utf8GraphQLParser.Parse(documentString);
+
+            // act
+            var serialized = QuerySyntaxSerializer.Serialize(document, false);
+
+            // assert
+            Assert.Equal(documentString, serialized);
+        }
+
+        [Fact]
+        public void Serialize_ShortHand()
+        {
+            // arrange
+            var documentString = "{ a }";
+            DocumentNode document = Utf8GraphQLParser.Parse(documentString);
+
+            // act
+            var serialized = QuerySyntaxSerializer.Serialize(document, false);
+
+            // assert
+            Assert.Equal(documentString, serialized);
+        }
+
+        [Fact]
+        public void Serialize_WithoutNameAndWithVariable()
+        {
+            // arrange
+            var documentString = "query ($id: String!) { a }";
+            DocumentNode document = Utf8GraphQLParser.Parse(documentString);
+
+            // act
+            var serialized = QuerySyntaxSerializer.Serialize(document, false);
+
+            // assert
+            Assert.Equal(documentString, serialized);
         }
     }
 }

--- a/src/Core/Language/Visitors/QuerySyntaxSerializer.cs
+++ b/src/Core/Language/Visitors/QuerySyntaxSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -102,12 +102,16 @@ namespace HotChocolate.Language
             OperationDefinitionNode node,
             DocumentWriter writer)
         {
-            if (node.Name != null)
+            if (node.Name != null || node.VariableDefinitions.Any())
             {
                 writer.Write(node.Operation.ToString().ToLowerInvariant());
                 writer.WriteSpace();
 
-                writer.WriteName(node.Name);
+                if (node.Name != null)
+                {
+                    writer.WriteName(node.Name);
+                }
+
                 if (node.VariableDefinitions.Any())
                 {
                     writer.Write('(');

--- a/src/Core/Language/Visitors/QuerySyntaxSerializer.cs
+++ b/src/Core/Language/Visitors/QuerySyntaxSerializer.cs
@@ -102,7 +102,7 @@ namespace HotChocolate.Language
             OperationDefinitionNode node,
             DocumentWriter writer)
         {
-            if (node.Name != null || node.VariableDefinitions.Any())
+            if (node.Name != null || node.VariableDefinitions.Count > 0)
             {
                 writer.Write(node.Operation.ToString().ToLowerInvariant());
                 writer.WriteSpace();


### PR DESCRIPTION
serialization of querydocument without name but with variables omits variables.
persisted queries can't use serialized document, exception "message": "The following variables were not declared: productId." is thrown
