### PR TITLE
Remember Tab Selection

### DIFF
--- a/website/src/components/doc-page/doc-page.tsx
+++ b/website/src/components/doc-page/doc-page.tsx
@@ -28,6 +28,7 @@ import {
   ArticleTitle,
 } from "../articles/article-elements";
 import { ArticleSections } from "../articles/article-sections";
+import { TabGroupProvider } from "../mdx/tabs/tab-groups";
 import {
   ArticleWrapper,
   ArticleWrapperElement,
@@ -85,42 +86,47 @@ export const DocPage: FunctionComponent<DocPageProperties> = ({
   }, [hasScrolled$]);
 
   return (
-    <Container>
-      <DocPageNavigation
-        data={data}
-        selectedPath={path}
-        selectedProduct={selectedProduct}
-        selectedVersion={selectedVersion}
-      />
-      <ArticleWrapper>
-        <ArticleContainer>
-          <Article>
-            {false && <DocPageLegacy />}
-            <ArticleHeader kind="doc">
-              <ResponsiveMenuWrapper>
-                <ResponsiveMenu ref={responsiveMenuRef}>
-                  <Button onClick={handleToggleTOC} className="toc-toggle">
-                    <ListAltIconSvg /> Table of contents
-                  </Button>
-                  <Button onClick={handleToggleAside} className="aside-toggle">
-                    <NewspaperIconSvg /> About this article
-                  </Button>
-                </ResponsiveMenu>
-              </ResponsiveMenuWrapper>
-              <ArticleTitle>{title}</ArticleTitle>
-            </ArticleHeader>
-            <ArticleContent>
-              <MDXRenderer>{body}</MDXRenderer>
-            </ArticleContent>
-          </Article>
-          {false && <ArticleComments data={data} path={path} title={title} />}
-        </ArticleContainer>
-      </ArticleWrapper>
-      <DocPageAside>
-        <DocPageCommunity data={data} originPath={originPath} />
-        <ArticleSections data={data.file!.childMdx!} />
-      </DocPageAside>
-    </Container>
+    <TabGroupProvider>
+      <Container>
+        <DocPageNavigation
+          data={data}
+          selectedPath={path}
+          selectedProduct={selectedProduct}
+          selectedVersion={selectedVersion}
+        />
+        <ArticleWrapper>
+          <ArticleContainer>
+            <Article>
+              {false && <DocPageLegacy />}
+              <ArticleHeader kind="doc">
+                <ResponsiveMenuWrapper>
+                  <ResponsiveMenu ref={responsiveMenuRef}>
+                    <Button onClick={handleToggleTOC} className="toc-toggle">
+                      <ListAltIconSvg /> Table of contents
+                    </Button>
+                    <Button
+                      onClick={handleToggleAside}
+                      className="aside-toggle"
+                    >
+                      <NewspaperIconSvg /> About this article
+                    </Button>
+                  </ResponsiveMenu>
+                </ResponsiveMenuWrapper>
+                <ArticleTitle>{title}</ArticleTitle>
+              </ArticleHeader>
+              <ArticleContent>
+                <MDXRenderer>{body}</MDXRenderer>
+              </ArticleContent>
+            </Article>
+            {false && <ArticleComments data={data} path={path} title={title} />}
+          </ArticleContainer>
+        </ArticleWrapper>
+        <DocPageAside>
+          <DocPageCommunity data={data} originPath={originPath} />
+          <ArticleSections data={data.file!.childMdx!} />
+        </DocPageAside>
+      </Container>
+    </TabGroupProvider>
   );
 };
 

