### PR TITLE
Expose ResolverMember on IObjectField

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IEnumType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IEnumType.cs
@@ -6,12 +6,35 @@ using HotChocolate.Language;
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// Represents a GraphQL enum type
+    /// </summary>
     public interface IEnumType : ILeafType
     {
+        /// <summary>
+        /// The associated syntax node from the GraphQL SDL.
+        /// </summary>
         new EnumTypeDefinitionNode? SyntaxNode { get; }
 
+        /// <summary>
+        /// Gets the possible enum values.
+        /// </summary>
         IReadOnlyCollection<IEnumValue> Values { get; }
 
+        /// <summary>
+        /// Tries to get the <paramref name="runtimeValue"/> for
+        /// the specified <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The GraphQL enum value name.
+        /// </param>
+        /// <param name="runtimeValue">
+        /// The .NET runtime value.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the <paramref name="name"/> represents a value of this enum type;
+        /// otherwise, <c>false</c>.
+        /// </returns>
         bool TryGetRuntimeValue(
             NameString name,
             [NotNullWhen(true)]out object? runtimeValue);

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IEnumType~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IEnumType~1.cs
@@ -4,8 +4,25 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// Represents a GraphQL enum type
+    /// </summary>
     public interface IEnumType<T> : IEnumType
     {
+        /// <summary>
+        /// Tries to get the <paramref name="runtimeValue"/> for
+        /// the specified <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The GraphQL enum value name.
+        /// </param>
+        /// <param name="runtimeValue">
+        /// The .NET runtime value.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the <paramref name="name"/> represents a value of this enum type;
+        /// otherwise, <c>false</c>.
+        /// </returns>
         bool TryGetRuntimeValue(
             NameString name,
             [NotNullWhen(true)]out T runtimeValue);

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IEnumValue.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IEnumValue.cs
@@ -4,10 +4,16 @@ using HotChocolate.Language;
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// Represents a GraphQL enum value.
+    /// </summary>
     public interface IEnumValue
         : IHasDirectives
         , IHasReadOnlyContextData
     {
+        /// <summary>
+        /// The associated syntax node from the GraphQL SDL.
+        /// </summary>
         EnumValueDefinitionNode? SyntaxNode { get; }
 
         /// <summary>
@@ -15,10 +21,19 @@ namespace HotChocolate.Types
         /// </summary>
         NameString Name { get; }
 
+        /// <summary>
+        /// Gets the GraphQL description for this enum value.
+        /// </summary>
         string? Description { get; }
 
+        /// <summary>
+        /// Defines if this enum value is deprecated.
+        /// </summary>
         bool IsDeprecated { get; }
 
+        /// <summary>
+        /// Gets the deprecation reason for this enum value.
+        /// </summary>
         string? DeprecationReason { get; }
 
         /// <summary>

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IHasDescription.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IHasDescription.cs
@@ -2,6 +2,9 @@
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// GraphQL type system members that have a description.
+    /// </summary>
     public interface IHasDescription
     {
         /// <summary>

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IHasDirectives.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IHasDirectives.cs
@@ -2,8 +2,14 @@
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// GraphQL type system members that have directives.
+    /// </summary>
     public interface IHasDirectives
     {
+        /// <summary>
+        /// Gets the directives of this type system member.
+        /// </summary>
         public IDirectiveCollection Directives { get; }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IHasName.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IHasName.cs
@@ -1,7 +1,13 @@
 ﻿namespace HotChocolate.Types
 {
+    /// <summary>
+    /// GraphQL type system members that have a name.
+    /// </summary>
     public interface IHasName
     {
+        /// <summary>
+        /// Gets the GraphQL type system member name.
+        /// </summary>
         NameString Name { get; }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IHasScope.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IHasScope.cs
@@ -2,6 +2,9 @@
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// GraphQL type system members that can be scoped.
+    /// </summary>
     public interface IHasScope
     {
         /// <summary>

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IHasTypeIdentity.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IHasTypeIdentity.cs
@@ -4,8 +4,14 @@ using System;
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// GraphQL type system members that have a type identity.
+    /// </summary>
     public interface IHasTypeIdentity
     {
+        /// <summary>
+        /// Gets the type identity of this type system member.
+        /// </summary>
         Type? TypeIdentity { get; }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/ILeafType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/ILeafType.cs
@@ -1,5 +1,8 @@
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// Represents a GraphQL leaf-type e.g. scalar or enum.
+    /// </summary>
     public interface ILeafType
         : INamedOutputType
         , INamedInputType

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/INamedInputType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/INamedInputType.cs
@@ -2,6 +2,9 @@
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// Represents a GraphQL input type which has a name.
+    /// </summary>
     public interface INamedInputType
         : INamedType
         , IInputType

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/INamedOutputType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/INamedOutputType.cs
@@ -1,5 +1,8 @@
 ﻿namespace HotChocolate.Types
 {
+    /// <summary>
+    /// Represents a GraphQL output type which has a name.
+    /// </summary>
     public interface INamedOutputType
         : INamedType
         , IOutputType

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/INamedType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/INamedType.cs
@@ -1,5 +1,8 @@
 ﻿namespace HotChocolate.Types
 {
+    /// <summary>
+    /// Represents a named GraphQL type.
+    /// </summary>
     public interface INamedType
         : INullableType
         , IHasName
@@ -7,6 +10,10 @@
         , IHasSyntaxNode
         , IHasReadOnlyContextData
     {
+        /// <summary>
+        /// Determines whether an instance of a specified type <paramref name="type" />
+        /// can be assigned to a variable of the current type.
+        /// </summary>
         bool IsAssignableFrom(INamedType type);
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IObjectField.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IObjectField.cs
@@ -9,8 +9,7 @@ namespace HotChocolate.Types
     /// <summary>
     /// Represents a field of an <see cref="IObjectType"/>.
     /// </summary>
-    public interface IObjectField
-        : IOutputField
+    public interface IObjectField : IOutputField
     {
         /// <summary>
         /// Gets the type that declares this field.
@@ -38,8 +37,9 @@ namespace HotChocolate.Types
         IReadOnlyList<IDirective> ExecutableDirectives { get; }
 
         /// <summary>
-        /// Gets the associated .net type member of this field.
-        /// This member can be <c>null</c>.
+        /// Gets the associated member of the runtime type for this field.
+        /// This property can be <c>null</c> if this field is not associated to
+        /// a concrete member on the runtime type.
         /// </summary>
         MemberInfo? Member { get; }
 

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IObjectField.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IObjectField.cs
@@ -42,5 +42,12 @@ namespace HotChocolate.Types
         /// This member can be <c>null</c>.
         /// </summary>
         MemberInfo? Member { get; }
+
+        /// <summary>
+        /// Gets the resolver member of this filed.
+        /// If this field has no explicit resolver member
+        /// this property will return <see cref="Member"/>.
+        /// </summary>
+        MemberInfo? ResolverMember { get; }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IObjectType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IObjectType.cs
@@ -1,3 +1,7 @@
+using HotChocolate.Language;
+
+#nullable enable
+
 namespace HotChocolate.Types
 {
     /// <summary>
@@ -5,6 +9,11 @@ namespace HotChocolate.Types
     /// </summary>
     public interface IObjectType : IComplexOutputType
     {
+        /// <summary>
+        /// The associated syntax node from the GraphQL SDL.
+        /// </summary>
+        new ObjectTypeDefinitionNode? SyntaxNode { get; }
+
         /// <summary>
         /// Gets the field that the type exposes.
         /// </summary>

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IUnionType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IUnionType.cs
@@ -6,6 +6,9 @@ using HotChocolate.Resolvers;
 
 namespace HotChocolate.Types
 {
+    /// <summary>
+    /// Represents a GraphQL union type.
+    /// </summary>
     public interface IUnionType : INamedOutputType
     {
         /// <summary>
@@ -19,7 +22,7 @@ namespace HotChocolate.Types
         IReadOnlyCollection<IObjectType> Types { get; }
 
         /// <summary>
-        /// Resolves the concrete type for the value of a type 
+        /// Resolves the concrete type for the value of a type
         /// that implements this interface.
         /// </summary>
         /// <param name="context">
@@ -29,7 +32,7 @@ namespace HotChocolate.Types
         /// The value for which the type shall be resolved.
         /// </param>
         /// <returns>
-        /// Returns <c>null</c> if the value is not of a type 
+        /// Returns <c>null</c> if the value is not of a type
         /// implementing this interface.
         /// </returns>
         IObjectType? ResolveConcreteType(
@@ -37,27 +40,27 @@ namespace HotChocolate.Types
             object resolverResult);
 
         /// <summary>
-        /// Checks if the type set of this union type contains the 
+        /// Checks if the type set of this union type contains the
         /// specified <paramref name="objectType"/>.
         /// </summary>
         /// <param name="objectType">
         /// The object type.
         /// </param>
         /// <returns>
-        /// Returns <c>true</c>, if the type set of this union type contains the 
+        /// Returns <c>true</c>, if the type set of this union type contains the
         /// specified <paramref name="objectType"/>; otherwise, <c>false</c> is returned.
         /// </returns>
         bool ContainsType(IObjectType objectType);
 
         /// <summary>
-        /// Checks if the type set of this union type contains the 
+        /// Checks if the type set of this union type contains the
         /// specified <paramref name="typeName"/>.
         /// </summary>
         /// <param name="objectType">
         /// The object type.
         /// </param>
         /// <returns>
-        /// Returns <c>true</c>, if the type set of this union type contains the 
+        /// Returns <c>true</c>, if the type set of this union type contains the
         /// specified <paramref name="typeName"/>; otherwise, <c>false</c> is returned.
         /// </returns>
         bool ContainsType(NameString typeName);

--- a/src/HotChocolate/Core/src/Types/Types/ObjectField.cs
+++ b/src/HotChocolate/Core/src/Types/Types/ObjectField.cs
@@ -28,9 +28,10 @@ namespace HotChocolate.Types
             : base(definition, fieldCoordinate, sortArgumentsByName)
         {
             Member = definition.Member;
+            ResolverMember = definition.ResolverMember ?? definition.Member;
             Middleware = _empty;
             Resolver = definition.Resolver!;
-            Expression = definition.Expression;
+            ResolverExpression = definition.Expression;
             SubscribeResolver = definition.SubscribeResolver;
             IsIntrospectionField = definition.IsIntrospectionField;
         }
@@ -70,10 +71,24 @@ namespace HotChocolate.Types
         public MemberInfo? Member { get; }
 
         /// <summary>
+        /// Gets the resolver member of this filed.
+        /// If this field has no explicit resolver member
+        /// this property will return <see cref="Member"/>.
+        /// </summary>
+        public MemberInfo? ResolverMember { get; }
+
+        /// <summary>
         /// Gets the associated resolver expression.
         /// This expression can be <c>null</c>.
         /// </summary>
-        public Expression? Expression { get; }
+        [Obsolete("Use resolver expression.")]
+        public Expression? Expression => ResolverExpression;
+
+        /// <summary>
+        /// Gets the associated resolver expression.
+        /// This expression can be <c>null</c>.
+        /// </summary>
+        public Expression? ResolverExpression { get; }
 
         /// <summary>
         /// Defines if this field as a introspection field.

--- a/src/HotChocolate/Core/test/Types.Tests/NamingConventionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/NamingConventionTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
+using HotChocolate.Execution;
+using HotChocolate.Tests;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
+using Microsoft.Extensions.DependencyInjection;
 using Snapshooter.Xunit;
 using Xunit;
 
@@ -19,6 +23,18 @@ namespace HotChocolate
                 .Create()
                 .Print()
                 .MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task PureCodeFirst_NamingConvention_RenameArgument_RequestBuilder()
+        {
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<QueryNamingConvention>()
+                .AddMutationType<MutationNamingConvention>()
+                .AddConvention<INamingConventions, CustomNamingConvention>()
+                .BuildSchemaAsync()
+                .MatchSnapshotAsync();
         }
 
         public class CustomNamingConvention : DefaultNamingConventions

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultTypeInspectorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultTypeInspectorTests.cs
@@ -194,7 +194,7 @@ namespace HotChocolate.Types.Descriptors
             // assert
             Assert.Equal("List<String!>!", typeReference.Type.ToString());
             Assert.Equal(TypeContext.Output, typeReference.Context);
-            Assert.Equal(typeReference.Scope, "abc");
+            Assert.Equal("abc", typeReference.Scope);
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace HotChocolate.Types.Descriptors
             // assert
             Assert.Equal("String!", typeReference.Type.ToString());
             Assert.Equal(TypeContext.Input, typeReference.Context);
-            Assert.Equal(typeReference.Scope, "abc");
+            Assert.Equal("abc", typeReference.Scope);
         }
 
         [Fact]
@@ -341,7 +341,7 @@ namespace HotChocolate.Types.Descriptors
             // assert
             Assert.Equal("Foo", typeReference.Type.ToString());
             Assert.Equal(TypeContext.Output, typeReference.Context);
-            Assert.Equal(typeReference.Scope, "abc");
+            Assert.Equal("abc", typeReference.Scope);
         }
 
         [Fact]

--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
@@ -602,6 +602,35 @@ namespace HotChocolate.Types
                 .MatchSnapshotAsync();
         }
 
+        [Fact]
+        public async Task Ensure_Member_And_ResolverMember_Are_Correctly_Set_When_Extending()
+        {
+            ISchema schema =
+                await new ServiceCollection()
+                    .AddGraphQL()
+                    .AddQueryType<ObjectField_Test_Query>()
+                    .AddTypeExtension<ObjectField_Test_Query_Extension>()
+                    .BuildSchemaAsync();
+
+            IObjectField field = schema.QueryType.Fields["foo1"];
+            Assert.Equal("GetFoo", field.Member?.Name);
+            Assert.Equal("GetFoo1", field.ResolverMember?.Name);
+        }
+
+        [Fact]
+        public async Task Ensure_Member_And_ResolverMember_Are_The_Same_When_Not_Extending()
+        {
+            ISchema schema =
+                await new ServiceCollection()
+                    .AddGraphQL()
+                    .AddQueryType<ObjectField_Test_Query>()
+                    .BuildSchemaAsync();
+
+            IObjectField field = schema.QueryType.Fields["foo"];
+            Assert.Equal("GetFoo", field.Member?.Name);
+            Assert.Equal("GetFoo", field.ResolverMember?.Name);
+        }
+
         public class FooType
             : ObjectType<Foo>
         {
@@ -868,6 +897,18 @@ namespace HotChocolate.Types
         public class ExtensionB
         {
             public string Foo() => "def";
+        }
+
+        public class ObjectField_Test_Query
+        {
+            public string GetFoo() => null;
+        }
+
+        [ExtendObjectType(typeof(ObjectField_Test_Query))]
+        public class ObjectField_Test_Query_Extension
+        {
+            [BindMember(nameof(ObjectField_Test_Query.GetFoo))]
+            public string GetFoo1() => null;
         }
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/NamingConventionTests.PureCodeFirst_NamingConvention_RenameArgument_RequestBuilder.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/NamingConventionTests.PureCodeFirst_NamingConvention_RenameArgument_RequestBuilder.snap
@@ -1,0 +1,34 @@
+﻿schema {
+  query: QueryNamingConvention_Named
+  mutation: MutationNamingConvention_Named
+}
+
+"GetTypeDescription"
+type MutationNamingConvention_Named {
+  "GetMemberDescription"
+  mutationField_Named("GetArgumentDescription" mutationArgument_Named: Int! "GetArgumentDescription" complexArgumentMutation_Named: InputObjectNamingConventionInput_Named): ObjectNamingConvention_Named
+}
+
+"GetTypeDescription"
+type ObjectNamingConvention_Named {
+  "GetMemberDescription"
+  outputField_Named: String
+}
+
+"GetTypeDescription"
+type QueryNamingConvention_Named {
+  "GetMemberDescription"
+  queryField_Named("GetArgumentDescription" queryArgument_Named: Int! "GetArgumentDescription" complexArgument_Named: InputObjectNamingConventionInput_Named): ObjectNamingConvention_Named
+}
+
+"GetTypeDescription"
+input InputObjectNamingConventionInput_Named {
+  "GetMemberDescription"
+  inputField_Named: String
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! "Streamed when true." if: Boolean!) on FIELD

--- a/src/HotChocolate/Language/src/Language/Legacy/Visitors/ListExtensions.cs
+++ b/src/HotChocolate/Language/src/Language/Legacy/Visitors/ListExtensions.cs
@@ -48,13 +48,14 @@ namespace HotChocolate.Language
             return false;
         }
 
-        public static T PeekOrDefault<T>(this IList<T> list, T defaultValue = default)
+        public static T PeekOrDefault<T>(this IList<T> list, T defaultValue = default!)
         {
             if (list.Count > 0)
             {
                 var lastIndex = list.Count - 1;
                 return list[lastIndex];
             }
+
             return defaultValue;
         }
 

--- a/src/HotChocolate/Language/src/Language/Legacy/Visitors/SyntaxNodeInfo.cs
+++ b/src/HotChocolate/Language/src/Language/Legacy/Visitors/SyntaxNodeInfo.cs
@@ -4,14 +4,14 @@ namespace HotChocolate.Language
 {
     public readonly struct SyntaxNodeInfo
     {
-        public SyntaxNodeInfo(ISyntaxNode node, string name)
+        public SyntaxNodeInfo(ISyntaxNode node, string? name)
         {
             Node = node ?? throw new ArgumentNullException(nameof(node));
             Name = name;
             Index = null;
         }
 
-        public SyntaxNodeInfo(ISyntaxNode node, string name, int? index)
+        public SyntaxNodeInfo(ISyntaxNode node, string? name, int? index)
         {
             Node = node ?? throw new ArgumentNullException(nameof(node));
             Name = name;
@@ -20,7 +20,7 @@ namespace HotChocolate.Language
 
         public ISyntaxNode Node { get; }
 
-        public string Name { get; }
+        public string? Name { get; }
 
         public int? Index { get; }
     }

--- a/src/HotChocolate/Language/src/Language/Legacy/Visitors/VisitorExtensions.cs
+++ b/src/HotChocolate/Language/src/Language/Legacy/Visitors/VisitorExtensions.cs
@@ -5,15 +5,14 @@ namespace HotChocolate.Language
 {
     public static partial class VisitorExtensions
     {
-        private static readonly VisitationMap _defaultVisitationMap =
-            new VisitationMap();
+        private static readonly VisitationMap _defaultVisitationMap = new();
 
         public static void Accept<T>(
             this ISyntaxNode node,
             VisitorFn<T> enter,
             VisitorFn<T> leave)
             where T : ISyntaxNode =>
-            Accept<T>(node, enter, leave, _defaultVisitationMap);
+            Accept(node, enter, leave, _defaultVisitationMap);
 
         public static void Accept<T>(
             this ISyntaxNode node,
@@ -73,7 +72,7 @@ namespace HotChocolate.Language
             this ISyntaxNode node,
             ISyntaxNodeVisitor visitor,
             IVisitationMap visitationMap,
-            Func<ISyntaxNode, VisitorAction> defaultAction)
+            Func<ISyntaxNode, VisitorAction>? defaultAction)
         {
             if (node is null)
             {
@@ -99,12 +98,12 @@ namespace HotChocolate.Language
             root.Push(new SyntaxNodeInfo(node, null));
             level.Push(root);
 
-            int index = 0;
+            var index = 0;
             SyntaxNodeInfo parent = default;
 
             while (level.Count != 0)
             {
-                bool isLeaving = level[index].Count == 0;
+                var isLeaving = level[index].Count == 0;
                 SyntaxNodeInfo current;
                 VisitorAction action;
 
@@ -180,7 +179,6 @@ namespace HotChocolate.Language
                     }
                     else if (action == VisitorAction.Skip)
                     {
-                        // TODO : replace with empty
                         level.Push(new List<SyntaxNodeInfo>());
                     }
 
@@ -215,7 +213,7 @@ namespace HotChocolate.Language
             IReadOnlyList<object> path,
             IReadOnlyList<ISyntaxNode> ancestors)
         {
-            if (_enterVisitors.TryGetValue(node.GetType(), out IntVisitorFn v))
+            if (_enterVisitors.TryGetValue(node.GetType(), out IntVisitorFn? v))
             {
                 return v.Invoke(visitor, node, parent, path, ancestors);
             }
@@ -229,7 +227,7 @@ namespace HotChocolate.Language
             IReadOnlyList<object> path,
             IReadOnlyList<ISyntaxNode> ancestors)
         {
-            if (_leaveVisitors.TryGetValue(node.GetType(), out IntVisitorFn v))
+            if (_leaveVisitors.TryGetValue(node.GetType(), out IntVisitorFn? v))
             {
                 return v.Invoke(visitor, node, parent, path, ancestors);
             }

--- a/src/StrawberryShake/Client/src/Core/OperationRequest.cs
+++ b/src/StrawberryShake/Client/src/Core/OperationRequest.cs
@@ -264,14 +264,15 @@ namespace StrawberryShake
 
         private int GetHashCodeFromList(IEnumerable enumerable)
         {
-            int hash = 17;
+            var hash = 17;
+
             foreach (var element in enumerable)
             {
                 if (element is IEnumerable inner)
                 {
                     hash ^= GetHashCodeFromList(inner) * 397;
                 }
-                else
+                else if(element is not null)
                 {
                     hash ^= element.GetHashCode() * 397;
                 }


### PR DESCRIPTION
We now have to members exposed on the `IObjectField`. 

- `Member`
   The actual member of the runtime type. This can be use for projections.
- `ResolverMember`
   The member of which the resolver is compiled. The `ResolverMember` is equals to the `Member` if no extension is applied.

`Member` is `null` if this field is not bound to any runtime type member or if the runtime type is `object`.
`ResolverMember` can be null if `Member` is null. But it also can be set when the `Member` property is null in the case that we have a member from which we compiled the resolver that still has non representation on the runtime type.