### PR TITLE
clarify AddHttpRequestInterceptor usage

### DIFF
--- a/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
+++ b/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
@@ -117,7 +117,9 @@ services.AddQueryRequestInterceptor(
 **New:**
 
 ```csharp
-services.AddHttpRequestInterceptor(
+services.AddGraphQLServer()
+    ...
+    .AddHttpRequestInterceptor(
     (context, executor, builder, ct) =>
     {
         // your code
@@ -127,7 +129,9 @@ services.AddHttpRequestInterceptor(
 You can also extend `DefaultHttpRequestInterceptor` and inject it like the following.
 
 ```csharp
-services.AddHttpRequestInterceptor<MyCustomExecutor>();
+services.AddGraphQLServer()
+    ...
+    .AddHttpRequestInterceptor<MyCustomExecutor>();
 ```
 
 > A request interceptor is a service that is used by all hosted schemas.


### PR DESCRIPTION
Brief update to docs to Indicate that `AddHttpRequestInterceptor` is a method off of `IRequestExecutorBuilder` not `IServiceCollection`.