### PR TITLE
Mark descriptor.Interface as obsolete

### DIFF
--- a/src/HotChocolate/Core/benchmark/StarWars/Types/DroidType.cs
+++ b/src/HotChocolate/Core/benchmark/StarWars/Types/DroidType.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Droid> descriptor)
         {
-            descriptor.Interface<CharacterType>();
+            descriptor.Implements<CharacterType>();
 
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();

--- a/src/HotChocolate/Core/benchmark/StarWars/Types/HumanType.cs
+++ b/src/HotChocolate/Core/benchmark/StarWars/Types/HumanType.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Human> descriptor)
         {
-            descriptor.Interface<CharacterType>();
+            descriptor.Implements<CharacterType>();
 
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();

--- a/src/HotChocolate/Core/benchmark10/StarWars/Types/DroidType.cs
+++ b/src/HotChocolate/Core/benchmark10/StarWars/Types/DroidType.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Droid> descriptor)
         {
-            descriptor.Interface<CharacterType>();
+            descriptor.Implements<CharacterType>();
 
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();

--- a/src/HotChocolate/Core/benchmark10/StarWars/Types/HumanType.cs
+++ b/src/HotChocolate/Core/benchmark10/StarWars/Types/HumanType.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Human> descriptor)
         {
-            descriptor.Interface<CharacterType>();
+            descriptor.Implements<CharacterType>();
 
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IInterfaceTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IInterfaceTypeDescriptor.cs
@@ -41,6 +41,7 @@ namespace HotChocolate.Types
         /// <see cref="InterfaceType"/>.
         /// </summary>
         /// <typeparam name="T">The interface type.</typeparam>
+        [Obsolete("Use Implements.")]
         IInterfaceTypeDescriptor Interface<T>()
             where T : InterfaceType;
 
@@ -49,6 +50,7 @@ namespace HotChocolate.Types
         /// <see cref="InterfaceType"/>.
         /// </summary>
         /// <typeparam name="T">The interface type.</typeparam>
+        [Obsolete("Use Implements.")]
         IInterfaceTypeDescriptor Interface<T>(T type)
             where T : InterfaceType;
 
@@ -59,6 +61,7 @@ namespace HotChocolate.Types
         /// <param name="type">
         /// A syntax node representing an interface type.
         /// </param>
+        [Obsolete("Use Implements.")]
         IInterfaceTypeDescriptor Interface(NamedTypeNode type);
 
         /// <summary>

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IInterfaceTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IInterfaceTypeDescriptor~1.cs
@@ -42,6 +42,7 @@ namespace HotChocolate.Types
         /// <see cref="InterfaceType"/>.
         /// </summary>
         /// <typeparam name="T">The interface type.</typeparam>
+        [Obsolete("Use Implements.")]
         IInterfaceTypeDescriptor<T> Interface<TInterface>()
             where TInterface : InterfaceType;
 
@@ -50,6 +51,7 @@ namespace HotChocolate.Types
         /// <see cref="InterfaceType"/>.
         /// </summary>
         /// <typeparam name="T">The interface type.</typeparam>
+        [Obsolete("Use Implements.")]
         IInterfaceTypeDescriptor<T> Interface<TInterface>(TInterface type)
             where TInterface : InterfaceType;
 
@@ -60,6 +62,7 @@ namespace HotChocolate.Types
         /// <param name="type">
         /// A syntax node representing an interface type.
         /// </param>
+        [Obsolete("Use Implements.")]
         IInterfaceTypeDescriptor<T> Interface(NamedTypeNode type);
 
         /// <summary>

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IObjectTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IObjectTypeDescriptor.cs
@@ -44,6 +44,7 @@ namespace HotChocolate.Types
         /// <see cref="ObjectType"/>.
         /// </summary>
         /// <typeparam name="T">The interface type.</typeparam>
+        [Obsolete("Use Implements.")]
         IObjectTypeDescriptor Interface<T>()
             where T : InterfaceType;
 
@@ -52,6 +53,7 @@ namespace HotChocolate.Types
         /// <see cref="ObjectType"/>.
         /// </summary>
         /// <typeparam name="T">The interface type.</typeparam>
+        [Obsolete("Use Implements.")]
         IObjectTypeDescriptor Interface<T>(T type)
             where T : InterfaceType;
 
@@ -62,6 +64,7 @@ namespace HotChocolate.Types
         /// <param name="type">
         /// A syntax node representing an interface type.
         /// </param>
+        [Obsolete("Use Implements.")]
         IObjectTypeDescriptor Interface(NamedTypeNode type);
 
         /// <summary>

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IObjectTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IObjectTypeDescriptor~1.cs
@@ -66,6 +66,7 @@ namespace HotChocolate.Types
         /// <see cref="ObjectType"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface type.</typeparam>
+        [Obsolete("Use Implements.")]
         IObjectTypeDescriptor<T> Interface<TInterface>()
             where TInterface : InterfaceType;
 
@@ -74,6 +75,7 @@ namespace HotChocolate.Types
         /// <see cref="ObjectType"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface type.</typeparam>
+        [Obsolete("Use Implements.")]
         IObjectTypeDescriptor<T> Interface<TInterface>(TInterface type)
             where TInterface : InterfaceType;
 
@@ -84,6 +86,7 @@ namespace HotChocolate.Types
         /// <param name="type">
         /// A syntax node representing an interface type.
         /// </param>
+        [Obsolete("Use Implements.")]
         IObjectTypeDescriptor<T> Interface(NamedTypeNode type);
 
         /// <summary>

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
@@ -104,22 +104,34 @@ namespace HotChocolate.Types.Descriptors
         [Obsolete("Use Implements.")]
         public IInterfaceTypeDescriptor Interface<TInterface>()
             where TInterface : InterfaceType
+            => Implements<TInterface>();
+
+        [Obsolete("Use Implements.")]
+        public IInterfaceTypeDescriptor Interface<TInterface>(
+            TInterface type)
+            where TInterface : InterfaceType
+            => Implements(type);
+
+        [Obsolete("Use Implements.")]
+        public IInterfaceTypeDescriptor Interface(NamedTypeNode namedType)
+            => Implements(namedType);
+
+        public IInterfaceTypeDescriptor Implements<T>()
+            where T : InterfaceType
         {
-            if (typeof(TInterface) == typeof(InterfaceType))
+            if (typeof(T) == typeof(InterfaceType))
             {
                 throw new ArgumentException(
                     TypeResources.InterfaceTypeDescriptor_InterfaceBaseClass);
             }
 
             Definition.Interfaces.Add(
-                Context.TypeInspector.GetTypeRef(typeof(TInterface), TypeContext.Output));
+                Context.TypeInspector.GetTypeRef(typeof(T), TypeContext.Output));
             return this;
         }
 
