### PR TITLE
IIdSerializer to get result type hint

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LibraryTargetFrameworks>net5.0; netcoreapp3.1; netstandard2.0</LibraryTargetFrameworks>
+    <LibraryTargetFrameworks>net5.0; netcoreapp3.1; netstandard2.1; netstandard2.0</LibraryTargetFrameworks>
     <TestTargetFrameworks>net5.0; netcoreapp3.1; netcoreapp2.1</TestTargetFrameworks>
   </PropertyGroup>
 

--- a/src/HotChocolate/Core/src/Execution/Processing/ResolverTaskPool.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/ResolverTaskPool.cs
@@ -43,7 +43,7 @@ namespace HotChocolate.Execution.Processing
                     break;
                 }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETSTANDARD2_1
                 spin.SpinOnce();
 #else
                 spin.SpinOnce(sleep1Threshold: -1);
@@ -77,7 +77,7 @@ namespace HotChocolate.Execution.Processing
                         break;
                     }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETSTANDARD2_1
                     spin.SpinOnce();
 #else
                     spin.SpinOnce(sleep1Threshold: -1);

--- a/src/HotChocolate/Core/src/Types/Types/Relay/GlobalIdInputValueFormatter.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/GlobalIdInputValueFormatter.cs
@@ -16,7 +16,9 @@ namespace HotChocolate.Types.Relay
         private readonly NameString _typeName;
         private readonly IIdSerializer _idSerializer;
         private readonly bool _validateType;
+#if !NETSTANDARD2_0
         private readonly Type _resultTypeSource;
+#endif
         private readonly Func<IList> _createList;
 
         public GlobalIdInputValueFormatter(
@@ -28,7 +30,9 @@ namespace HotChocolate.Types.Relay
             _typeName = typeName;
             _idSerializer = idSerializer;
             _validateType = validateType;
+#if !NETSTANDARD2_0
             _resultTypeSource = resultType.Source;
+#endif
             _createList = CreateListFactory(resultType);
         }
 
