### PR TITLE
Fix Release-Drafter

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,16 @@
+"🌶️ green donut":
+  - "src/GreenDonut/**/*"
+"🌶️ hot chocolate":
+  - "src/HotChocolate/**/*"
+"🌶️ marshmallow pie":
+  - "src/MarshmallowPie/**/*"
+"🌶️ strawberry shake":
+  - "src/StrawberryShake/**/*"
+"🌶️ website":
+  - any: ['website/**/*', '!website/src/docs/**/*.md']
+"📚 documentation":
+  - "website/src/docs/**/*.md"
+"🧰 maintenance":
+  - ".build/**/*"
+  - ".github/**/*"
+  - ".devops/**/*"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
+commitish: main
 change-template: '- $TITLE by @$AUTHOR (#$NUMBER)'
 no-changes-template: '- No changes'
 categories:
@@ -27,45 +28,9 @@ categories:
   - title: '🧰 Maintenance'
     labels:
       - '🧰 maintenance'
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
 template: |
   $CHANGES
 
   ## 👨🏼‍💻 Contributors
 
   $CONTRIBUTORS
-autolabeler:
-  - label: '🌶️ banana cake pop'
-    files:
-      - 'src/BananaCakePop'
-  - label: '🌶️ green donut'
-    files:
-      - 'src/GreenDonut'
-  - label: '🌶️ hot chocolate'
-    files:
-      - 'src/HotChocolate'
-  - label: '🌶️ marshmallow pie'
-    files:
-      - 'src/MarshmallowPie'
-  - label: '🌶️ strawberry shake'
-    files:
-      - 'src/StrawberryShake'
-  - label: '🌶️ website'
-    files:
-      - 'website'
-  - label: '🧰 maintenance'
-    files:
-      - '.build/**/*'
-      - '.github/**/*'
-      - '.devops/**/*'
-      - '.vscode/**/*'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+
+on:
+- pull_request_target
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@main
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}" 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,15 +4,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   workflow_dispatch:
 
 jobs:
-  update_release_draft:
+  release-drafter:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
At the moment the Release-Drafter runs for every PR that is opened. This causes un-merged changes to be displayed in the release draft.

### Summary of changes 
- Splits labeling of PRs and drafting of releases into two separate GitHub actions with different triggers
  - The PR labeler runs for [every PR change](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target)
  - The release drafter only runs when changes are pushed to `main` (or when manually invoked)
- Documentation changes are now automatically labeled