### PR TITLE
fix: projection of edge type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed projection of edge type (#2888)
+
 ## [11.0.8]
 
 ### Added

--- a/ErrorCodes.md
+++ b/ErrorCodes.md
@@ -20,3 +20,4 @@
 | HC0018 | Execution         | Variable `xyz` is required.                                                                                |
 | HC0019 | Execution         | Unable to create an instance for the operation type (initial value).                                       |
 | HC0020 | Execution         | A persisted query was not found when using the active persisted query pipeline.                            |
+| HC0028 | Data              | Type does not contain a valid node field. Only `items` and `nodes` are supported                           |

--- a/src/HotChocolate/Core/src/Abstractions/ErrorCodes.cs
+++ b/src/HotChocolate/Core/src/Abstractions/ErrorCodes.cs
@@ -114,5 +114,13 @@ namespace HotChocolate
             public const string TypeNotDefined = "STITCHING_TYPE_NOT_DEFINED";
             public const string ArgumentNotFound = "STITCHING_DEL_ARGUMENT_NOT_FOUND";
         }
+
+        public static class Data
+        {
+            /// <summary>
+            /// Type does not contain a valid node field. Only `items` and `nodes` are supported
+            /// </summary>
+            public const string NodeFieldWasNotFound = "HC0028";
+        }
     }
 }

--- a/src/HotChocolate/Data/src/Data/DataResources.Designer.cs
+++ b/src/HotChocolate/Data/src/Data/DataResources.Designer.cs
@@ -417,6 +417,12 @@ namespace HotChocolate.Data {
             }
         }
         
+        internal static string ProjectionVisitor_NodeFieldWasNotFound {
+            get {
+                return ResourceManager.GetString("ProjectionVisitor_NodeFieldWasNotFound", resourceCulture);
+            }
+        }
+        
         internal static string FilterConvention_ProviderHasToBeInitializedByConvention {
             get {
                 return ResourceManager.GetString("FilterConvention_ProviderHasToBeInitializedByConvention", resourceCulture);

--- a/src/HotChocolate/Data/src/Data/DataResources.resx
+++ b/src/HotChocolate/Data/src/Data/DataResources.resx
@@ -209,6 +209,9 @@
   <data name="ProjectionConvention_CouldNotProject" xml:space="preserve">
     <value>Projection Visitor is in invalid state. Projection failed!</value>
   </data>
+  <data name="ProjectionVisitor_NodeFieldWasNotFound" xml:space="preserve">
+    <value>Type {0} does not contain a valid node field. Only `items` and `nodes` are supported</value>
+  </data>
   <data name="FilterConvention_ProviderHasToBeInitializedByConvention" xml:space="preserve">
     <value>The filter provider {0} {1}was not initialized by a convention. It is only valid to register a provider over a FilterConvention</value>
   </data>

--- a/src/HotChocolate/Data/src/Data/ErrorHelper.cs
+++ b/src/HotChocolate/Data/src/Data/ErrorHelper.cs
@@ -6,6 +6,7 @@ using HotChocolate.Data.Sorting;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using HotChocolate.Types;
+using HotChocolate.Types.Pagination;
 
 namespace HotChocolate.Data
 {
@@ -83,18 +84,23 @@ namespace HotChocolate.Data
                 .SetCode("SELECTIONS_SINGLE_MORE_THAN_ONE")
                 .Build();
 
-        public static IError ProjectionProvider_CouldNotProjectFiltering(
-            IValueNode node) =>
+        public static IError ProjectionProvider_CouldNotProjectFiltering(IValueNode node) =>
             ErrorBuilder.New()
                 .SetMessage(DataResources.ProjectionProvider_CouldNotProjectFiltering)
                 .AddLocation(node)
                 .Build();
 
-        public static IError ProjectionProvider_CouldNotProjectSorting(
-            IValueNode node) =>
+        public static IError ProjectionProvider_CouldNotProjectSorting(IValueNode node) =>
             ErrorBuilder.New()
                 .SetMessage(DataResources.ProjectionProvider_CouldNotProjectSorting)
                 .AddLocation(node)
+                .Build();
+
+        public static IError ProjectionVisitor_NodeFieldWasNotFound(IPageType pageType) =>
+            ErrorBuilder.New()
+                .SetMessage(DataResources.ProjectionVisitor_NodeFieldWasNotFound,
+                    pageType.Name)
+                .SetCode(ErrorCodes.Data.NodeFieldWasNotFound)
                 .Build();
     }
 }

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Optimizers/QueryablePagingProjectionOptimizer.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Optimizers/QueryablePagingProjectionOptimizer.cs
@@ -83,22 +83,18 @@ namespace HotChocolate.Data.Projections.Handlers
         private IReadOnlyList<ISelectionNode> CollectSelection(SelectionOptimizerContext context)
         {
             var selections = new List<ISelectionNode>();
-            if (context.Fields.TryGetValue("nodes", out Selection? nodeSelection))
-            {
-                foreach (var nodeField in nodeSelection.SelectionSet.Selections)
-                {
-                    selections.Add(CloneSelectionSetVisitor.Default.CloneSelectionNode(nodeField));
-                }
-            }
 
-            if (context.Fields.TryGetValue("items", out Selection? itemSelection))
-            {
-                foreach (var nodeField in itemSelection.SelectionSet.Selections)
-                {
-                    selections.Add(CloneSelectionSetVisitor.Default.CloneSelectionNode(nodeField));
-                }
-            }
+            CollectSelectionOfNodes(context, selections);
+            CollectSelectionOfItems(context, selections);
+            CollectSelectionOfEdges(context, selections);
 
+            return selections;
+        }
+
+        private static void CollectSelectionOfEdges(
+            SelectionOptimizerContext context,
+            List<ISelectionNode> selections)
+        {
             if (context.Fields.TryGetValue("edges", out Selection? edgeSelection))
             {
                 foreach (var edgeSubField in edgeSelection.SelectionSet.Selections)
@@ -115,8 +111,32 @@ namespace HotChocolate.Data.Projections.Handlers
                     }
                 }
             }
