### PR TITLE
Add HasErrors to IResolverContext

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/DirectiveContext.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/DirectiveContext.cs
@@ -62,6 +62,8 @@ namespace HotChocolate.Execution.Processing
         public Path Path =>
             _middlewareContext.Path;
 
+        public bool HasErrors => _middlewareContext.HasErrors;
+
         public CancellationToken CancellationToken =>
             RequestAborted;
 

--- a/src/HotChocolate/Core/src/Execution/Processing/DirectiveContext.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/DirectiveContext.cs
@@ -62,7 +62,8 @@ namespace HotChocolate.Execution.Processing
         public Path Path =>
             _middlewareContext.Path;
 
-        public bool HasErrors => _middlewareContext.HasErrors;
+        public bool HasErrors =>
+            _middlewareContext.HasErrors;
 
         public CancellationToken CancellationToken =>
             RequestAborted;

--- a/src/HotChocolate/Core/src/Types/Resolvers/IResolverContext.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/IResolverContext.cs
@@ -77,7 +77,7 @@ namespace HotChocolate.Resolvers
         Path Path { get; }
 
         /// <summary>
-        /// Indicates that context has errors. To report new error use <see cref="ReportError(IError)"/>
+        /// Indicates that the context has errors. To report new errors use <see cref="ReportError(IError)"/>
         /// </summary>
         bool HasErrors { get; }
 

--- a/src/HotChocolate/Core/src/Types/Resolvers/IResolverContext.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/IResolverContext.cs
@@ -77,6 +77,11 @@ namespace HotChocolate.Resolvers
         Path Path { get; }
 
         /// <summary>
+        /// Indicates that context has errors. To report new error use <see cref="ReportError(IError)"/>
+        /// </summary>
+        bool HasErrors { get; }
+
+        /// <summary>
         /// The scoped context data dictionary can be used by middlewares and
         /// resolvers to store and retrieve data during execution scoped to the
         /// hierarchy

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/QueryableCursorPagingProviderTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/QueryableCursorPagingProviderTests.cs
@@ -449,6 +449,8 @@ namespace HotChocolate.Types.Pagination
 
             public Path Path => throw new NotImplementedException();
 
+            public bool HasErrors => throw new NotImplementedException();
+
             public IImmutableDictionary<string, object> ScopedContextData
             {
                 get => throw new NotImplementedException();


### PR DESCRIPTION
Introduces `HasErrors` to the `IResolverContext` interface.

The `HasErrors` property was already on the `MiddlewareContext` implementation and indicated that an error was raised in the pipeline. The property can use to abort the processing of a field pipeline in cases where an error was raised that was not caused by an exception.