### PR TITLE
Fix a couple of error messages

### DIFF
--- a/src/HotChocolate/Core/src/Types/Utilities/ThrowHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ThrowHelper.cs
@@ -140,8 +140,8 @@ namespace HotChocolate.Utilities
                 SchemaErrorBuilder.New()
                     .SetMessage(
                         "The specified node resolver `{0}` does not exist on `{1}`.",
-                        type.FullName ?? type.Name,
-                        nodeResolver)
+                        nodeResolver,
+                        type.FullName ?? type.Name)
                     .Build());
 
         public static SchemaException NodeAttribute_IdFieldNotFound(
@@ -151,8 +151,8 @@ namespace HotChocolate.Utilities
                 SchemaErrorBuilder.New()
                     .SetMessage(
                         "The specified id field `{0}` does not exist on `{1}`.",
-                        type.FullName ?? type.Name,
-                        idField)
+                        idField,
+                        type.FullName ?? type.Name)
                     .Build());
 
 #nullable enable


### PR DESCRIPTION
Fixes 2 small errors in error messages:

- The specified node resolver `NodeType` does not exist on `NodeResolver`.
- The specified id field `NodeType` does not exist on `IdField`.

have changed to:

- The specified node resolver `NodeResolver` does not exist on `NodeType`.
- The specified id field `IdField` does not exist on `NodeType`.