+        }
 
-            return selections;
+        private static void CollectSelectionOfItems(
+            SelectionOptimizerContext context,
+            List<ISelectionNode> selections)
+        {
+            if (context.Fields.TryGetValue("items", out Selection? itemSelection))
+            {
+                foreach (var nodeField in itemSelection.SelectionSet.Selections)
+                {
+                    selections.Add(CloneSelectionSetVisitor.Default.CloneSelectionNode(nodeField));
+                }
+            }
+        }
+
+        private static void CollectSelectionOfNodes(
+            SelectionOptimizerContext context,
+            List<ISelectionNode> selections)
+        {
+            if (context.Fields.TryGetValue("nodes", out Selection? nodeSelection))
+            {
+                foreach (var nodeField in nodeSelection.SelectionSet.Selections)
+                {
+                    selections.Add(CloneSelectionSetVisitor.Default.CloneSelectionNode(nodeField));
+                }
+            }
         }
 
         private class CloneSelectionSetVisitor : QuerySyntaxRewriter<object>

--- a/src/HotChocolate/Data/src/Data/Projections/ProjectionVisitor.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/ProjectionVisitor.cs
@@ -6,6 +6,7 @@ using HotChocolate.Resolvers;
 using HotChocolate.Types;
 using HotChocolate.Types.Pagination;
 using static HotChocolate.Data.Projections.ProjectionProvider;
+using static HotChocolate.Data.Projections.WellKnownProjectionFields;
 
 namespace HotChocolate.Data.Projections
 {
@@ -127,19 +128,16 @@ namespace HotChocolate.Data.Projections
             }
 
             if (field.Type is IPageType and ObjectType pageType &&
-                context.SelectionSetNodes.Peek() is {} pagingFieldSelection)
+                context.SelectionSetNodes.Peek() is { } pagingFieldSelection)
             {
                 IReadOnlyList<IFieldSelection> selections =
                     context.Context.GetSelections(pageType, pagingFieldSelection, true);
 
                 foreach (var selection in selections)
                 {
-                    if ((selection.Field.Name.Value is "nodes" ||
-                        selection.Field.Name.Value is "items") &&
-                        selection.SyntaxNode.SelectionSet is not null)
+                    if (selection.ResponseName.Value is CombinedEdgeField)
                     {
-                        context.SelectionSetNodes.Push(
-                            selection.SyntaxNode.SelectionSet);
+                        context.SelectionSetNodes.Push(selection.SyntaxNode.SelectionSet);
 
                         return base.Visit(selection.Field, context);
                     }

--- a/src/HotChocolate/Data/src/Data/Projections/WellKnownProjectionFields.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/WellKnownProjectionFields.cs
@@ -1,0 +1,7 @@
+namespace HotChocolate.Data.Projections
+{
+    internal static class WellKnownProjectionFields
+    {
+        public const string CombinedEdgeField = "_combinedSelectionSet";
+    }
+}

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionVisitorPagingTests.CreateNullable_ProjectsTwoProperties_EdgesAndNodes.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionVisitorPagingTests.CreateNullable_ProjectsTwoProperties_EdgesAndNodes.snap
@@ -3,15 +3,12 @@
     "root": {
       "nodes": [
         {
-          "bar": true,
           "baz": "a"
         },
         {
-          "bar": null,
           "baz": null
         },
         {
-          "bar": false,
           "baz": "c"
         }
       ],

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionVisitorPagingTests.CreateNullable_ProjectsTwoProperties_EdgesAndNodes__sql.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionVisitorPagingTests.CreateNullable_ProjectsTwoProperties_EdgesAndNodes__sql.snap
@@ -1,2 +1,2 @@
-﻿SELECT "d"."Bar", "d"."Baz"
+﻿SELECT "d"."Baz", "d"."Bar"
 FROM "Data" AS "d"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionVisitorPagingTests.Create_ProjectsTwoProperties_EdgesAndNodes.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionVisitorPagingTests.Create_ProjectsTwoProperties_EdgesAndNodes.snap
@@ -3,11 +3,9 @@
     "root": {
       "nodes": [
         {
-          "bar": true,
           "baz": "a"
         },
         {
-          "bar": false,
           "baz": "b"
         }
       ],

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionVisitorPagingTests.Create_ProjectsTwoProperties_EdgesAndNodes__sql.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionVisitorPagingTests.Create_ProjectsTwoProperties_EdgesAndNodes__sql.snap
@@ -1,2 +1,2 @@
-﻿SELECT "d"."Bar", "d"."Baz"
+﻿SELECT "d"."Baz", "d"."Bar"
 FROM "Data" AS "d"

--- a/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
@@ -265,6 +265,43 @@ namespace HotChocolate.Data
             result.ToJson().MatchSnapshot();
         }
 
+        [Fact]
+        public async Task ExecuteAsync_Should_ProjectAndPage_When_BothAreAppliedAndProvided()
+        {
+            // arrange
+            IRequestExecutor executor = await new ServiceCollection()
+                .AddGraphQL()
+                .AddFiltering()
+                .EnableRelaySupport()
+                .AddSorting()
+                .AddProjections()
+                .AddQueryType<PagingAndProjection>()
+                .AddObjectType<Book>(x =>
+                    x.ImplementsNode().IdField(x => x.Id).ResolveNode(x => default!))
+                .BuildRequestExecutorAsync();
+
+            // act
+            IExecutionResult result = await executor.ExecuteAsync(
+                @"
+                {
+                    books {
+                        nodes {
+                            id
+                        }
+                        edges {
+                            node {
+                                title
+                            }
+                        }
+
+                    }
+                }
+                ");
+
+            // assert
+            result.ToJson().MatchSnapshot();
+        }
+
         public class PagingAndProjection
         {
             [UsePaging]

--- a/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
@@ -256,7 +256,6 @@ namespace HotChocolate.Data
                                 }
                             }
                         }
-
                     }
                 }
                 ");