-        [Obsolete("Use Implements.")]
-        public IInterfaceTypeDescriptor Interface<TInterface>(
-            TInterface type)
-            where TInterface : InterfaceType
+        public IInterfaceTypeDescriptor Implements<T>(T type)
+            where T : InterfaceType
         {
             if (type is null)
             {
@@ -130,29 +142,16 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
-        [Obsolete("Use Implements.")]
-        public IInterfaceTypeDescriptor Interface(
-            NamedTypeNode namedType)
+        public IInterfaceTypeDescriptor Implements(NamedTypeNode type)
         {
-            if (namedType is null)
+            if (type is null)
             {
-                throw new ArgumentNullException(nameof(namedType));
+                throw new ArgumentNullException(nameof(type));
             }
 
-            Definition.Interfaces.Add(TypeReference.Create(namedType, TypeContext.Output));
+            Definition.Interfaces.Add(TypeReference.Create(type, TypeContext.Output));
             return this;
         }
-
-        public IInterfaceTypeDescriptor Implements<T>()
-            where T : InterfaceType =>
-            Interface<T>();
-
-        public IInterfaceTypeDescriptor Implements<T>(T type)
-            where T : InterfaceType =>
-            Interface(type);
-
-        public IInterfaceTypeDescriptor Implements(NamedTypeNode type) =>
-            Interface(type);
 
         public IInterfaceFieldDescriptor Field(NameString name)
         {

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
@@ -101,6 +101,7 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use Implements.")]
         public IInterfaceTypeDescriptor Interface<TInterface>()
             where TInterface : InterfaceType
         {
@@ -115,6 +116,7 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use Implements.")]
         public IInterfaceTypeDescriptor Interface<TInterface>(
             TInterface type)
             where TInterface : InterfaceType
@@ -128,6 +130,7 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use Implements.")]
         public IInterfaceTypeDescriptor Interface(
             NamedTypeNode namedType)
         {

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
@@ -113,8 +113,8 @@ namespace HotChocolate.Types.Descriptors
             => Implements(type);
 
         [Obsolete("Use Implements.")]
-        public IInterfaceTypeDescriptor Interface(NamedTypeNode namedType)
-            => Implements(namedType);
+        public IInterfaceTypeDescriptor Interface(NamedTypeNode type)
+            => Implements(type);
 
         public IInterfaceTypeDescriptor Implements<T>()
             where T : InterfaceType

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor~1.cs
@@ -80,6 +80,7 @@ namespace HotChocolate.Types.Descriptors
         public IInterfaceTypeDescriptor<T> BindFieldsImplicitly() =>
             BindFields(BindingBehavior.Implicit);
 
+        [Obsolete("Use Implements.")]
         public new IInterfaceTypeDescriptor<T> Interface<TInterface>()
             where TInterface : InterfaceType
         {
@@ -87,8 +88,16 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use Implements.")]
         public new IInterfaceTypeDescriptor<T> Interface<TInterface>(TInterface type)
             where TInterface : InterfaceType
+        {
+            base.Interface(type);
+            return this;
+        }
+
+        [Obsolete("Use Implements.")]
+        public new IInterfaceTypeDescriptor<T> Interface(NamedTypeNode type)
         {
             base.Interface(type);
             return this;
@@ -97,12 +106,6 @@ namespace HotChocolate.Types.Descriptors
         public new IInterfaceTypeDescriptor<T> Implements<TInterface>()
             where TInterface : InterfaceType =>
             Interface<TInterface>();
-
-        public new IInterfaceTypeDescriptor<T> Interface(NamedTypeNode type)
-        {
-            base.Interface(type);
-            return this;
-        }
 
         public new IInterfaceTypeDescriptor<T> Implements<TInterface>(TInterface type)
             where TInterface : InterfaceType =>

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor~1.cs
@@ -83,36 +83,36 @@ namespace HotChocolate.Types.Descriptors
         [Obsolete("Use Implements.")]
         public new IInterfaceTypeDescriptor<T> Interface<TInterface>()
             where TInterface : InterfaceType
-        {
-            base.Interface<TInterface>();
-            return this;
-        }
+            => Implements<TInterface>();
 
         [Obsolete("Use Implements.")]
         public new IInterfaceTypeDescriptor<T> Interface<TInterface>(TInterface type)
             where TInterface : InterfaceType
-        {
-            base.Interface(type);
-            return this;
-        }
+            => Implements(type);
 
         [Obsolete("Use Implements.")]
         public new IInterfaceTypeDescriptor<T> Interface(NamedTypeNode type)
+            => Implements(type);
+
+        public new IInterfaceTypeDescriptor<T> Implements<TInterface>()
+            where TInterface : InterfaceType
         {
-            base.Interface(type);
+            base.Implements<TInterface>();
             return this;
         }
 
-        public new IInterfaceTypeDescriptor<T> Implements<TInterface>()
-            where TInterface : InterfaceType =>
-            Interface<TInterface>();
-
         public new IInterfaceTypeDescriptor<T> Implements<TInterface>(TInterface type)
-            where TInterface : InterfaceType =>
-            Interface(type);
+            where TInterface : InterfaceType
+        {
+            base.Implements(type);
+            return this;
+        }
 
-        public new IInterfaceTypeDescriptor<T> Implements(NamedTypeNode type) =>
-            Interface(type);
+        public new IInterfaceTypeDescriptor<T> Implements(NamedTypeNode type)
+        {
+            base.Implements(type);
+            return this;
+        }
 
         public IInterfaceFieldDescriptor Field(
             Expression<Func<T, object>> propertyOrMethod)

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -178,6 +178,7 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use Implements.")]
         public IObjectTypeDescriptor Interface<TInterface>()
             where TInterface : InterfaceType
         {
@@ -192,6 +193,7 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use Implements.")]
         public IObjectTypeDescriptor Interface<TInterface>(
             TInterface type)
             where TInterface : InterfaceType
@@ -206,6 +208,7 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use Implements.")]
         public IObjectTypeDescriptor Interface(
             NamedTypeNode namedType)
         {

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -181,22 +181,35 @@ namespace HotChocolate.Types.Descriptors
         [Obsolete("Use Implements.")]
         public IObjectTypeDescriptor Interface<TInterface>()
             where TInterface : InterfaceType
+            => Implements<TInterface>();
+
+        [Obsolete("Use Implements.")]
+        public IObjectTypeDescriptor Interface<TInterface>(
+            TInterface type)
+            where TInterface : InterfaceType
+            => Implements(type);
+
+        [Obsolete("Use Implements.")]
+        public IObjectTypeDescriptor Interface(
+            NamedTypeNode namedType)
+            => Implements(namedType);
+
+        public IObjectTypeDescriptor Implements<T>()
+            where T : InterfaceType
         {
-            if (typeof(TInterface) == typeof(InterfaceType))
+            if (typeof(T) == typeof(InterfaceType))
             {
                 throw new ArgumentException(
                     ObjectTypeDescriptor_InterfaceBaseClass);
             }
 
             Definition.Interfaces.Add(
-                Context.TypeInspector.GetTypeRef(typeof(TInterface)));
+                Context.TypeInspector.GetTypeRef(typeof(T)));
             return this;
         }
 
-        [Obsolete("Use Implements.")]
-        public IObjectTypeDescriptor Interface<TInterface>(
-            TInterface type)
-            where TInterface : InterfaceType
+        public IObjectTypeDescriptor Implements<T>(T type)
+            where T : InterfaceType
         {
             if (type is null)
             {
@@ -208,29 +221,16 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
-        [Obsolete("Use Implements.")]
-        public IObjectTypeDescriptor Interface(
-            NamedTypeNode namedType)
+        public IObjectTypeDescriptor Implements(NamedTypeNode type)
         {
-            if (namedType is null)
+            if (type is null)
             {
-                throw new ArgumentNullException(nameof(namedType));
+                throw new ArgumentNullException(nameof(type));
             }
 
-            Definition.Interfaces.Add(TypeReference.Create(namedType, TypeContext.Output));
+            Definition.Interfaces.Add(TypeReference.Create(type, TypeContext.Output));
             return this;
         }
-
-        public IObjectTypeDescriptor Implements<T>()
-            where T : InterfaceType =>
-            Interface<T>();
-
-        public IObjectTypeDescriptor Implements<T>(T type)
-            where T : InterfaceType =>
-            Interface(type);
-
-        public IObjectTypeDescriptor Implements(NamedTypeNode type) =>
-            Interface(type);
 
         public IObjectTypeDescriptor Include<TResolver>()
         {

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptorBase~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptorBase~1.cs
@@ -52,7 +52,7 @@ namespace HotChocolate.Types.Descriptors
                         var descriptor = ObjectFieldDescriptor.New(
                             Context, p, Definition.RuntimeType, Definition.FieldBindingType);
 
-                        if(Definition.IsExtension && Context.TypeInspector.IsMemberIgnored(p))
+                        if (Definition.IsExtension && Context.TypeInspector.IsMemberIgnored(p))
                         {
                             descriptor.Ignore();
                         }
@@ -82,7 +82,7 @@ namespace HotChocolate.Types.Descriptors
                 {
                     subscribeResolver = new HashSet<string>();
 
-                    foreach(MemberInfo member in all)
+                    foreach (MemberInfo member in all)
                     {
                         HandlePossibleSubscribeMember(member);
                     }
@@ -93,9 +93,9 @@ namespace HotChocolate.Types.Descriptors
 
             void HandlePossibleSubscribeMember(MemberInfo member)
             {
-                if(member.IsDefined(typeof(SubscribeAttribute)))
+                if (member.IsDefined(typeof(SubscribeAttribute)))
                 {
-                    if(member.GetCustomAttribute<SubscribeAttribute>() is { With: not null } attr)
+                    if (member.GetCustomAttribute<SubscribeAttribute>() is { With: not null } attr)
                     {
                         subscribeResolver.Add(attr.With);
                     }
@@ -129,6 +129,7 @@ namespace HotChocolate.Types.Descriptors
         public IObjectTypeDescriptor<T> BindFieldsImplicitly() =>
             BindFields(BindingBehavior.Implicit);
 
+        [Obsolete("Use Implements.")]
         public new IObjectTypeDescriptor<T> Interface<TInterface>()
             where TInterface : InterfaceType
         {
@@ -136,8 +137,16 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use Implements.")]
         public new IObjectTypeDescriptor<T> Interface<TInterface>(TInterface type)
             where TInterface : InterfaceType
+        {
+            base.Interface(type);
+            return this;
+        }
+
+        [Obsolete("Use Implements.")]
+        public new IObjectTypeDescriptor<T> Interface(NamedTypeNode type)
         {
             base.Interface(type);
             return this;
@@ -146,12 +155,6 @@ namespace HotChocolate.Types.Descriptors
         public new IObjectTypeDescriptor<T> Implements<TInterface>()
             where TInterface : InterfaceType =>
             Interface<TInterface>();
-
-        public new IObjectTypeDescriptor<T> Interface(NamedTypeNode type)
-        {
-            base.Interface(type);
-            return this;
-        }
 
         public new IObjectTypeDescriptor<T> Implements<TInterface>(TInterface type)
             where TInterface : InterfaceType =>

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptorBase~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptorBase~1.cs
@@ -132,36 +132,36 @@ namespace HotChocolate.Types.Descriptors
         [Obsolete("Use Implements.")]
         public new IObjectTypeDescriptor<T> Interface<TInterface>()
             where TInterface : InterfaceType
-        {
-            base.Interface<TInterface>();
-            return this;
-        }
+            => Implements<TInterface>();
 
         [Obsolete("Use Implements.")]
         public new IObjectTypeDescriptor<T> Interface<TInterface>(TInterface type)
             where TInterface : InterfaceType
-        {
-            base.Interface(type);
-            return this;
-        }
+            => Implements(type);
 
         [Obsolete("Use Implements.")]
         public new IObjectTypeDescriptor<T> Interface(NamedTypeNode type)
+            => Implements(type);
+
+        public new IObjectTypeDescriptor<T> Implements<TInterface>()
+            where TInterface : InterfaceType
         {
-            base.Interface(type);
+            base.Implements<TInterface>();
             return this;
         }
 
-        public new IObjectTypeDescriptor<T> Implements<TInterface>()
-            where TInterface : InterfaceType =>
-            Interface<TInterface>();
-
         public new IObjectTypeDescriptor<T> Implements<TInterface>(TInterface type)
-            where TInterface : InterfaceType =>
-            Interface(type);
+            where TInterface : InterfaceType
+        {
+            base.Implements(type);
+            return this;
+        }
 
-        public new IObjectTypeDescriptor<T> Implements(NamedTypeNode type) =>
-            Interface(type);
+        public new IObjectTypeDescriptor<T> Implements(NamedTypeNode type)
+        {
+            base.Implements(type);
+            return this;
+        }
 
         public new IObjectTypeDescriptor<T> Include<TResolver>()
         {

--- a/src/HotChocolate/Core/test/Execution.Tests/CodeFirstTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/CodeFirstTests.cs
@@ -400,7 +400,7 @@ namespace HotChocolate.Execution
             protected override void Configure(IObjectTypeDescriptor descriptor)
             {
                 descriptor.Name("Tea");
-                descriptor.Interface<DrinkType>();
+                descriptor.Implements<DrinkType>();
                 descriptor.Field("kind")
                     .Type<NonNullType<DrinkKindType>>()
                     .Resolver(() => DrinkKind.BlackTea);

--- a/src/HotChocolate/Core/test/StarWars/Types/DroidType.cs
+++ b/src/HotChocolate/Core/test/StarWars/Types/DroidType.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Droid> descriptor)
         {
-            descriptor.Interface<CharacterType>();
+            descriptor.Implements<CharacterType>();
 
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();

--- a/src/HotChocolate/Core/test/StarWars/Types/HumanType.cs
+++ b/src/HotChocolate/Core/test/StarWars/Types/HumanType.cs
@@ -10,7 +10,7 @@ namespace HotChocolate.StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Human> descriptor)
         {
-            descriptor.Interface<CharacterType>();
+            descriptor.Implements<CharacterType>();
 
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();

--- a/src/HotChocolate/Core/test/Validation.Tests/Types/AlienType.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/Types/AlienType.cs
@@ -7,7 +7,7 @@ namespace HotChocolate.Validation.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Alien> descriptor)
         {
-            descriptor.Interface<SentientType>();
+            descriptor.Implements<SentientType>();
             descriptor.Field(t => t.Name).Type<NonNullType<StringType>>();
         }
     }

--- a/src/HotChocolate/Core/test/Validation.Tests/Types/CatType.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/Types/CatType.cs
@@ -7,8 +7,8 @@ namespace HotChocolate.Validation.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Cat> descriptor)
         {
-            descriptor.Interface<PetType>();
-            descriptor.Interface<BeingType>();
+            descriptor.Implements<PetType>();
+            descriptor.Implements<BeingType>();
             descriptor.Implements<MammalType>();
             descriptor.Field(t => t.Name).Type<NonNullType<StringType>>();
             descriptor.Field(t => t.DoesKnowCommand(default))

--- a/src/HotChocolate/Core/test/Validation.Tests/Types/HumanType.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/Types/HumanType.cs
@@ -7,7 +7,7 @@ namespace HotChocolate.Validation.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Human> descriptor)
         {
-            descriptor.Interface<SentientType>();
+            descriptor.Implements<SentientType>();
             descriptor.Implements<BeingType>();
             descriptor.Implements<IntelligentType>();
             descriptor.Field(t => t.Name).Type<NonNullType<StringType>>();

--- a/src/HotChocolate/Core/test/Validation.Tests/Types/PetType.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/Types/PetType.cs
@@ -8,7 +8,7 @@ namespace HotChocolate.Validation.Types
         protected override void Configure(IInterfaceTypeDescriptor descriptor)
         {
             descriptor.Name("Pet");
-            descriptor.Interface<BeingType>();
+            descriptor.Implements<BeingType>();
             descriptor.Field("name").Type<NonNullType<StringType>>();
         }
     }

--- a/src/HotChocolate/Stitching/test/Stitching.Tests/Schemas/Contracts/LifeInsuranceContractType.cs
+++ b/src/HotChocolate/Stitching/test/Stitching.Tests/Schemas/Contracts/LifeInsuranceContractType.cs
@@ -22,7 +22,7 @@ namespace HotChocolate.Stitching.Schemas.Contracts
                             .FirstOrDefault(t => t.Id.Equals(id)));
                 });
 
-            descriptor.Interface<ContractType>();
+            descriptor.Implements<ContractType>();
             descriptor.Field(t => t.Id).Type<NonNullType<IdType>>();
             descriptor.Field(t => t.CustomerId).Type<NonNullType<IdType>>();
             descriptor.Field("foo")

--- a/src/HotChocolate/Stitching/test/Stitching.Tests/Schemas/Contracts/SomeOtherContractType.cs
+++ b/src/HotChocolate/Stitching/test/Stitching.Tests/Schemas/Contracts/SomeOtherContractType.cs
@@ -21,7 +21,7 @@ namespace HotChocolate.Stitching.Schemas.Contracts
                             .FirstOrDefault(t => t.Id.Equals(id)));
                 });
 
-            descriptor.Interface<ContractType>();
+            descriptor.Implements<ContractType>();
 
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();


### PR DESCRIPTION
- Marks all occurrences of descriptor.Interface as obsolete
- Tests and StarWars now use descriptor.Implements
- descriptor.Interface now calls descriptor.Implements, making it easier to remove