### PR TITLE
fix: naming collision of paging with total count

### DIFF
--- a/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionCountType.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionCountType.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using HotChocolate.Configuration;
+using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Types.Pagination
 {
@@ -16,8 +18,8 @@ namespace HotChocolate.Types.Pagination
             Action<IObjectTypeDescriptor<Connection>> configure)
             : base(descriptor =>
             {
-                ApplyConfig(descriptor);
-                configure(descriptor);
+                    ApplyConfig(descriptor);
+                    configure(descriptor);
             })
         {
         }
@@ -33,6 +35,21 @@ namespace HotChocolate.Types.Pagination
                 .Field("totalCount")
                 .Type<NonNullType<IntType>>()
                 .ResolveWith<Resolvers>(t => t.GetTotalCount(default!, default));
+        }
+
+        protected override void OnCompleteName(
+            ITypeCompletionContext context,
+            ObjectTypeDefinition definition)
+        {
+            if (context.TryGetType<ConnectionType<T>>(
+                context.TypeInspector
+                    .GetTypeRef(typeof(ConnectionType<T>), TypeContext.Output),
+                out _))
+            {
+                definition.Name = definition.Name.Value.Replace(TypeSuffix, "Count" + TypeSuffix);
+            }
+
+            base.OnCompleteName(context, definition);
         }
 
         private sealed class Resolvers

