### PR TITLE
Mark descriptor.Item and descriptor.BindItems as obsolete

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor.cs
@@ -35,12 +35,14 @@ namespace HotChocolate.Types
         IEnumTypeDescriptor Description(
             string value);
 
+        [Obsolete("Use `Value`.")]
         IEnumValueDescriptor Item<T>(
             T value);
 
         IEnumValueDescriptor Value<T>(
             T value);
 
+        [Obsolete("Use `BindValues`.")]
         IEnumTypeDescriptor BindItems(
             BindingBehavior behavior);
 

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor.cs
@@ -1,4 +1,5 @@
-﻿using HotChocolate.Language;
+﻿using System;
+using HotChocolate.Language;
 using HotChocolate.Types.Descriptors.Definitions;
 
 namespace HotChocolate.Types

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor~1.cs
@@ -33,10 +33,12 @@ namespace HotChocolate.Types
         /// </param>
         IEnumTypeDescriptor<T> Description(string value);
 
+        [Obsolete("Use `Value`.")]
         IEnumValueDescriptor Item(T value);
 
         IEnumValueDescriptor Value(T value);
 
+        [Obsolete("Use `BindValues`.")]
         IEnumTypeDescriptor<T> BindItems(BindingBehavior behavior);
 
         IEnumTypeDescriptor<T> BindValues(BindingBehavior behavior);

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IEnumTypeDescriptor~1.cs
@@ -1,3 +1,4 @@
+using System;
 using HotChocolate.Language;
 using HotChocolate.Types.Descriptors.Definitions;
 

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumTypeDescriptor.cs
@@ -103,6 +103,7 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use `BindValues`.")]
         public IEnumTypeDescriptor BindItems(
             BindingBehavior behavior) =>
             BindValues(behavior);
@@ -120,7 +121,10 @@ namespace HotChocolate.Types.Descriptors
         public IEnumTypeDescriptor BindValuesImplicitly() =>
             BindValues(BindingBehavior.Implicit);
 
-        public IEnumValueDescriptor Item<T>(T value)
+        [Obsolete("Use `Value`.")]
+        public IEnumValueDescriptor Item<T>(T value) => Value<T>(value);
+
+        public IEnumValueDescriptor Value<T>(T value)
         {
             EnumValueDescriptor descriptor = Values.FirstOrDefault(t =>
                 t.Definition.Value is not null &&
@@ -135,8 +139,6 @@ namespace HotChocolate.Types.Descriptors
             Values.Add(descriptor);
             return descriptor;
         }
-
-        public IEnumValueDescriptor Value<T>(T value) => Item<T>(value);
 
         public IEnumTypeDescriptor Directive<T>(T directiveInstance)
             where T : class

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumTypeDescriptor~1.cs
@@ -13,7 +13,7 @@ namespace HotChocolate.Types.Descriptors
         }
 
         protected internal EnumTypeDescriptor(
-            IDescriptorContext context, 
+            IDescriptorContext context,
             EnumTypeDefinition definition)
             : base(context, definition)
         {
@@ -38,6 +38,7 @@ namespace HotChocolate.Types.Descriptors
             return this;
         }
 
+        [Obsolete("Use `BindValues`.")]
         public new IEnumTypeDescriptor<T> BindItems(
             BindingBehavior behavior) =>
             BindValues(behavior);
@@ -54,12 +55,13 @@ namespace HotChocolate.Types.Descriptors
         public new IEnumTypeDescriptor<T> BindValuesImplicitly() =>
             BindValues(BindingBehavior.Implicit);
 
-        public IEnumValueDescriptor Item(T value)
-        {
-            return base.Item(value);
-        }
+        [Obsolete("Use `Value`.")]
+        public IEnumValueDescriptor Item(T value) => Value<T>(value);
 
-        public IEnumValueDescriptor Value(T value) => Item(value);
+        public IEnumValueDescriptor Value(T value)
+        {
+            return base.Value(value);
+        }
 
         public new IEnumTypeDescriptor<T> Directive<TDirective>(
             TDirective directiveInstance)

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumTypeDescriptor~1.cs
@@ -1,3 +1,4 @@
+using System;
 using HotChocolate.Language;
 using HotChocolate.Types.Descriptors.Definitions;
 

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__DirectiveLocation.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__DirectiveLocation.cs
@@ -15,100 +15,100 @@ namespace HotChocolate.Types.Introspection
                 .Description(TypeResources.DirectiveLocation_Description)
                 // Introspection types must always be bound explicitly so that we
                 // do not get any interference with conventions.