@@ -43,7 +47,11 @@ namespace HotChocolate.Types.Relay
             {
                 try
                 {
+#if !NETSTANDARD2_0
                     IdValue id = _idSerializer.Deserialize(s, _resultTypeSource);
+#else
+                    IdValue id = _idSerializer.Deserialize(s);
+#endif
 
                     if (!_validateType || _typeName.Equals(id.TypeName))
                     {
@@ -72,7 +80,11 @@ namespace HotChocolate.Types.Relay
 
                     foreach (string sv in stringEnumerable)
                     {
+#if !NETSTANDARD2_0
                         IdValue id = _idSerializer.Deserialize(sv, _resultTypeSource);
+#else
+                        IdValue id = _idSerializer.Deserialize(sv);
+#endif
 
                         if (!_validateType || _typeName.Equals(id.TypeName))
                         {

--- a/src/HotChocolate/Core/src/Types/Types/Relay/GlobalIdInputValueFormatter.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/GlobalIdInputValueFormatter.cs
@@ -16,6 +16,7 @@ namespace HotChocolate.Types.Relay
         private readonly NameString _typeName;
         private readonly IIdSerializer _idSerializer;
         private readonly bool _validateType;
+        private readonly Type _resultTypeSource;
         private readonly Func<IList> _createList;
 
         public GlobalIdInputValueFormatter(
@@ -27,6 +28,7 @@ namespace HotChocolate.Types.Relay
             _typeName = typeName;
             _idSerializer = idSerializer;
             _validateType = validateType;
+            _resultTypeSource = resultType.Source;
             _createList = CreateListFactory(resultType);
         }
 
@@ -41,7 +43,7 @@ namespace HotChocolate.Types.Relay
             {
                 try
                 {
-                    IdValue id = _idSerializer.Deserialize(s);
+                    IdValue id = _idSerializer.Deserialize(s, _resultTypeSource);
 
                     if (!_validateType || _typeName.Equals(id.TypeName))
                     {
@@ -70,7 +72,7 @@ namespace HotChocolate.Types.Relay
 
                     foreach (string sv in stringEnumerable)
                     {
-                        IdValue id = _idSerializer.Deserialize(sv);
+                        IdValue id = _idSerializer.Deserialize(sv, _resultTypeSource);
 
                         if (!_validateType || _typeName.Equals(id.TypeName))
                         {

--- a/src/HotChocolate/Core/src/Types/Types/Relay/IIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/IIdSerializer.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace HotChocolate.Types.Relay
 {
     public interface IIdSerializer
@@ -25,6 +27,9 @@ namespace HotChocolate.Types.Relay
         /// <param name="serializedId">
         /// The schema unique ID string.
         /// </param>
+        /// <param name="resultType">
+        /// An optional hint about the CLR type of the <see cref="IdValue.Value"/>.
+        /// </param>
         /// <returns>
         /// Returns an <see cref="IdValue"/> containing the information
         /// encoded into the unique ID string.
@@ -32,6 +37,6 @@ namespace HotChocolate.Types.Relay
         /// <exception cref="IdSerializationException">
         /// Unable to deconstruct the schema unique ID string.
         /// </exception>
-        IdValue Deserialize(string serializedId);
+        IdValue Deserialize(string serializedId, Type resultType = null);
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Relay/IIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/IIdSerializer.cs
@@ -1,4 +1,6 @@
+#if !NETSTANDARD2_0
 using System;
+#endif
 
 namespace HotChocolate.Types.Relay
 {
@@ -27,6 +29,23 @@ namespace HotChocolate.Types.Relay
         /// <param name="serializedId">
         /// The schema unique ID string.
         /// </param>
+        /// <returns>
+        /// Returns an <see cref="IdValue"/> containing the information
+        /// encoded into the unique ID string.
+        /// </returns>
+        /// <exception cref="IdSerializationException">
+        /// Unable to deconstruct the schema unique ID string.
+        /// </exception>
+        IdValue Deserialize(string serializedId);
+
+#if !NETSTANDARD2_0
+        /// <summary>
+        /// Deserializes a schema unique identifier to reveal the source
+        /// schema, internal ID and type name of an object.
+        /// </summary>
+        /// <param name="serializedId">
+        /// The schema unique ID string.
+        /// </param>
         /// <param name="resultType">
         /// An optional hint about the CLR type of the <see cref="IdValue.Value"/>.
         /// </param>
@@ -37,6 +56,8 @@ namespace HotChocolate.Types.Relay
         /// <exception cref="IdSerializationException">
         /// Unable to deconstruct the schema unique ID string.
         /// </exception>
-        IdValue Deserialize(string serializedId, Type resultType = null);
+        IdValue Deserialize(string serializedId, Type resultType) =>
+            Deserialize(serializedId);
+#endif
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Relay/IdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/IdSerializer.cs
@@ -173,7 +173,7 @@ namespace HotChocolate.Types.Relay
             }
         }
 
-        public IdValue Deserialize(string serializedId) => 
+        public IdValue Deserialize(string serializedId) =>
             Deserialize(serializedId, resultType: null);
 
         public IdValue Deserialize(string serializedId, Type resultType = null)

--- a/src/HotChocolate/Core/src/Types/Types/Relay/IdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/IdSerializer.cs
@@ -176,7 +176,7 @@ namespace HotChocolate.Types.Relay
         public IdValue Deserialize(string serializedId) =>
             Deserialize(serializedId, resultType: null);
 
-        public IdValue Deserialize(string serializedId, Type resultType = null)
+        public IdValue Deserialize(string serializedId, Type resultType)
         {
             if (serializedId is null)
             {

--- a/src/HotChocolate/Core/src/Types/Types/Relay/IdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/IdSerializer.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Text;
 using System.Buffers;
 using System.Buffers.Text;
+using System.Text;
 using HotChocolate.Language;
 using HotChocolate.Properties;
 
@@ -173,7 +173,10 @@ namespace HotChocolate.Types.Relay
             }
         }
 
-        public IdValue Deserialize(string serializedId)
+        public IdValue Deserialize(string serializedId) => 
+            Deserialize(serializedId, resultType: null);
+
+        public IdValue Deserialize(string serializedId, Type resultType = null)
         {
             if (serializedId is null)
             {

--- a/src/HotChocolate/Core/test/Execution.Tests/DependencyInjection/RequestExecutorBuilderExtensions_IdSerializer.Tests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/DependencyInjection/RequestExecutorBuilderExtensions_IdSerializer.Tests.cs
@@ -275,7 +275,7 @@ namespace HotChocolate.Execution.DependencyInjection
                 return "mock";
             }
 
-            public IdValue Deserialize(string serializedId)
+            public IdValue Deserialize(string serializedId, Type resultType = null)
             {
                 return new IdValue(null, null, "mock");
             }

--- a/src/HotChocolate/Core/test/Execution.Tests/DependencyInjection/RequestExecutorBuilderExtensions_IdSerializer.Tests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/DependencyInjection/RequestExecutorBuilderExtensions_IdSerializer.Tests.cs
@@ -275,7 +275,7 @@ namespace HotChocolate.Execution.DependencyInjection
                 return "mock";
             }
 
-            public IdValue Deserialize(string serializedId, Type resultType = null)
+            public IdValue Deserialize(string serializedId)
             {
                 return new IdValue(null, null, "mock");
             }


### PR DESCRIPTION
Allows an `IIdSerializer` implementation to get a hint about what the expected result type is of `IdValue.Value` so other implementations can do polymorphic deserialization.

Addresses #2662
