### PR TITLE
#3628 add support for IsRepeatable not being specified on directives

### DIFF
--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionDeserializer.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionDeserializer.cs
@@ -261,7 +261,7 @@ namespace HotChocolate.Utilities.Introspection
                 null,
                 new NameNode(directive.Name),
                 CreateDescription(directive.Description),
-                directive.IsRepeatable,
+                directive.IsRepeatable ?? false,
                 CreateInputValues(directive.Args),
                 locations
             );

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/Models/Directive.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/Models/Directive.cs
@@ -11,7 +11,7 @@ namespace HotChocolate.Utilities.Introspection
         public string Description { get; set; }
         public ICollection<InputField> Args { get; set; }
         public ICollection<string> Locations { get; set; }
-        public bool IsRepeatable { get; set; }
+        public bool? IsRepeatable { get; set; }
         public bool OnOperation { get; set; }
         public bool OnFragment { get; set; }
         public bool OnField { get; set; }


### PR DESCRIPTION
Add support for IsRepeatable not being specified in GraphQL schemas

- Directive.IsRepeatable becomes nullable
- When Directive.IsRepeatable is null, code assumes that the the directive is *not* repeatable

Closes #3628 
