### PR TITLE
chore: fix obsolete message on `QueryCacheSize`

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
@@ -46,7 +46,7 @@ namespace HotChocolate.Execution.Options
         /// <c>10</c>.
         /// </summary>
         [Obsolete(
-            "Use AddDocumentCache or AddOperationCache on the IRequestExecutorBuilder.",
+            "Use AddDocumentCache or AddOperationCache on the IServiceCollection.",
             true)]
         public int QueryCacheSize
         {


### PR DESCRIPTION
Fixes incorrect obsolete message

Addresses #3412
