### PR TITLE
Change [BindProperty] to [BindMember] in docs

### DIFF
--- a/website/src/docs/hotchocolate/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/extending-types.md
@@ -111,7 +111,7 @@ To replace the `TrackId` with a field `Track` that returns the `Tack` object we 
 [ExtendObjectType(typeof(Session))]
 public class SessionResolvers
 {
-    [BindProperty(nameof(Session.TrackId))]
+    [BindMember(nameof(Session.TrackId))]
     public async Task<Track> GetTrackAsync([Parent] Session session) => ...
 }
 ```


### PR DESCRIPTION
The correct attribute for extending types where you replace a member is not [BindProperty] but [BindMember]


