### PR TITLE
Fixed TypeTrimmer interface detection

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/TypeTrimmer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeTrimmer.cs
@@ -112,7 +112,7 @@ namespace HotChocolate.Configuration
 
             foreach (InterfaceType interfaceType in type.Implements)
             {
-                VisitInterface(interfaceType);
+                Visit(interfaceType);
             }
 
             foreach (ObjectField field in type.Fields)

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeTrimmerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeTrimmerTests.cs
@@ -76,6 +76,35 @@ namespace HotChocolate.Configuration
         }
 
         [Fact]
+        private void Interface_Implementors_Correctly_Detected_2()
+        {
+            // arrange
+            // act
+            ISchema schema = SchemaBuilder.New()
+                .AddQueryType(c => c
+                    .Name("abc")
+                    .Field("field")
+                    .Type(new NamedTypeNode("ghi"))
+                    .Resolver("test"))
+                .AddInterfaceType(c => c
+                    .Name("def")
+                    .Field("field")
+                    .Type<StringType>())
+                .AddObjectType(c => c
+                    .Name("ghi")
+                    .Implements(new NamedTypeNode("def"))
+                    .Field("field")
+                    .Type<StringType>()
+                    .Resolver("test"))
+                .AddType<FloatType>()
+                .ModifyOptions(o => o.RemoveUnreachableTypes = true)
+                .Create();
+
+            // assert
+            schema.ToString().MatchSnapshot();
+        }
+
+        [Fact]
         private void Union_Set_Is_Correctly_Detected()
         {
             // arrange

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeTrimmerTests.Interface_Implementors_Correctly_Detected_2.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeTrimmerTests.Interface_Implementors_Correctly_Detected_2.snap
@@ -1,0 +1,30 @@
+﻿schema {
+  query: abc
+}
+
+interface def {
+  field: String
+}
+
+type abc {
+  field: ghi
+}
+
+type ghi implements def {
+  field: String
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The @deprecated directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema,such as deprecated fields on a type or deprecated enum values."
+directive @deprecated("Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by CommonMark)." reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
+"Directs the executor to include this field or fragment only when the `if` argument is true."
+directive @include("Included when true." if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Directs the executor to skip this field or fragment when the `if` argument is true."
+directive @skip("Skipped when true." if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! "Streamed when true." if: Boolean!) on FIELD


### PR DESCRIPTION
TypeTrimmer removes too many interfaces. Types possibly reference an interface, which is not existing anymore.

Addresses #1669
