### PR TITLE
Fixed string literals in places of enum values have to raise a query errors.

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/EnumType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/EnumType.cs
@@ -55,6 +55,11 @@ namespace HotChocolate.Types
                 return _enumValues.ContainsKey(ev.Value);
             }
 
+            if (valueSyntax is StringValueNode sv)
+            {
+                return _enumValues.ContainsKey(sv.Value);
+            }
+
             return false;
         }
 
@@ -75,6 +80,12 @@ namespace HotChocolate.Types
 
             if (valueSyntax is EnumValueNode evn &&
                 _enumValues.TryGetValue(evn.Value, out IEnumValue? ev))
+            {
+                return ev.Value;
+            }
+
+            if (valueSyntax is StringValueNode svn &&
+                _enumValues.TryGetValue(svn.Value, out ev))
             {
                 return ev.Value;
             }

--- a/src/HotChocolate/Core/src/Types/Types/EnumType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/EnumType.cs
@@ -55,11 +55,6 @@ namespace HotChocolate.Types
                 return _enumValues.ContainsKey(ev.Value);
             }
 
-            if (valueSyntax is StringValueNode sv)
-            {
-                return _enumValues.ContainsKey(sv.Value);
-            }
-
             return false;
         }
 
@@ -80,12 +75,6 @@ namespace HotChocolate.Types
 
             if (valueSyntax is EnumValueNode evn &&
                 _enumValues.TryGetValue(evn.Value, out IEnumValue? ev))
-            {
-                return ev.Value;
-            }
-
-            if (valueSyntax is StringValueNode svn &&
-                _enumValues.TryGetValue(svn.Value, out ev))
             {
                 return ev.Value;
             }

--- a/src/HotChocolate/Core/src/Validation/Rules/ValueVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/ValueVisitor.cs
@@ -382,6 +382,12 @@ namespace HotChocolate.Validation.Rules
                 return true;
             }
 
+            if (inputType.IsEnumType() &&
+                value is StringValueNode)
+            {
+                return false;
+            }
+
             return internalType.IsInstanceOfType(value);
         }
 

--- a/src/HotChocolate/Core/test/Validation.Tests/ValuesOfCorrectTypeRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/ValuesOfCorrectTypeRuleTests.cs
@@ -619,8 +619,7 @@ namespace HotChocolate.Validation
             ");
         }
 
-        // is this something that we find ok or should we change it back?
-        [Fact(Skip = "We do allow this at the moment.")]
+        [Fact]
         public void BadStringIntoEnum()
         {
             ExpectErrors(@"


### PR DESCRIPTION
String Literals in Places of Enum Values have to raise a query error:

https://spec.graphql.org/June2018/#sec-Enums

>Input Coercion
>
>GraphQL has a constant literal to represent enum input values. GraphQL string literals must not be accepted as an enum input and instead raise a query error.