-                .BindItems(BindingBehavior.Explicit);
+                .BindValues(BindingBehavior.Explicit);
 
             descriptor
-                .Item(DirectiveLocation.Query)
+                .Value(DirectiveLocation.Query)
                 .Name(Lang.Query.Value)
                 .Description(TypeResources.DirectiveLocation_Query);
 
             descriptor
-                .Item(DirectiveLocation.Mutation)
+                .Value(DirectiveLocation.Mutation)
                 .Name(Lang.Mutation.Value)
                 .Description(TypeResources.DirectiveLocation_Mutation);
 
             descriptor
-                .Item(DirectiveLocation.Subscription)
+                .Value(DirectiveLocation.Subscription)
                 .Name(Lang.Subscription.Value)
                 .Description(TypeResources.DirectiveLocation_Subscription);
 
             descriptor
-                .Item(DirectiveLocation.Field)
+                .Value(DirectiveLocation.Field)
                 .Name(Lang.Field.Value)
                 .Description(TypeResources.DirectiveLocation_Field);
 
             descriptor
-                .Item(DirectiveLocation.FragmentDefinition)
+                .Value(DirectiveLocation.FragmentDefinition)
                 .Name(Lang.FragmentDefinition.Value)
                 .Description(TypeResources.DirectiveLocation_FragmentDefinition);
 
             descriptor
-                .Item(DirectiveLocation.FragmentSpread)
+                .Value(DirectiveLocation.FragmentSpread)
                 .Name(Lang.FragmentSpread.Value)
                 .Description(TypeResources.DirectiveLocation_FragmentSpread);
 
             descriptor
-                .Item(DirectiveLocation.InlineFragment)
+                .Value(DirectiveLocation.InlineFragment)
                 .Name(Lang.InlineFragment.Value)
                 .Description(TypeResources.DirectiveLocation_InlineFragment);
 
             descriptor
-                .Item(DirectiveLocation.VariableDefinition)
+                .Value(DirectiveLocation.VariableDefinition)
                 .Name(Lang.VariableDefinition.Value)
                 .Description("Location adjacent to a variable definition.");
 
             descriptor
-                .Item(DirectiveLocation.Schema)
+                .Value(DirectiveLocation.Schema)
                 .Name(Lang.Schema.Value)
                 .Description(TypeResources.DirectiveLocation_Schema);
 
             descriptor
-                .Item(DirectiveLocation.Scalar)
+                .Value(DirectiveLocation.Scalar)
                 .Name(Lang.Scalar.Value)
                 .Description(TypeResources.DirectiveLocation_Scalar);
 
             descriptor
-                .Item(DirectiveLocation.Object)
+                .Value(DirectiveLocation.Object)
                 .Name(Lang.Object.Value)
                 .Description(TypeResources.DirectiveLocation_Object);
 
             descriptor
-                .Item(DirectiveLocation.FieldDefinition)
+                .Value(DirectiveLocation.FieldDefinition)
                 .Name(Lang.FieldDefinition.Value)
                 .Description(TypeResources.DirectiveLocation_FieldDefinition);
 
             descriptor
-                .Item(DirectiveLocation.ArgumentDefinition)
+                .Value(DirectiveLocation.ArgumentDefinition)
                 .Name(Lang.ArgumentDefinition.Value)
                 .Description(TypeResources.DirectiveLocation_ArgumentDefinition);
 
             descriptor
-                .Item(DirectiveLocation.Interface)
+                .Value(DirectiveLocation.Interface)
                 .Name(Lang.Interface.Value)
                 .Description(TypeResources.DirectiveLocation_Interface);
 
             descriptor
-                .Item(DirectiveLocation.Union)
+                .Value(DirectiveLocation.Union)
                 .Name(Lang.Union.Value)
                 .Description(TypeResources.DirectiveLocation_Union);
 
             descriptor
-                .Item(DirectiveLocation.Enum)
+                .Value(DirectiveLocation.Enum)
                 .Name(Lang.Enum.Value)
                 .Description(TypeResources.DirectiveLocation_Enum);
 
             descriptor
