### PR TITLE
docs: remove obsolete function refrence

### DIFF
--- a/website/src/docs/hotchocolate/v10/security/index.md
+++ b/website/src/docs/hotchocolate/v10/security/index.md
@@ -27,7 +27,7 @@ In order to use the `@authorize`-directive we have to register it like the follo
 ```csharp
 SchemaBuilder.New()
   ...
-  .AddAuthorizeDirectiveType()
+  .AddAuthorization()
   ...
   .Create();
 ```


### PR DESCRIPTION
replace with non obsolete function name