@@ -293,7 +292,6 @@ namespace HotChocolate.Data
                                 title
                             }
                         }
-
                     }
                 }
                 ");

--- a/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using HotChocolate.Execution;
+using HotChocolate.Execution.Processing;
 using HotChocolate.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Snapshooter.Xunit;
@@ -224,6 +226,53 @@ namespace HotChocolate.Data
 
             // assert
             result.ToJson().MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_ProjectAndPage_When_BothMiddlewaresAreApplied()
+        {
+            // arrange
+            IRequestExecutor executor = await new ServiceCollection()
+                .AddGraphQL()
+                .AddFiltering()
+                .EnableRelaySupport()
+                .AddSorting()
+                .AddProjections()
+                .AddQueryType<PagingAndProjection>()
+                .AddObjectType<Book>(x =>
+                    x.ImplementsNode().IdField(x => x.Id).ResolveNode(x => default!))
+                .BuildRequestExecutorAsync();
+
+            // act
+            IExecutionResult result = await executor.ExecuteAsync(
+                @"
+                {
+                    books {
+                        edges {
+                            node {
+                                id
+                                author {
+                                    name
+                                }
+                            }
+                        }
+
+                    }
+                }
+                ");
+
+            // assert
+            result.ToJson().MatchSnapshot();
+        }
+
+        public class PagingAndProjection
+        {
+            [UsePaging]
+            [UseProjection]
+            public IQueryable<Book> GetBooks() => new[]
+            {
+                new Book { Id = 1, Title = "BookTitle", Author = new Author { Name = "Author" } }
+            }.AsQueryable();
         }
     }
 }

--- a/src/HotChocolate/Data/test/Data.Tests/__snapshots__/IntegrationTests.ExecuteAsync_Should_ProjectAndPage_When_BothAreAppliedAndProvided.snap
+++ b/src/HotChocolate/Data/test/Data.Tests/__snapshots__/IntegrationTests.ExecuteAsync_Should_ProjectAndPage_When_BothAreAppliedAndProvided.snap
@@ -1,0 +1,18 @@
+﻿{
+  "data": {
+    "books": {
+      "nodes": [
+        {
+          "id": "Qm9vawppMQ=="
+        }
+      ],
+      "edges": [
+        {
+          "node": {
+            "title": "BookTitle"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/HotChocolate/Data/test/Data.Tests/__snapshots__/IntegrationTests.ExecuteAsync_Should_ProjectAndPage_When_BothMiddlewaresAreApplied.snap
+++ b/src/HotChocolate/Data/test/Data.Tests/__snapshots__/IntegrationTests.ExecuteAsync_Should_ProjectAndPage_When_BothMiddlewaresAreApplied.snap
@@ -1,0 +1,16 @@
+﻿{
+  "data": {
+    "books": {
+      "edges": [
+        {
+          "node": {
+            "id": "Qm9vawppMQ==",
+            "author": {
+              "name": "Author"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Projection of edge types collect all the selections set of node and edges and create internal selections for them
Because of the caching of the selection set in the operation compiler, the selection set in edge types was discovered as internal and was not resolved by the execution engine

Closes #2727 
