### PR TITLE
Update migrate-from-10-to-11.md

### DIFF
--- a/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
+++ b/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
@@ -309,6 +309,30 @@ Further, you can override the paging option on the resolver level.
 descriptor.Field(...).UsePaging(maxPageSize = 100)...
 ```
 
+## Projections
+
+Selection middleware, that was available in `HotChocolate.Types.Selections` package was replaced by projection middleware from `HotChocolate.Data` package. 
+
+**Old:**
+
+```csharp
+descriptor.Field(...).UseSelection()...
+```
+
+**New:**
+
+```csharp
+descriptor.Field(...).UseProjection()...
+```
+
+Similarly, attribute `[UseSelection]` was replaced by `[UseProjection]`. To use projections with your GraphQL endpoint you have to register projections on the schema:
+
+```csharp
+services.AddGraphQLServer()
+  // Your schmea configuration
+  .AddProjections();
+```
+
 ## Enum Type
 
 HotChocolate server 11 now follows the spec recommendation with the new enum name conventions and formats the enum values by default as UPPER_SNAIL_CASE.

--- a/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
+++ b/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
@@ -311,7 +311,7 @@ descriptor.Field(...).UsePaging(maxPageSize = 100)...
 
 ## Projections
 
-The selection middleware, that was available in `HotChocolate.Types.Selections` was replaced by projection middleware from the `HotChocolate.Data` package. 
+The selection middleware, that was available in `HotChocolate.Types.Selections` was replaced by the projection middleware from `HotChocolate.Data`. 
 
 **Old:**
 

--- a/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
+++ b/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
@@ -311,7 +311,7 @@ descriptor.Field(...).UsePaging(maxPageSize = 100)...
 
 ## Projections
 
-The selection middleware, that was available in `HotChocolate.Types.Selections` package was replaced by projection middleware from the `HotChocolate.Data` package. 
+The selection middleware, that was available in `HotChocolate.Types.Selections` was replaced by projection middleware from the `HotChocolate.Data` package. 
 
 **Old:**
 

--- a/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
+++ b/website/src/docs/hotchocolate/api-reference/migrate-from-10-to-11.md
@@ -311,7 +311,7 @@ descriptor.Field(...).UsePaging(maxPageSize = 100)...
 
 ## Projections
 
-Selection middleware, that was available in `HotChocolate.Types.Selections` package was replaced by projection middleware from `HotChocolate.Data` package. 
+The selection middleware, that was available in `HotChocolate.Types.Selections` package was replaced by projection middleware from the `HotChocolate.Data` package. 
 
 **Old:**
 
@@ -325,7 +325,9 @@ descriptor.Field(...).UseSelection()...
 descriptor.Field(...).UseProjection()...
 ```
 
-Similarly, attribute `[UseSelection]` was replaced by `[UseProjection]`. To use projections with your GraphQL endpoint you have to register projections on the schema:
+Similarly, the attribute `[UseSelection]` was replaced by `[UseProjection]`. 
+
+To use projections with your GraphQL endpoint you have to register it on the schema:
 
 ```csharp
 services.AddGraphQLServer()


### PR DESCRIPTION
Selection middleware (HotChocolate.Types.Selections) was replaced by projection middleware (HotChocolate.Data)

Recently my team was migrating HotChocolate to v11. The NuGet package HotChocolate.Types.Selections, that we were using, was only available in v10. After a long investigation, we found how to migrate properly, but it would be really helpful if the guide would contain information about projection middleware.