-                .Item(DirectiveLocation.EnumValue)
+                .Value(DirectiveLocation.EnumValue)
                 .Name(Lang.EnumValue.Value)
                 .Description(TypeResources.DirectiveLocation_EnumValue);
 
             descriptor
-                .Item(DirectiveLocation.InputObject)
+                .Value(DirectiveLocation.InputObject)
                 .Name(Lang.InputObject.Value)
                 .Description(TypeResources.DirectiveLocation_InputObject);
 
             descriptor
-                .Item(DirectiveLocation.InputFieldDefinition)
+                .Value(DirectiveLocation.InputFieldDefinition)
                 .Name(Lang.InputFieldDefinition.Value)
                 .Description(TypeResources.DirectiveLocation_InputFieldDefinition);
         }

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__TypeKind.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__TypeKind.cs
@@ -15,45 +15,45 @@ namespace HotChocolate.Types.Introspection
                 .Description(TypeResources.TypeKind_Description)
                 // Introspection types must always be bound explicitly so that we
                 // do not get any interference with conventions.
-                .BindItems(BindingBehavior.Explicit);
+                .BindValues(BindingBehavior.Explicit);
 
             descriptor
-                .Item(TypeKind.Scalar)
+                .Value(TypeKind.Scalar)
                 .Name(Names.Scalar)
                 .Description(TypeResources.TypeKind_Scalar);
 
             descriptor
-                .Item(TypeKind.Object)
+                .Value(TypeKind.Object)
                 .Name(Names.Object)
                 .Description(TypeResources.TypeKind_Object);
 
             descriptor
-                .Item(TypeKind.Interface)
+                .Value(TypeKind.Interface)
                 .Name(Names.Interface)
                 .Description(TypeResources.TypeKind_Interface);
 
             descriptor
-                .Item(TypeKind.Union)
+                .Value(TypeKind.Union)
                 .Name(Names.Union)
                 .Description(TypeResources.TypeKind_Union);
 
             descriptor
-                .Item(TypeKind.Enum)
+                .Value(TypeKind.Enum)
                 .Name(Names.Enum)
                 .Description(TypeResources.TypeKind_Enum);
 
             descriptor
-                .Item(TypeKind.InputObject)
+                .Value(TypeKind.InputObject)
                 .Name(Names.InputObject)
                 .Description(TypeResources.TypeKind_InputObject);
 
             descriptor
-                .Item(TypeKind.List)
+                .Value(TypeKind.List)
                 .Name(Names.List)
                 .Description(TypeResources.TypeKind_List);
 
             descriptor
-                .Item(TypeKind.NonNull)
+                .Value(TypeKind.NonNull)
                 .Name(Names.NonNull)
                 .Description(TypeResources.TypeKind_NonNull);
         }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/EnumTypeDescriptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/EnumTypeDescriptorTests.cs
@@ -58,7 +58,7 @@ namespace HotChocolate.Types
 
             // act
             IEnumTypeDescriptor desc = descriptor;
-            desc.Item(FooEnum.Bar1).Name("FOOBAR");
+            desc.Value(FooEnum.Bar1).Name("FOOBAR");
 
             // assert
             EnumTypeDefinition description = descriptor.CreateDefinition();
@@ -83,7 +83,7 @@ namespace HotChocolate.Types
 
             // act
             IEnumTypeDescriptor desc = descriptor;
-            desc.Item(FooEnum.Bar1).Name("FOOBAR");
+            desc.Value(FooEnum.Bar1).Name("FOOBAR");
             desc.BindValues(BindingBehavior.Explicit);
 
             // assert

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeExtensionTests.cs
@@ -33,7 +33,7 @@ namespace HotChocolate.Types
                 .AddType<FooType>()
                 .AddType(new EnumTypeExtension(d => d
                     .Name("Foo")
-                    .Item("FOOBAR")))
+                    .Value("FOOBAR")))
                 .Create();
 
             // assert
@@ -134,8 +134,8 @@ namespace HotChocolate.Types
                 IEnumTypeDescriptor<Foo> descriptor)
             {
                 descriptor.BindValues(BindingBehavior.Explicit);
-                descriptor.Item(Foo.Bar);
-                descriptor.Item(Foo.Baz);
+                descriptor.Value(Foo.Bar);
+                descriptor.Value(Foo.Baz);
             }
         }
 
