### PR TITLE
Fixed how we initialize field resolvers.

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/Bindings/BindResolver.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Bindings/BindResolver.cs
@@ -8,8 +8,7 @@ namespace HotChocolate.Configuration.Bindings
     {
         private readonly IResolverTypeBindingBuilder _typeBuilder;
 
-        public BindResolver(
-            IResolverTypeBindingBuilder typeBuilder)
+        public BindResolver(IResolverTypeBindingBuilder typeBuilder)
         {
             _typeBuilder = typeBuilder
                 ?? throw new ArgumentNullException(nameof(typeBuilder));

--- a/src/HotChocolate/Core/src/Types/Configuration/Contracts/ITypeCompletionContext.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Contracts/ITypeCompletionContext.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
 using HotChocolate.Resolvers;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
@@ -74,6 +76,9 @@ namespace HotChocolate.Configuration
         /// </exception>
         T GetType<T>(ITypeReference typeRef) where T : IType;
 
+        /// <summary>
+        /// Gets all registered types of <typeparamref name="T"/>.
+        /// </summary>
         IEnumerable<T> GetTypes<T>() where T : IType;
 
         bool TryGetDirectiveType(

--- a/src/HotChocolate/Core/src/Types/Configuration/Contracts/ITypeDiscoveryContext.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Contracts/ITypeDiscoveryContext.cs
@@ -11,8 +11,7 @@ namespace HotChocolate.Configuration
     /// The type discovery context is available during the discovery phase of the type system.
     /// In this phase types are inspected and registered.
     /// </summary>
-    public interface ITypeDiscoveryContext
-        : ITypeSystemObjectContext
+    public interface ITypeDiscoveryContext : ITypeSystemObjectContext
     {
         /// <summary>
         /// The collected type dependencies.
@@ -20,15 +19,15 @@ namespace HotChocolate.Configuration
         IReadOnlyList<TypeDependency> TypeDependencies { get; }
 
         /// <summary>
-        /// Register a reference to a type on which <see cref="Type" /> depends. 
-        /// Such a reference could for instance represent a type of a field that 
+        /// Register a reference to a type on which <see cref="Type" /> depends.
+        /// Such a reference could for instance represent a type of a field that
         /// <see cref="Type" /> exposes.
         /// </summary>
         /// <param name="reference">
         /// A reference representing a type on which <see cref="Type" /> depends.
         /// </param>
         /// <param name="kind">
-        /// The type dependency context defines if this type for instance is 
+        /// The type dependency context defines if this type for instance is
         /// discovered in an input context.
         /// </param>
         void RegisterDependency(
@@ -36,27 +35,27 @@ namespace HotChocolate.Configuration
             TypeDependencyKind kind);
 
         /// <summary>
-        /// Register a reference to a type on which <see cref="Type" /> depends. 
-        /// Such a reference could for instance represent a type of a field that 
+        /// Register a reference to a type on which <see cref="Type" /> depends.
+        /// Such a reference could for instance represent a type of a field that
         /// <see cref="Type" /> exposes.
         /// </summary>
         /// <param name="dependency">
-        /// A type dependency containing the type reference and context representing 
+        /// A type dependency containing the type reference and context representing
         /// a type on which <see cref="Type" /> depends.
         /// </param>
         void RegisterDependency(
             TypeDependency dependency);
 
         /// <summary>
-        /// Register multiple references to types on which <see cref="Type" /> depends. 
-        /// Such a reference could for instance represent a type of a field that 
+        /// Register multiple references to types on which <see cref="Type" /> depends.
+        /// Such a reference could for instance represent a type of a field that
         /// <see cref="Type" /> exposes.
         /// </summary>
         /// <param name="references">
         /// Type references representing types on which <see cref="Type" /> depends.
         /// </param>
         /// <param name="kind">
-        /// The type dependency context defines if this type for instance is 
+        /// The type dependency context defines if this type for instance is
         /// discovered in an input context.
         /// </param>
         void RegisterDependencyRange(
@@ -65,11 +64,11 @@ namespace HotChocolate.Configuration
 
         /// <summary>
         /// Register multiple references to types on which <see cref="Type" /> depends.
-        /// Such a reference could for instance represent a type of a field that 
+        /// Such a reference could for instance represent a type of a field that
         /// <see cref="Type" /> exposes.
         /// </summary>
         /// <param name="dependencies">
-        /// Type dependencies containing the type reference and context representing 
+        /// Type dependencies containing the type reference and context representing
         /// a types on which <see cref="Type" /> depends.
         /// </param>
         void RegisterDependencyRange(
@@ -92,31 +91,5 @@ namespace HotChocolate.Configuration
         /// </param>
         void RegisterDependencyRange(
             IEnumerable<IDirectiveReference> references);
-
-        /// <summary>
-        /// Registers a resolver for compilation.
-        /// </summary>
-        /// <param name="fieldName">The field name to which the resolver belongs to.</param>
-        /// <param name="member">The member that represents the resolver.</param>
-        /// <param name="sourceType">The source type.</param>
-        /// <param name="resolverType">The type that declares the resolver.</param>
-        void RegisterResolver(
-            NameString fieldName,
-            MemberInfo member,
-            Type sourceType,
-            Type resolverType);
-
-        /// <summary>
-        /// Registers a resolver for compilation.
-        /// </summary>
-        /// <param name="fieldName">The field name to which the resolver belongs to.</param>
-        /// <param name="expression">The expression representing the resolver.</param>
-        /// <param name="sourceType">The source type.</param>
-        /// <param name="resolverType">The type that declares the resolver.</param>
-        void RegisterResolver(
-            NameString fieldName,
-            Expression expression,
-            Type sourceType,
-            Type resolverType);
     }
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/RegisteredResolver.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/RegisteredResolver.cs
@@ -1,28 +1,20 @@
 using System;
 using HotChocolate.Resolvers;
 
+#nullable enable
+
 namespace HotChocolate.Configuration
 {
     internal sealed class RegisteredResolver
     {
         public RegisteredResolver(
-            Type sourceType,
-            IFieldReference field)
-            : this(sourceType, sourceType, field)
-        {
-        }
-
-        public RegisteredResolver(
-            Type resolverType,
+            Type? resolverType,
             Type sourceType,
             IFieldReference field)
         {
-            ResolverType = resolverType
-                ?? throw new ArgumentNullException(nameof(resolverType));
-            SourceType = sourceType
-                ?? throw new ArgumentNullException(nameof(sourceType));
-            Field = field
-                ?? throw new ArgumentNullException(nameof(field));
+            ResolverType = resolverType ?? sourceType;
+            SourceType = sourceType ?? throw new ArgumentNullException(nameof(sourceType));
+            Field = field ?? throw new ArgumentNullException(nameof(field));
         }
 
         public Type ResolverType { get; }

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeBindingInfo.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeBindingInfo.cs
@@ -8,16 +8,14 @@ using HotChocolate.Resolvers;
 
 namespace HotChocolate.Configuration
 {
-    internal sealed class TypeBindingInfo
-        : ITypeBindingInfo
+    internal sealed class TypeBindingInfo : ITypeBindingInfo
     {
         private readonly IDescriptorContext _context;
         private readonly Dictionary<NameString, RegisteredResolver> _resolvers;
         private readonly Dictionary<NameString, MemberInfo> _members;
         private readonly BindingBehavior _bindingBehavior;
-        private readonly HashSet<NameString> _fieldNames =
-            new HashSet<NameString>();
-        private List<MemberInfo> _allMembers;        
+        private readonly HashSet<NameString> _fieldNames = new();
+        private List<MemberInfo> _allMembers;
 
         public TypeBindingInfo(
             IDescriptorContext context,
@@ -39,15 +37,12 @@ namespace HotChocolate.Configuration
 
             name.EnsureNotEmpty(nameof(name));
 
-            _context = context
-                ?? throw new ArgumentNullException(nameof(context));
+            _context = context ?? throw new ArgumentNullException(nameof(context));
             Name = name;
             SourceType = sourceType;
             _bindingBehavior = bindingBehavior;
-            _resolvers = new Dictionary<NameString, RegisteredResolver>(
-                resolvers);
-            _members = new Dictionary<NameString, MemberInfo>(
-                members);
+            _resolvers = new Dictionary<NameString, RegisteredResolver>(resolvers);
+            _members = new Dictionary<NameString, MemberInfo>(members);
         }
 
         public NameString Name { get; }
@@ -140,6 +135,7 @@ namespace HotChocolate.Configuration
                 _resolvers.Add(
                     fieldName,
                     new RegisteredResolver(
+                        SourceType,
                         SourceType,
                         new FieldMember(Name, fieldName, member)));
             }

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeCompletionContext.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeCompletionContext.cs
@@ -11,7 +11,7 @@ namespace HotChocolate.Configuration
 {
     internal sealed class TypeCompletionContext : ITypeCompletionContext
     {
-        private readonly HashSet<NameString> _alternateNames = new HashSet<NameString>();
+        private readonly HashSet<NameString> _alternateNames = new();
         private readonly TypeDiscoveryContext _initializationContext;
         private readonly TypeReferenceResolver _typeReferenceResolver;
         private readonly IDictionary<FieldReference, RegisteredResolver> _resolvers;

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeDiscoveryContext.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeDiscoveryContext.cs
@@ -1,24 +1,18 @@
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Reflection;
 using HotChocolate.Internal;
-using HotChocolate.Resolvers;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
 using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Configuration
 {
-    internal sealed class TypeDiscoveryContext
-        : ITypeDiscoveryContext
+    internal sealed class TypeDiscoveryContext : ITypeDiscoveryContext
     {
         private readonly TypeRegistry _typeRegistry;
         private readonly TypeLookup _typeLookup;
-        private readonly List<TypeDependency> _typeDependencies =
-            new List<TypeDependency>();
-        private readonly List<IDirectiveReference> _directiveReferences =
-            new List<IDirectiveReference>();
+        private readonly List<TypeDependency> _typeDependencies = new();
+        private readonly List<IDirectiveReference> _directiveReferences = new();
 
         public TypeDiscoveryContext(
             ITypeSystemObject type,
@@ -71,9 +65,6 @@ namespace HotChocolate.Configuration
         public IReadOnlyList<TypeDependency> TypeDependencies => _typeDependencies;
 
         public ICollection<IDirectiveReference> DirectiveReferences => _directiveReferences;
-
-        public IDictionary<FieldReference, RegisteredResolver> Resolvers { get; } =
-            new Dictionary<FieldReference, RegisteredResolver>();
 
         public ICollection<ISchemaError> Errors { get; } =
             new List<ISchemaError>();
@@ -148,56 +139,6 @@ namespace HotChocolate.Configuration
             }
 
             _directiveReferences.AddRange(references);
-        }
-
-        public void RegisterResolver(
-            NameString fieldName,
-            MemberInfo member,
-            Type sourceType,
-            Type resolverType)
-        {
-            if (member is null)
-            {
-                throw new ArgumentNullException(nameof(member));
-            }
-
-            if (sourceType is null)
-            {
-                throw new ArgumentNullException(nameof(sourceType));
-            }
-
-            fieldName.EnsureNotEmpty(nameof(fieldName));
-
-            var fieldMember = new FieldMember(InternalName, fieldName, member);
-
-            Resolvers[fieldMember.ToFieldReference()] = resolverType is null
-                ? new RegisteredResolver(sourceType, fieldMember)
-                : new RegisteredResolver(resolverType, sourceType, fieldMember);
-        }
-
-        public void RegisterResolver(
-            NameString fieldName,
-            Expression expression,
-            Type sourceType,
-            Type resolverType)
-        {
-            if (expression == null)
-            {
-                throw new ArgumentNullException(nameof(expression));
-            }
-
-            if (sourceType == null)
-            {
-                throw new ArgumentNullException(nameof(sourceType));
-            }
-
-            fieldName.EnsureNotEmpty(nameof(fieldName));
-
-            var fieldMember = new FieldMember(InternalName, fieldName, expression);
-
-            Resolvers[fieldMember.ToFieldReference()] = resolverType == null
-                ? new RegisteredResolver(sourceType, fieldMember)
-                : new RegisteredResolver(resolverType, sourceType, fieldMember);
         }
 
         public void ReportError(ISchemaError error)

--- a/src/HotChocolate/Core/src/Types/Internal/TypeDependencyHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/TypeDependencyHelper.cs
@@ -30,37 +30,6 @@ namespace HotChocolate.Internal
             RegisterAdditionalDependencies(context, definition);
             RegisterDirectiveDependencies(context, definition);
             RegisterFieldDependencies(context, definition.Fields);
-
-            foreach (ObjectFieldDefinition field in definition.Fields)
-            {
-                if (field.Resolver is null)
-                {
-                    if (field.Expression is not null)
-                    {
-                        context.RegisterResolver(
-                            field.Name,
-                            field.Expression,
-                            definition.RuntimeType,
-                            field.ResolverType);
-                    }
-                    else if (field.ResolverMember is not null)
-                    {
-                        context.RegisterResolver(
-                            field.Name,
-                            field.ResolverMember,
-                            definition.RuntimeType,
-                            field.ResolverType);
-                    }
-                    else if (field.Member is not null)
-                    {
-                        context.RegisterResolver(
-                            field.Name,
-                            field.Member,
-                            definition.RuntimeType,
-                            field.ResolverType);
-                    }
-                }
-            }
         }
 
         public static void RegisterDependencies(

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
@@ -1190,5 +1190,11 @@ namespace HotChocolate.Properties {
                 return ResourceManager.GetString("ExtendedTypeReferenceHandler_NonGenericExecutableNotAllowed", resourceCulture);
             }
         }
+        
+        internal static string BindingCompiler_AddBinding_BindingCannotBeHandled {
+            get {
+                return ResourceManager.GetString("BindingCompiler_AddBinding_BindingCannotBeHandled", resourceCulture);
+            }
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
@@ -696,4 +696,7 @@ Type: `{0}`</value>
   <data name="ExtendedTypeReferenceHandler_NonGenericExecutableNotAllowed" xml:space="preserve">
     <value>The non-generic IExecutable interface cannot be used as a type in the schema.</value>
   </data>
+  <data name="BindingCompiler_AddBinding_BindingCannotBeHandled" xml:space="preserve">
+    <value>The specified binding cannot be handled.</value>
+  </data>
 </root>

--- a/src/HotChocolate/Core/src/Types/Resolvers/FieldReference.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/FieldReference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace HotChocolate.Resolvers
@@ -32,19 +33,16 @@ namespace HotChocolate.Resolvers
             return new FieldReference(TypeName, fieldName);
         }
 
-        public FieldMember WithMember(MemberInfo member)
-        {
-            return new FieldMember(TypeName, FieldName, member);
-        }
+        public FieldMember WithMember(MemberInfo member) =>
+            new(TypeName, FieldName, member);
 
-        public FieldResolver WithResolver(FieldResolverDelegate resolver)
-        {
-            return new FieldResolver(TypeName, FieldName, resolver);
-        }
+        public FieldMember WithExpression(Expression expression) =>
+            new(TypeName, FieldName, expression);
 
-        public bool Equals(FieldReference other)
-        {
-            return IsEqualTo(other);
-        }
+        public FieldResolver WithResolver(FieldResolverDelegate resolver) =>
+            new(TypeName, FieldName, resolver);
+
+        public bool Equals(FieldReference other) =>
+            IsEqualTo(other);
     }
 }

--- a/src/HotChocolate/Core/src/Types/SchemaBuilder.Setup.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaBuilder.Setup.cs
@@ -213,7 +213,7 @@ namespace HotChocolate
                 foreach (FieldReference reference in builder._resolvers.Keys)
                 {
                     initializer.Resolvers[reference] = new RegisteredResolver(
-                        typeof(object), builder._resolvers[reference]);
+                        typeof(object), typeof(object), builder._resolvers[reference]);
                 }
 
                 foreach (RegisteredResolver resolver in

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/ObjectTypeDefinition.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/ObjectTypeDefinition.cs
@@ -123,17 +123,20 @@ namespace HotChocolate.Types.Descriptors.Definitions
 
             if (_knownClrTypes is { Count: > 0 })
             {
-                target._knownClrTypes = new List<Type>(_knownClrTypes);
+                target._knownClrTypes ??= new List<Type>();
+                target._knownClrTypes.AddRange(_knownClrTypes);
             }
 
             if (_interfaces is { Count: > 0 })
             {
-                target._interfaces = new List<ITypeReference>(_interfaces);
+                target._interfaces ??= new List<ITypeReference>();
+                target._interfaces.AddRange(_interfaces);
             }
 
             if (_fieldIgnores is { Count: > 0 })
             {
-                target._fieldIgnores = new List<ObjectFieldBinding>(_fieldIgnores);
+                target._fieldIgnores ??= new List<ObjectFieldBinding>();
+                target._fieldIgnores.AddRange(_fieldIgnores);
             }
 
             foreach (var field in Fields)
@@ -180,6 +183,13 @@ namespace HotChocolate.Types.Descriptors.Definitions
                     var newField = new ObjectFieldDefinition();
                     field.CopyTo(newField);
                     newField.SourceType = target.RuntimeType;
+
+                    if (newField.Member is not null && newField.ResolverMember is null)
+                    {
+                        newField.ResolverMember = newField.Member;
+                        newField.Member = targetField?.Member;
+                    }
+
                     target.Fields.Add(newField);
                 }
                 else

--- a/src/HotChocolate/Core/src/Types/Types/ObjectField.cs
+++ b/src/HotChocolate/Core/src/Types/Types/ObjectField.cs
@@ -27,7 +27,7 @@ namespace HotChocolate.Types
             bool sortArgumentsByName = false)
             : base(definition, fieldCoordinate, sortArgumentsByName)
         {
-            Member = definition.Member ?? definition.ResolverMember;
+            Member = definition.Member;
             Middleware = _empty;
             Resolver = definition.Resolver!;
             Expression = definition.Expression;
@@ -63,8 +63,9 @@ namespace HotChocolate.Types
         public IReadOnlyList<IDirective> ExecutableDirectives => _executableDirectives;
 
         /// <summary>
-        /// Gets the associated .net type member of this field.
-        /// This member can be <c>null</c>.
+        /// Gets the associated member of the runtime type for this field.
+        /// This property can be <c>null</c> if this field is not associated to
+        /// a concrete member on the runtime type.
         /// </summary>
         public MemberInfo? Member { get; }
 

--- a/src/HotChocolate/Core/src/Types/Types/ObjectTypeExtension.cs
+++ b/src/HotChocolate/Core/src/Types/Types/ObjectTypeExtension.cs
@@ -16,7 +16,8 @@ namespace HotChocolate.Types
     /// Any type extension instance is will not survive the initialization and instead is
     /// merged into the target type.
     /// </summary>
-    public class ObjectTypeExtension : NamedTypeExtensionBase<ObjectTypeDefinition>
+    public class ObjectTypeExtension
+        : NamedTypeExtensionBase<ObjectTypeDefinition>
     {
         private Action<IObjectTypeDescriptor>? _configure;
 

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Attributes/NodeAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Attributes/NodeAttribute.cs
@@ -112,11 +112,15 @@ namespace HotChocolate.Types.Relay
                         throw NodeAttribute_NodeResolverNotFound(type, NodeResolver);
                     }
 
-                    ObjectFieldDefinition? fieldDefinition =
-                        definition.Fields.FirstOrDefault(t => t.Member == method);
-                    if (fieldDefinition is not null)
+                    if (definition.Fields.Any(
+                        t => t.Member == method || t.ResolverMember == method))
                     {
-                        definition.Fields.Remove(fieldDefinition);
+                        foreach (var fieldDefinition in definition.Fields
+                            .Where(t => t.Member == method || t.ResolverMember == method)
+                            .ToArray())
+                        {
+                            definition.Fields.Remove(fieldDefinition);
+                        }
                     }
 
                     nodeDescriptor.ResolveNodeWith(method);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
@@ -560,6 +560,34 @@ namespace HotChocolate.Types
             schema.Print().MatchSnapshot();
         }
 
+        [Fact]
+        public async Task Replace_Field_With_The_Same_Name()
+        {
+            Snapshot.FullName();
+
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType()
+                .AddTypeExtension<Replace_Field_PersonDto_2_Query>()
+                .AddTypeExtension<Replace_Field_PersonResolvers_2>()
+                .BuildSchemaAsync()
+                .MatchSnapshotAsync();
+        }
+
+        [Fact]
+        public async Task Replace_Field_With_The_Same_Name_Execute()
+        {
+            Snapshot.FullName();
+
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType()
+                .AddTypeExtension<Replace_Field_PersonDto_2_Query>()
+                .AddTypeExtension<Replace_Field_PersonResolvers_2>()
+                .ExecuteRequestAsync("{ person { someId(arg: \"efg\") } }")
+                .MatchSnapshotAsync();
+        }
+
         public class FooType
             : ObjectType<Foo>
         {
@@ -790,6 +818,30 @@ namespace HotChocolate.Types
         {
             [BindMember(nameof(Replace_Field_PersonDto.InternalId))]
             public string SomeId { get; } = "abc";
+        }
+
+        public interface IPersonDto
+        {
+            string SomeId();
+        }
+
+        [ExtendObjectType("Query")]
+        public class Replace_Field_PersonDto_2_Query
+        {
+            public Replace_Field_PersonDto_2 GetPerson() => new();
+        }
+
+        public class Replace_Field_PersonDto_2 : IPersonDto
+        {
+            public string SomeId() => "1";
+        }
+
+        [ExtendObjectType(typeof(IPersonDto))]
+        public class Replace_Field_PersonResolvers_2
+        {
+            [BindMember(nameof(Replace_Field_PersonDto_2.SomeId))]
+            public string SomeId([Parent] IPersonDto dto, string arg = "abc") =>
+                dto.SomeId() + arg;
         }
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.Replace_Field_With_The_Same_Name.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.Replace_Field_With_The_Same_Name.snap
@@ -1,0 +1,17 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  person: Replace_Field_PersonDto_2
+}
+
+type Replace_Field_PersonDto_2 {
+  someId(arg: String = "abc"): String
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! "Streamed when true." if: Boolean!) on FIELD

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.Replace_Field_With_The_Same_Name_Execute.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.Replace_Field_With_The_Same_Name_Execute.snap
@@ -1,0 +1,7 @@
+﻿{
+  "data": {
+    "person": {
+      "someId": "1efg"
+    }
+  }
+}


### PR DESCRIPTION
The type initialization was registering resolvers early, after the type discovery. With type extensions it is better to move this to the point where we already merged the type extensions with the types. This also helps avoiding collisions. 

We need to do a bigger refactoring on type extensions to accommodate for more cases but we will do that with the V12 iteration in order to not break to much behavior.