### PR TITLE
Updated packages with new names and links

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -11,8 +11,8 @@ Various libraries, packages, etc. that developers can add to their own project a
 ### Validation
 
 - [FairyBread](https://github.com/benmccallum/fairybread) - Input validation for Hot Chocolate
-- [DarkHills.HotChocolate.FluentValidation](https://github.com/DarkHills/HotChocolate.FluentValidation) - FluentValidation middleware for Hot Chocolate
+- [FluentChoco](https://github.com/dalrankov/FluentChoco) - FluentValidation middleware for Hot Chocolate
 
 ### Data access
 
-- [DarkHills.HotChocolate.TransactionScope](https://github.com/DarkHills/HotChocolate.TransactionScope) - TransactionScope middleware for Hot Chocolate
+- [TransactChoco](https://github.com/dalrankov/TransactChoco) - TransactionScope middleware for Hot Chocolate


### PR DESCRIPTION
For a long-term maintenance and clear separation between yours (official) HC package names and namespaces and community ones, I've renamed my packages and their namespaces to clearly show that these are not official ones.