@@ -145,7 +145,7 @@ namespace HotChocolate.Types
             protected override void Configure(IEnumTypeDescriptor descriptor)
             {
                 descriptor.Name("Foo");
-                descriptor.Item(Foo.Quox).Name("_QUOX");
+                descriptor.Value(Foo.Quox).Name("_QUOX");
             }
         }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeTests.cs
@@ -22,7 +22,7 @@ namespace HotChocolate.Types
                 c.RegisterType(new EnumType(d => d
                     .Name(dep => dep.Name + "Enum")
                     .DependsOn<StringType>()
-                    .Item("BAR")));
+                    .Value("BAR")));
 
                 c.Options.StrictValidation = false;
             });
@@ -57,7 +57,7 @@ namespace HotChocolate.Types
                 c.RegisterType(new EnumType(d => d
                     .Name(dep => dep.Name + "Enum")
                     .DependsOn(typeof(StringType))
-                    .Item("BAR")));
+                    .Value("BAR")));
 
                 c.Options.StrictValidation = false;
             });
@@ -175,7 +175,7 @@ namespace HotChocolate.Types
                 c.RegisterType(new EnumType<Foo>(d =>
                 {
                     d.BindValues(BindingBehavior.Explicit);
-                    d.Item(Foo.Bar1);
+                    d.Value(Foo.Bar1);
                 }));
                 c.Options.StrictValidation = false;
             });
@@ -198,7 +198,7 @@ namespace HotChocolate.Types
                 c.RegisterType(new EnumType<Foo>(d =>
                 {
                     d.BindValuesImplicitly().BindValuesExplicitly();
-                    d.Item(Foo.Bar1);
+                    d.Value(Foo.Bar1);
                 }));
                 c.Options.StrictValidation = false;
             });
@@ -220,7 +220,7 @@ namespace HotChocolate.Types
             {
                 c.RegisterType(new EnumType<Foo>(d =>
                 {
-                    d.Item(Foo.Bar1).Name("FOOBAR");
+                    d.Value(Foo.Bar1).Name("FOOBAR");
                 }));
                 c.Options.StrictValidation = false;
             });
@@ -302,7 +302,7 @@ namespace HotChocolate.Types
                 SchemaBuilder.New()
                     .AddQueryType<Bar>()
                     .AddType(new EnumType<Foo?>(d => d.Name("Foo")
-                        .Item(null)))
+                        .Value(null)))
                     .Create();
 
             // assert
@@ -328,7 +328,7 @@ namespace HotChocolate.Types
 
                 c.RegisterType(new EnumType(d => d
                     .Name("Foo")
-                    .Item("baz")
+                    .Value("baz")
                     .Directive<DirectiveNode>(new DirectiveNode("bar"))));
 
                 c.Options.StrictValidation = false;
@@ -353,7 +353,7 @@ namespace HotChocolate.Types
 
                 c.RegisterType(new EnumType(d => d
                     .Name("Foo")
-                    .Item("baz")
+                    .Value("baz")
                     .Directive("bar", Array.Empty<ArgumentNode>())));
 
                 c.Options.StrictValidation = false;
@@ -378,7 +378,7 @@ namespace HotChocolate.Types
 
                 c.RegisterType(new EnumType(d => d
                     .Name("Foo")
-                    .Item("baz")
+                    .Value("baz")
                     .Directive<DirectiveNode>(new DirectiveNode("bar"))));
 
                 c.Options.StrictValidation = false;
@@ -400,7 +400,7 @@ namespace HotChocolate.Types
 
                 c.RegisterType(new EnumType(d => d
                     .Name("Foo")
-                    .Item("baz")
+                    .Value("baz")
                     .Directive<Bar>()));
 
                 c.Options.StrictValidation = false;
@@ -425,7 +425,7 @@ namespace HotChocolate.Types
 
                 c.RegisterType(new EnumType(d => d
                     .Name("Foo")
-                    .Item("baz")
+                    .Value("baz")
                     .Directive<Bar>(new Bar())));
 
                 c.Options.StrictValidation = false;


### PR DESCRIPTION
This marks `descriptor.Item` and `descriptor.BindItems` on the `EnumTypeDescriptor` as obsolete and recommends using `descriptor.Value` and `descriptor.BindValues` instead.
