### PR TITLE
IIdSerializer to get result type hint v10

### DIFF
--- a/src/Core/Types/Types/Relay/FieldValueSerializer.cs
+++ b/src/Core/Types/Types/Relay/FieldValueSerializer.cs
@@ -15,7 +15,9 @@ namespace HotChocolate.Types.Relay
         private readonly IIdSerializer _innerSerializer;
         private readonly bool _validate;
         private readonly bool _list;
+#if !NETSTANDARD2_0
         private readonly Type _valueType;
+#endif
         private readonly Type _listType;
         private NameString _schemaName;
 
@@ -30,7 +32,9 @@ namespace HotChocolate.Types.Relay
             _innerSerializer = innerSerializer;
             _validate = validateType;
             _list = isListType;
+#if !NETSTANDARD2_0
             _valueType = valueType;
+#endif
             _listType = CreateListType(valueType);
         }
 
@@ -49,7 +53,11 @@ namespace HotChocolate.Types.Relay
             {
                 try
                 {
+#if !NETSTANDARD2_0
                     IdValue id = _innerSerializer.Deserialize(s, _valueType);
+#else
+                    IdValue id = _innerSerializer.Deserialize(s);
+#endif
 
                     if (!_validate || _typeName.Equals(id.TypeName))
                     {
@@ -77,7 +85,11 @@ namespace HotChocolate.Types.Relay
 
                     foreach (string sv in stringEnumerable)
                     {
+#if !NETSTANDARD2_0
                         IdValue id = _innerSerializer.Deserialize(sv, _valueType);
+#else
+                        IdValue id = _innerSerializer.Deserialize(sv);
+#endif
 
                         if (!_validate || _typeName.Equals(id.TypeName))
                         {

--- a/src/Core/Types/Types/Relay/FieldValueSerializer.cs
+++ b/src/Core/Types/Types/Relay/FieldValueSerializer.cs
@@ -15,6 +15,7 @@ namespace HotChocolate.Types.Relay
         private readonly IIdSerializer _innerSerializer;
         private readonly bool _validate;
         private readonly bool _list;
+        private readonly Type _valueType;
         private readonly Type _listType;
         private NameString _schemaName;
 
@@ -29,6 +30,7 @@ namespace HotChocolate.Types.Relay
             _innerSerializer = innerSerializer;
             _validate = validateType;
             _list = isListType;
+            _valueType = valueType;
             _listType = CreateListType(valueType);
         }
 
@@ -47,7 +49,7 @@ namespace HotChocolate.Types.Relay
             {
                 try
                 {
-                    IdValue id = _innerSerializer.Deserialize(s);
+                    IdValue id = _innerSerializer.Deserialize(s, _valueType);
 
                     if (!_validate || _typeName.Equals(id.TypeName))
                     {
@@ -75,7 +77,7 @@ namespace HotChocolate.Types.Relay
 
                     foreach (string sv in stringEnumerable)
                     {
-                        IdValue id = _innerSerializer.Deserialize(sv);
+                        IdValue id = _innerSerializer.Deserialize(sv, _valueType);
 
                         if (!_validate || _typeName.Equals(id.TypeName))
                         {

--- a/src/Core/Types/Types/Relay/IIdSerializer.cs
+++ b/src/Core/Types/Types/Relay/IIdSerializer.cs
@@ -1,4 +1,6 @@
+#if !NETSTANDARD2_0
 using System;
+#endif
 
 namespace HotChocolate.Types.Relay
 {
@@ -41,6 +43,23 @@ namespace HotChocolate.Types.Relay
         /// <param name="serializedId">
         /// The schema unique ID string.
         /// </param>
+        /// <returns>
+        /// Returns an <see cref="IdValue"/> containing the information
+        /// encoded into the unique ID string.
+        /// </returns>
+        /// <exception cref="IdSerializationException">
+        /// Unable to deconstruct the schema unique ID string.
+        /// </exception>
+        IdValue Deserialize(string serializedId);
+
+#if !NETSTANDARD2_0
+        /// <summary>
+        /// Deserializes a schema unique identifier to reveal the source
+        /// schema, internal ID and type name of an object.
+        /// </summary>
+        /// <param name="serializedId">
+        /// The schema unique ID string.
+        /// </param>
         /// <param name="resultType">
         /// An optional hint about the CLR type of the <see cref="IdValue.Value"/>.
         /// </param>
@@ -51,6 +70,9 @@ namespace HotChocolate.Types.Relay
         /// <exception cref="IdSerializationException">
         /// Unable to deconstruct the schema unique ID string.
         /// </exception>
-        IdValue Deserialize(string serializedId, Type resultType = null);
+        IdValue Deserialize(string serializedId, Type resultType) =>
+            // TODO: Remove default implementation at a major version bump
+            Deserialize(serializedId);
+#endif
     }
 }

--- a/src/Core/Types/Types/Relay/IIdSerializer.cs
+++ b/src/Core/Types/Types/Relay/IIdSerializer.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace HotChocolate.Types.Relay
 {
     public interface IIdSerializer
@@ -39,6 +41,9 @@ namespace HotChocolate.Types.Relay
         /// <param name="serializedId">
         /// The schema unique ID string.
         /// </param>
+        /// <param name="resultType">
+        /// An optional hint about the CLR type of the <see cref="IdValue.Value"/>.
+        /// </param>
         /// <returns>
         /// Returns an <see cref="IdValue"/> containing the information
         /// encoded into the unique ID string.
@@ -46,6 +51,6 @@ namespace HotChocolate.Types.Relay
         /// <exception cref="IdSerializationException">
         /// Unable to deconstruct the schema unique ID string.
         /// </exception>
-        IdValue Deserialize(string serializedId);
+        IdValue Deserialize(string serializedId, Type resultType = null);
     }
 }

--- a/src/Core/Types/Types/Relay/IdSerializer.cs
+++ b/src/Core/Types/Types/Relay/IdSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using System.Buffers;
 using System.Buffers.Text;
@@ -171,7 +171,7 @@ namespace HotChocolate.Types.Relay
             }
         }
 
-        public IdValue Deserialize(string serializedId)
+        public IdValue Deserialize(string serializedId, Type resultType = null)
         {
             if (serializedId == null)
             {

--- a/src/Core/Types/Types/Relay/IdSerializer.cs
+++ b/src/Core/Types/Types/Relay/IdSerializer.cs
@@ -171,7 +171,10 @@ namespace HotChocolate.Types.Relay
             }
         }
 
-        public IdValue Deserialize(string serializedId, Type resultType = null)
+        public IdValue Deserialize(string serializedId) =>
+            Deserialize(serializedId, resultType: null);
+
+        public IdValue Deserialize(string serializedId, Type resultType)
         {
             if (serializedId == null)
             {

--- a/tools/CoreFramework.props
+++ b/tools/CoreFramework.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">netstandard2.0; net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">netstandard2.0; netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">netstandard2.0; netstandard2.1; net461</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Allows an IIdSerializer implementation to get a hint about what the expected result type is of IdValue.Value so other implementations can do polymorphic deserialization.

Addresses #2662