### PR TITLE
Add enum conversion support for f.e. IPAddress and StringGUID #2658

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
@@ -199,12 +199,13 @@ namespace HotChocolate.Types.Descriptors
             }
 
             bool allUpper = true;
+            int lengthMinusOne = name.Length - 1;
 
             for (var i = 0; i < name.Length; i++)
             {
                 var c = name[i];
 
-                if (i > 0 && char.IsUpper(c))
+                if (i > 0 && char.IsUpper(c) && (!char.IsUpper(name[i - 1]) || (i < lengthMinusOne && char.IsLower(name[i + 1]))))
                 {
                     underscores++;
                 }
@@ -241,7 +242,7 @@ namespace HotChocolate.Types.Descriptors
 
                 for (var i = 1; i < name.Length; i++)
                 {
-                    if (char.IsUpper(name[i]))
+                    if (char.IsUpper(name[i]) && (!char.IsUpper(name[i - 1]) || (i < lengthMinusOne && char.IsLower(name[i + 1]))))
                     {
                         buffer[p++] = '_';
                     }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultNamingConventions.cs
@@ -205,7 +205,9 @@ namespace HotChocolate.Types.Descriptors
             {
                 var c = name[i];
 
-                if (i > 0 && char.IsUpper(c) && (!char.IsUpper(name[i - 1]) || (i < lengthMinusOne && char.IsLower(name[i + 1]))))
+                if (i > 0 && char.IsUpper(c) && 
+                    (!char.IsUpper(name[i - 1]) || 
+                        (i < lengthMinusOne && char.IsLower(name[i + 1]))))
                 {
                     underscores++;
                 }
@@ -242,7 +244,9 @@ namespace HotChocolate.Types.Descriptors
 
                 for (var i = 1; i < name.Length; i++)
                 {
-                    if (char.IsUpper(name[i]) && (!char.IsUpper(name[i - 1]) || (i < lengthMinusOne && char.IsLower(name[i + 1]))))
+                    if (char.IsUpper(name[i]) && 
+                        (!char.IsUpper(name[i - 1]) || 
+                            (i < lengthMinusOne && char.IsLower(name[i + 1]))))
                     {
                         buffer[p++] = '_';
                     }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultNamingConventionsTypes.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultNamingConventionsTypes.cs
@@ -8,6 +8,8 @@ namespace HotChocolate.Types.Descriptors
         [InlineData("Foo", "FOO")]
         [InlineData("FooBar", "FOO_BAR")]
         [InlineData("FooBarBaz", "FOO_BAR_BAZ")]
+        [InlineData("StringGUID", "STRING_GUID")]
+        [InlineData("IPAddress", "IP_ADDRESS")]
         [InlineData("FOO_BAR_BAZ", "FOO_BAR_BAZ")]
         [InlineData("FOOBAR", "FOOBAR")]
         [InlineData("F", "F")]


### PR DESCRIPTION
The `!char.IsUpper(name[i - 1])` addition is to support conversions like `StringGUID -> STRING_GUID`.
While the `(i < lengthMinusOne && char.IsLower(name[i + 1]))` addition is to support more complex conversions like `IPAddress -> IP_ADDRESS`.

Closes #2658