### PR TITLE
Add support for relative URI's #2589

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
@@ -127,7 +127,10 @@ namespace HotChocolate.Types
 
             // Don't accept a relative URI that does not start with '/'
             if (!uri.IsAbsoluteUri && !uri.OriginalString.StartsWith("/"))
+            {
+                uri = null;
                 return false;
+            }
 
             return true;
         }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
@@ -123,7 +123,9 @@ namespace HotChocolate.Types
         private bool TryParseUri(string value, [NotNullWhen(true)] out Uri? uri)
         {
             if (!Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out uri))
+            {
                 return false;
+            }
 
             // Don't accept a relative URI that does not start with '/'
             if (!uri.IsAbsoluteUri && !uri.OriginalString.StartsWith("/"))

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
@@ -88,7 +88,9 @@ namespace HotChocolate.Types
 
             if (runtimeValue is Uri uri)
             {
-                resultValue = uri.AbsoluteUri;
+                resultValue = uri.IsAbsoluteUri
+                    ? uri.AbsoluteUri
+                    : uri.ToString();
                 return true;
             }
 
@@ -120,7 +122,16 @@ namespace HotChocolate.Types
             return false;
         }
 
-        private bool TryParseUri(string value, [NotNullWhen(true)] out Uri? uri) =>
-            Uri.TryCreate(value, UriKind.Absolute, out uri);
+        private bool TryParseUri(string value, [NotNullWhen(true)] out Uri? uri)
+        {
+            if (!Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out uri))
+                return false;
+
+            // Don't accept a relative URI that does not start with '/'
+            if (!uri.IsAbsoluteUri && !uri.OriginalString.StartsWith("/"))
+                return false;
+
+            return true;
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
@@ -88,9 +88,7 @@ namespace HotChocolate.Types
 
             if (runtimeValue is Uri uri)
             {
-                resultValue = uri.IsAbsoluteUri
-                    ? uri.AbsoluteUri
-                    : uri.ToString();
+                resultValue = uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.ToString();
                 return true;
             }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/UrlTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/UrlTypeTests.cs
@@ -26,8 +26,7 @@ namespace HotChocolate.Types
             var literal = new StringValueNode(expected.AbsoluteUri);
 
             // act
-            var actual = (Uri)urlType
-                .ParseLiteral(literal);
+            var actual = (Uri)urlType.ParseLiteral(literal);
 
             // assert
             Assert.Equal(expected, actual);
@@ -56,8 +55,7 @@ namespace HotChocolate.Types
             var literal = new StringValueNode($"{expected}");
 
             // act
-            var actual = (Uri)urlType
-                .ParseLiteral(literal);
+            var actual = (Uri)urlType.ParseLiteral(literal);
 
             // Assert
             Assert.Equal(expected, actual);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/UrlTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/UrlTypeTests.cs
@@ -48,6 +48,22 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public void ParseLiteral_RelativeUrl()
+        {
+            // arrange
+            var urlType = new UrlType();
+            var expected = new Uri("/relative/path", UriKind.Relative);
+            var literal = new StringValueNode($"{expected}");
+
+            // act
+            var actual = (Uri)urlType
+                .ParseLiteral(literal);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void ParseLiteral_Invalid_Url_Throws()
         {
             // arrange
@@ -117,6 +133,20 @@ namespace HotChocolate.Types
 
             // assert
             Assert.Equal(uri.AbsoluteUri, Assert.IsType<string>(serializedValue));
+        }
+
+        [Fact]
+        public void Serialize_RelativeUrl()
+        {
+            // arrange
+            var urlType = new UrlType();
+            var uri = new Uri("/relative/path", UriKind.Relative);
+
+            // act
+            object serializedValue = urlType.Serialize(uri);
+
+            // assert
+            Assert.Equal(uri.ToString(), Assert.IsType<string>(serializedValue));
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds support for relative URI's which was supported pre v11.

I wanted to make it a little bit more strict than the default 'relative' URI rules (it seems like Uri.TryCreate accepts anything as relative URI). So I'd like to propose that, when parsing a relative URI, it _must_ start with a `/`-character, so we don't allow URI's like `$*^domain.test`.

Closes #2589