--- a/website/src/components/mdx/example-tabs.tsx
+++ b/website/src/components/mdx/example-tabs.tsx
@@ -11,7 +11,7 @@ export const ExampleTabs: FunctionComponent & ExampleTabsComposition = ({
   children,
 }) => {
   return (
-    <Tabs defaultValue={"annotation"}>
+    <Tabs defaultValue={"annotation"} groupId="code-style">
       <Tabs.List>
         <Tabs.Tab value="annotation">Annotation-based</Tabs.Tab>
         <Tabs.Tab value="code">Code-first</Tabs.Tab>

--- a/website/src/components/mdx/tabs/tab-groups.tsx
+++ b/website/src/components/mdx/tabs/tab-groups.tsx
@@ -3,6 +3,7 @@ import React, {
   FC,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -74,4 +75,14 @@ export function useActiveTab(
   );
 
   return [activeGroupTab, handleSetGroupTab];
+}
+
+export function useIsClient() {
+  const [isClient, setClient] = useState(false);
+
+  useEffect(() => {
+    setClient(true);
+  }, []);
+
+  return { isClient, key: isClient ? "client" : "server" };
 }

--- a/website/src/components/mdx/tabs/tab-groups.tsx
+++ b/website/src/components/mdx/tabs/tab-groups.tsx
@@ -8,16 +8,16 @@ import React, {
   useState,
 } from "react";
 
-type Groups = {
-  [group: string]: string;
-};
+interface GroupMap {
+  [groupId: string]: string | undefined;
+}
 
 type SetGroup = (groupId: string, value: string) => void;
 
-type TabGroupContextShape = {
-  groups: Groups;
+interface TabGroupContextShape {
+  readonly groups: GroupMap;
   setGroup: SetGroup;
-};
+}
 
 const TabGroupContext = createContext<TabGroupContextShape>({
   groups: {},
@@ -27,7 +27,7 @@ const TabGroupContext = createContext<TabGroupContextShape>({
 const getLocalStorageKey = (groupId: string) => `tab-${groupId}`;
 
 export const TabGroupProvider: FC = ({ children }) => {
-  const [groups, setGroups] = useState<Groups>({});
+  const [groups, setGroups] = useState<GroupMap>({});
 
   const handleSetGroup: SetGroup = (groupId, value) => {
     if (groups[groupId] === value) return;
@@ -58,7 +58,7 @@ export function useActiveTab(
   if (!groupId) return [activeTab, setActiveTab];
 
   const activeGroupTab = useMemo(() => {
-    let value: string | null = groups[groupId];
+    let value: string | null | undefined = groups[groupId];
 
     if (!value && typeof window !== "undefined" && window.localStorage) {
       value = window.localStorage.getItem(getLocalStorageKey(groupId));

--- a/website/src/components/mdx/tabs/tab-groups.tsx
+++ b/website/src/components/mdx/tabs/tab-groups.tsx
@@ -33,7 +33,9 @@ export const TabGroupProvider: FC = ({ children }) => {
 
     setGroups({ ...groups, [groupId]: value });
 
-    localStorage.setItem(getLocalStorageKey(groupId), value);
+    if (typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.setItem(getLocalStorageKey(groupId), value);
+    }
   };
 
   return (
@@ -55,13 +57,13 @@ export function useActiveTab(
   if (!groupId) return [activeTab, setActiveTab];
 
   const activeGroupTab = useMemo(() => {
-    let value = groups[groupId];
+    let value: string | null = groups[groupId];
 
-    if (!value) {
-      value = localStorage.getItem(getLocalStorageKey(groupId)) ?? defaultValue;
+    if (!value && typeof window !== "undefined" && window.localStorage) {
+      value = window.localStorage.getItem(getLocalStorageKey(groupId));
     }
 
-    return value;
+    return value ?? defaultValue;
   }, [groups]);
 
   const handleSetGroupTab = useCallback(

--- a/website/src/components/mdx/tabs/tab-groups.tsx
+++ b/website/src/components/mdx/tabs/tab-groups.tsx
@@ -8,14 +8,14 @@ import React, {
 } from "react";
 
 interface GroupMap {
-  [groupId: string]: string | undefined;
+  readonly [groupId: string]: string | undefined;
 }
 
 type SetGroup = (groupId: string, value: string) => void;
 
 interface TabGroupContextShape {
   readonly groups: GroupMap;
-  setGroup: SetGroup;
+  readonly setGroup: SetGroup;
 }
 
 const TabGroupContext = createContext<TabGroupContextShape>({
@@ -70,7 +70,7 @@ export function useActiveTab(
     if (value) {
       setActiveTab(value);
     }
-  }, [groups, groupId]);
+  }, [groups, groupId, setActiveTab]);
 
   if (!groupId) {
     return [activeTab, setActiveTab];

--- a/website/src/components/mdx/tabs/tab-groups.tsx
+++ b/website/src/components/mdx/tabs/tab-groups.tsx
@@ -1,0 +1,75 @@
+import React, {
+  createContext,
+  FC,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+type Groups = {
+  [group: string]: string;
+};
+
+type SetGroup = (groupId: string, value: string) => void;
+
+type TabGroupContextShape = {
+  groups: Groups;
+  setGroup: SetGroup;
+};
+
+const TabGroupContext = createContext<TabGroupContextShape>({
+  groups: {},
+  setGroup: () => {},
+});
+
+const getLocalStorageKey = (groupId: string) => `tab-${groupId}`;
+
+export const TabGroupProvider: FC = ({ children }) => {
+  const [groups, setGroups] = useState<Groups>({});
+
+  const handleSetGroup: SetGroup = (groupId, value) => {
+    if (groups[groupId] === value) return;
+
+    setGroups({ ...groups, [groupId]: value });
+
+    localStorage.setItem(getLocalStorageKey(groupId), value);
+  };
+
+  return (
+    <TabGroupContext.Provider value={{ groups, setGroup: handleSetGroup }}>
+      {children}
+    </TabGroupContext.Provider>
+  );
+};
+
+type TabGroupReturn = [string, (value: string) => void];
+
+export function useActiveTab(
+  defaultValue: string,
+  groupId?: string
+): TabGroupReturn {
+  const { groups, setGroup } = useContext(TabGroupContext);
+  const [activeTab, setActiveTab] = useState(defaultValue);
+
+  if (!groupId) return [activeTab, setActiveTab];
+
+  const activeGroupTab = useMemo(() => {
+    let value = groups[groupId];
+
+    if (!value) {
+      value = localStorage.getItem(getLocalStorageKey(groupId)) ?? defaultValue;
+    }
+
+    return value;
+  }, [groups]);
+
+  const handleSetGroupTab = useCallback(
+    (value: string) => {
+      setGroup(groupId, value);
+    },
+    [groupId]
+  );
+
+  return [activeGroupTab, handleSetGroupTab];
+}

--- a/website/src/components/mdx/tabs/tab-groups.tsx
+++ b/website/src/components/mdx/tabs/tab-groups.tsx
@@ -4,7 +4,6 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useState,
 } from "react";
 
@@ -55,38 +54,34 @@ export function useActiveTab(
   groupId?: string
 ): TabGroupReturn {
   const { groups, setGroup } = useContext(TabGroupContext);
-  const localTabState = useState(defaultValue);
+  const [activeTab, setActiveTab] = useState(defaultValue);
 
-  if (!groupId) {
-    return localTabState;
-  }
+  useEffect(() => {
+    if (!groupId) {
+      return;
+    }
 
-  const activeGroupTab = useMemo(() => {
     let value: string | null | undefined = groups[groupId];
 
     if (!value && typeof window !== "undefined" && window.localStorage) {
       value = window.localStorage.getItem(getLocalStorageKey(groupId));
     }
 
-    return value ?? defaultValue;
-  }, [groups]);
+    if (value) {
+      setActiveTab(value);
+    }
+  }, [groups, groupId]);
 
-  const handleSetGroupTab = useCallback(
+  if (!groupId) {
+    return [activeTab, setActiveTab];
+  }
+
+  const setGroupTab = useCallback(
     (value: string) => {
       setGroup(groupId, value);
     },
-    [groupId]
+    [groupId, setGroup]
   );
 
-  return [activeGroupTab, handleSetGroupTab];
-}
-
-export function useIsClient() {
-  const [isClient, setClient] = useState(false);
-
-  useEffect(() => {
-    setClient(true);
-  }, []);
-
-  return { isClient, key: isClient ? "client" : "server" };
+  return [activeTab, setGroupTab];
 }

--- a/website/src/components/mdx/tabs/tab-groups.tsx
+++ b/website/src/components/mdx/tabs/tab-groups.tsx
@@ -30,7 +30,9 @@ export const TabGroupProvider: FC = ({ children }) => {
   const [groups, setGroups] = useState<GroupMap>({});
 
   const handleSetGroup: SetGroup = (groupId, value) => {
-    if (groups[groupId] === value) return;
+    if (groups[groupId] === value) {
+      return;
+    }
 
     setGroups({ ...groups, [groupId]: value });
 
@@ -53,9 +55,11 @@ export function useActiveTab(
   groupId?: string
 ): TabGroupReturn {
   const { groups, setGroup } = useContext(TabGroupContext);
-  const [activeTab, setActiveTab] = useState(defaultValue);
+  const localTabState = useState(defaultValue);
 
-  if (!groupId) return [activeTab, setActiveTab];
+  if (!groupId) {
+    return localTabState;
+  }
 
   const activeGroupTab = useMemo(() => {
     let value: string | null | undefined = groups[groupId];

--- a/website/src/components/mdx/tabs/tabs.tsx
+++ b/website/src/components/mdx/tabs/tabs.tsx
@@ -7,7 +7,7 @@ import React, {
 import { List } from "./list";
 import { Panel, PanelProps } from "./panel";
 import { Tab, TabProps } from "./tab";
-import { useActiveTab } from "./tab-groups";
+import { useActiveTab, useIsClient } from "./tab-groups";
 
 interface TabsContext {
   activeTab: string;
@@ -33,10 +33,12 @@ export const Tabs: FunctionComponent<TabsProps> & TabsComposition = ({
   groupId,
   children,
 }) => {
+  const { key } = useIsClient();
   const [activeTab, setActiveTab] = useActiveTab(defaultValue, groupId);
 
   return (
     <TabsContext.Provider
+      key={key}
       value={{
         activeTab,
         setActiveTab,

--- a/website/src/components/mdx/tabs/tabs.tsx
+++ b/website/src/components/mdx/tabs/tabs.tsx
@@ -3,12 +3,11 @@ import React, {
   FunctionComponent,
   ReactNode,
   useContext,
-  useMemo,
-  useState,
 } from "react";
-import { Tab, TabProps } from "./tab";
-import { Panel, PanelProps } from "./panel";
 import { List } from "./list";
+import { Panel, PanelProps } from "./panel";
+import { Tab, TabProps } from "./tab";
+import { useActiveTab } from "./tab-groups";
 
 interface TabsContext {
   activeTab: string;
@@ -25,25 +24,24 @@ const TabsContext = createContext<TabsContext | undefined>(undefined);
 
 export interface TabsProps {
   defaultValue: string;
+  groupId?: string;
   children: ReactNode;
 }
 
 export const Tabs: FunctionComponent<TabsProps> & TabsComposition = ({
   defaultValue,
+  groupId,
   children,
 }) => {
-  const [activeTab, setActiveTab] = useState(defaultValue);
-
-  const memoizedContextValue = useMemo(
-    () => ({
-      activeTab,
-      setActiveTab,
-    }),
-    [activeTab, setActiveTab]
-  );
+  const [activeTab, setActiveTab] = useActiveTab(defaultValue, groupId);
 
   return (
-    <TabsContext.Provider value={memoizedContextValue}>
+    <TabsContext.Provider
+      value={{
+        activeTab,
+        setActiveTab,
+      }}
+    >
       {children}
     </TabsContext.Provider>
   );

--- a/website/src/components/mdx/tabs/tabs.tsx
+++ b/website/src/components/mdx/tabs/tabs.tsx
@@ -23,9 +23,9 @@ export interface TabsComposition {
 const TabsContext = createContext<TabsContext | undefined>(undefined);
 
 export interface TabsProps {
-  defaultValue: string;
-  groupId?: string;
-  children: ReactNode;
+  readonly defaultValue: string;
+  readonly groupId?: string;
+  readonly children: ReactNode;
 }
 
 export const Tabs: FunctionComponent<TabsProps> & TabsComposition = ({

--- a/website/src/components/mdx/tabs/tabs.tsx
+++ b/website/src/components/mdx/tabs/tabs.tsx
@@ -7,7 +7,7 @@ import React, {
 import { List } from "./list";
 import { Panel, PanelProps } from "./panel";
 import { Tab, TabProps } from "./tab";
-import { useActiveTab, useIsClient } from "./tab-groups";
+import { useActiveTab } from "./tab-groups";
 
 interface TabsContext {
   activeTab: string;
@@ -33,12 +33,10 @@ export const Tabs: FunctionComponent<TabsProps> & TabsComposition = ({
   groupId,
   children,
 }) => {
-  const { key } = useIsClient();
   const [activeTab, setActiveTab] = useActiveTab(defaultValue, groupId);
 
   return (
     <TabsContext.Provider
-      key={key}
       value={{
         activeTab,
         setActiveTab,


### PR DESCRIPTION
This allows to specify a `groupId` on the `Tabs` component. Changes to a tab with this `groupId` will propagate to all other tabs with that `groupId`. The selection is also persisted in the localStorage and the last selection is restored on the next page visit.

<img src="https://user-images.githubusercontent.com/45513122/118553498-b10b8e00-b760-11eb-9359-350c9c78bca9.gif" height="750px" />

I was inspired to include this after I've seen it while playing around with Docusaurus. I think this is a nice little UX improvement.
