### PR TITLE
Align HotChocolate.Templates.Server with official templates

### DIFF
--- a/templates/Server/content/Program.cs
+++ b/templates/Server/content/Program.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace HotChocolate.Server.Template
 {

--- a/templates/Server/content/Startup.cs
+++ b/templates/Server/content/Startup.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using HotChocolate.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -13,14 +8,19 @@ namespace HotChocolate.Server.Template
 {
     public class Startup
     {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
         // This method gets called by the runtime. Use this method to add services to the container.
-        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
             // If you need dependency injection with your query object add your query type as a services.
             // services.AddSingleton<Query>();
             services
-                .AddRouting()
                 .AddGraphQLServer()
                 .AddQueryType<Query>();
         }
@@ -38,8 +38,8 @@ namespace HotChocolate.Server.Template
             app.UseEndpoints(endpoints =>
             {
                 // By default the GraphQL server is mapped to /graphql
-                // This route also provides you with our GraphQL IDE. In order to configure the
-                // the GraphQL IDE use endpoints.MapGraphQL().WithToolOptions(...).
+                // This route also provides you with our GraphQL IDE. 
+                // In order to configure the GraphQL IDE use endpoints.MapGraphQL().WithToolOptions(...).
                 endpoints.MapGraphQL();
             });
         }

--- a/templates/Server/content/appsettings.Development.json
+++ b/templates/Server/content/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/templates/Server/content/appsettings.json
+++ b/templates/Server/content/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
I just created a new GraphQL project with `HotChocolate.Templates.Server` and had to use `IConfiguration` in my Startup. But it was not there automatically as a property as I'm used to from the other ASP.NET Core templates, which was a little annoyance.

So I modified the template to align more closely to the official templates.