### PR TITLE
Unseal StringType scalar as was done in v10

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Scalars/StringType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/StringType.cs
@@ -13,7 +13,7 @@ namespace HotChocolate.Types
     /// http://facebook.github.io/graphql/June2018/#sec-String
     /// </summary>
     [SpecScalar]
-    public sealed class StringType
+    public class StringType
         : ScalarType<string, StringValueNode>
     {
         /// <summary>


### PR DESCRIPTION
Allows for us to implement more specific string-based scalars easily.

Unblocks AutoGuru's upgrade to v11.