### PR TITLE
Update Pull Request template to use a GitHub supported keyword

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,4 @@ Summary of the changes (Less than 80 chars)
 - Detail 1
 - Detail 2
 
-Addresses #bugnumber (in this specific format)
+Closes #bugnumber (in this specific format)


### PR DESCRIPTION
Uses 'Closes' instead of 'Addresses' in the PR template, so issues are automatically linked to the PR.

Closes #3476 (in this specific format)