--- a/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionType.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionType.cs
@@ -10,6 +10,8 @@ namespace HotChocolate.Types.Pagination
         , IPageType
         where T : class, IOutputType
     {
+        internal const string TypeSuffix = "Connection";
+
         public ConnectionType()
         {
         }
@@ -34,7 +36,7 @@ namespace HotChocolate.Types.Pagination
         protected static void ApplyConfig(IObjectTypeDescriptor<Connection> descriptor)
         {
             descriptor
-                .Name(dependency => $"{dependency.Name}Connection")
+                .Name(d => $"{d.Name}{TypeSuffix}")
                 .DependsOn<T>()
                 .Description("A connection to a list of items.")
                 .BindFields(BindingBehavior.Explicit);

--- a/src/HotChocolate/Core/src/Types.OffsetPagination/CollectionSegmentCountType.cs
+++ b/src/HotChocolate/Core/src/Types.OffsetPagination/CollectionSegmentCountType.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using HotChocolate.Configuration;
+using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Types.Pagination
 {
@@ -53,6 +56,21 @@ namespace HotChocolate.Types.Pagination
                 .Field(OffsetPagingFieldNames.TotalCount)
                 .Type<NonNullType<IntType>>()
                 .ResolveWith<Resolvers>(t => t.GetTotalCount(default!, default));
+        }
+
+        protected override void OnCompleteName(
+            ITypeCompletionContext context,
+            ObjectTypeDefinition definition)
+        {
+            if (context.TryGetType<CollectionSegmentType<T>>(
+                    context.TypeInspector
+                        .GetTypeRef(typeof(CollectionSegmentType<T>), TypeContext.Output),
+                    out _))
+            {
+                definition.Name = definition.Name.Value.Replace(TypeSuffix, "Count" + TypeSuffix);
+            }
+
+            base.OnCompleteName(context, definition);
         }
 
         private sealed class Resolvers

--- a/src/HotChocolate/Core/src/Types.OffsetPagination/CollectionSegmentType~1.cs
+++ b/src/HotChocolate/Core/src/Types.OffsetPagination/CollectionSegmentType~1.cs
@@ -9,6 +9,8 @@ namespace HotChocolate.Types.Pagination
         , IPageType
         where T : class, IOutputType
     {
+        internal const string TypeSuffix = "CollectionSegment";
+
         /// <summary>
         /// Initializes <see cref="CollectionSegmentType{T}" />.
         /// </summary>
@@ -43,7 +45,7 @@ namespace HotChocolate.Types.Pagination
         protected static void ApplyConfig(IObjectTypeDescriptor<CollectionSegment> descriptor)
         {
             descriptor
-                .Name(dependency => $"{dependency.Name}CollectionSegment")
+                .Name(d => $"{d.Name}{TypeSuffix}")
                 .DependsOn<T>()
                 .BindFieldsExplicitly();
 

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
@@ -611,6 +611,37 @@ namespace HotChocolate.Types.Pagination
             schema.Print().MatchSnapshot();
         }
 
+        [Fact]
+        public async Task CursorPaging_DifferentOptionsInTotalCount_NoTypeCollection()
+        {
+            IRequestExecutor executor =
+                await new ServiceCollection()
+                    .AddGraphQL()
+                    .AddQueryType<TotalCountMixQuery>()
+                    .Services
+                    .BuildServiceProvider()
+                    .GetRequestExecutorAsync();
+
+            var schema = executor.Schema.Print();
+
+            schema.MatchSnapshot();
+        }
+
+        public class TotalCountMixQuery
+        {
+            [UsePaging]
+            public IQueryable<Foo> GetFoos()
+            {
+                return new[] { new Foo() }.AsQueryable();
+            }
+
+            [UsePaging(IncludeTotalCount = true)]
+            public IQueryable<Foo> GetFoos2()
+            {
+                return new[] { new Foo() }.AsQueryable();
+            }
+        }
+
         public class QueryType : ObjectType<Query>
         {
             protected override void Configure(IObjectTypeDescriptor<Query> descriptor)

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/__snapshots__/IntegrationTests.CursorPaging_DifferentOptionsInTotalCount_NoTypeCollection.snap
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/__snapshots__/IntegrationTests.CursorPaging_DifferentOptionsInTotalCount_NoTypeCollection.snap
@@ -1,0 +1,68 @@
+﻿schema {
+  query: TotalCountMixQuery
+}
+
+type Foo {
+  bar: String!
+}
+
+"A connection to a list of items."
+type FooConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [FooEdge!]
+  "A flattened list of the nodes."
+  nodes: [Foo!]
+}
+
+"A connection to a list of items."
+type FooCountConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [FooEdge!]
+  "A flattened list of the nodes."
+  nodes: [Foo!]
+  totalCount: Int!
+}
+
+"An edge in a connection."
+type FooEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: Foo!
+}
+
+"Information about pagination in a connection."
+type PageInfo {
+  "Indicates whether more edges exist following the set defined by the clients arguments."
+  hasNextPage: Boolean!
+  "Indicates whether more edges exist prior the set defined by the clients arguments."
+  hasPreviousPage: Boolean!
+  "When paginating backwards, the cursor to continue."
+  startCursor: String
+  "When paginating forwards, the cursor to continue."
+  endCursor: String
+}
+
+type TotalCountMixQuery {
+  foos(first: Int after: String last: Int before: String): FooConnection
+  foos2(first: Int after: String last: Int before: String): FooCountConnection
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"Directs the executor to include this field or fragment only when the `if` argument is true."
+directive @include("Included when true." if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Directs the executor to skip this field or fragment when the `if` argument is true."
+directive @skip("Skipped when true." if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! "Streamed when true." if: Boolean!) on FIELD

--- a/src/HotChocolate/Core/test/Types.OffsetPagination.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Types.OffsetPagination.Tests/IntegrationTests.cs
@@ -540,6 +540,37 @@ namespace HotChocolate.Types.Pagination
             schema.Print().MatchSnapshot();
         }
 
+        [Fact]
+        public async Task OffsetPaging_DifferentOptionsInTotalCount_NoTypeCollection()
+        {
+            IRequestExecutor executor =
+                await new ServiceCollection()
+                    .AddGraphQL()
+                    .AddQueryType<TotalCountMixQuery>()
+                    .Services
+                    .BuildServiceProvider()
+                    .GetRequestExecutorAsync();
+
+            var schema = executor.Schema.Print();
+
+            schema.MatchSnapshot();
+        }
+
+        public class TotalCountMixQuery
+        {
+            [UseOffsetPaging]
+            public IQueryable<Foo> GetFoos()
+            {
+                return new[] { new Foo() }.AsQueryable();
+            }
+
+            [UseOffsetPaging(IncludeTotalCount = true)]
+            public IQueryable<Foo> GetFoos2()
+            {
+                return new[] { new Foo() }.AsQueryable();
+            }
+        }
+
         public class QueryType : ObjectType<Query>
         {
             protected override void Configure(IObjectTypeDescriptor<Query> descriptor)

--- a/src/HotChocolate/Core/test/Types.OffsetPagination.Tests/__snapshots__/IntegrationTests.OffsetPaging_DifferentOptionsInTotalCount_NoTypeCollection.snap
+++ b/src/HotChocolate/Core/test/Types.OffsetPagination.Tests/__snapshots__/IntegrationTests.OffsetPaging_DifferentOptionsInTotalCount_NoTypeCollection.snap
@@ -1,0 +1,48 @@
+﻿schema {
+  query: TotalCountMixQuery
+}
+
+"Information about the offset pagination."
+type CollectionSegmentInfo {
+  "Indicates whether more items exist following the set defined by the clients arguments."
+  hasNextPage: Boolean!
+  "Indicates whether more items exist prior the set defined by the clients arguments."
+  hasPreviousPage: Boolean!
+}
+
+type Foo {
+  bar: String!
+}
+
+type FooCollectionSegment {
+  items: [Foo!]
+  "Information to aid in pagination."
+  pageInfo: CollectionSegmentInfo!
+}
+
+type FooCountCollectionSegment {
+  items: [Foo!]
+  "Information to aid in pagination."
+  pageInfo: CollectionSegmentInfo!
+  totalCount: Int!
+}
+
+type TotalCountMixQuery {
+  foos(skip: Int take: Int): FooCollectionSegment
+  foos2(skip: Int take: Int): FooCountCollectionSegment
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"Directs the executor to include this field or fragment only when the `if` argument is true."
+directive @include("Included when true." if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Directs the executor to skip this field or fragment when the `if` argument is true."
+directive @skip("Skipped when true." if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! "Streamed when true." if: Boolean!) on FIELD


### PR DESCRIPTION
In case paging is once registered with total count and once without the type names collide
To avoid breaking changes the type names are now only rewritten when there are both kinds defined


closes #2747 