### PR TITLE
update v11 migration docs for batch serialization

### DIFF
--- a/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
+++ b/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
@@ -665,6 +665,15 @@ downstream schemas.
     }
 ```
 
+## Batch responses
+In v10, responses to batched operations were returned as a JsonArray. In v11 the default is to return MultiPartChunked responses. To switch back to JsonArray, configure the HttpResult serializer as follows:
+
+```csharp
+services.AddHttpResultSerializer(
+    batchSerialization: HttpResultSerialization.JsonArray
+);
+```
+
 # Testing
 
 We have added a couple of test helpers to make the transition to the new configuration API easier.


### PR DESCRIPTION
Default behavior has changed, updating docs with instructions on how to revert.