### PR TITLE
Fixed no scheme authorization in tooling

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/DefaultHttpClientFactory.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/DefaultHttpClientFactory.cs
@@ -20,10 +20,16 @@ namespace StrawberryShake.Tools
 
             if (token is not null)
             {
-                httpClient.DefaultRequestHeaders.Authorization =
-                    scheme is null
-                        ? new AuthenticationHeaderValue(token)
-                        : new AuthenticationHeaderValue(scheme, token);
+                if (string.IsNullOrWhiteSpace(scheme))
+                {
+                    httpClient.DefaultRequestHeaders
+                        .TryAddWithoutValidation("Authorization", token);
+                }
+                else
+                {
+                    httpClient.DefaultRequestHeaders.Authorization =
+                        new AuthenticationHeaderValue(scheme, token);
+                }
             }
 
             return httpClient;


### PR DESCRIPTION
Fixed the case where you want to add a pure authroization header without scheme validation

```
Authroization     3AC3A...
```
