### PR TITLE
Allow resolvers to return null instead of Task<TResult>

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Extensions/ResolveObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Extensions/ResolveObjectFieldDescriptorExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using HotChocolate.Resolvers;
@@ -76,7 +76,7 @@ namespace HotChocolate.Types
 
         public static IObjectFieldDescriptor Resolve<TResult>(
             this IObjectFieldDescriptor descriptor,
-            Func<IResolverContext, Task<TResult>> resolver)
+            Func<IResolverContext, Task<TResult>?> resolver)
         {
             if (descriptor is null)
             {
@@ -91,7 +91,7 @@ namespace HotChocolate.Types
             return descriptor.Resolve(
                 async ctx =>
                 {
-                    Task<TResult> resolverTask = resolver(ctx);
+                    Task<TResult>? resolverTask = resolver(ctx);
                     if (resolverTask is null)
                     {
                         return default;
@@ -158,7 +158,7 @@ namespace HotChocolate.Types
 
         public static IObjectFieldDescriptor Resolve<TResult>(
             this IObjectFieldDescriptor descriptor,
-            Func<Task<TResult>> resolver)
+            Func<Task<TResult>?> resolver)
         {
             if (descriptor is null)
             {
@@ -173,7 +173,7 @@ namespace HotChocolate.Types
             return descriptor.Resolve(
                 async ctx =>
                 {
-                    Task<TResult> resolverTask = resolver();
+                    Task<TResult>? resolverTask = resolver();
                     if (resolverTask is null)
                     {
                         return default;
@@ -224,7 +224,7 @@ namespace HotChocolate.Types
 
         public static IObjectFieldDescriptor Resolve<TResult>(
             this IObjectFieldDescriptor descriptor,
-            Func<IResolverContext, CancellationToken, Task<TResult>> resolver)
+            Func<IResolverContext, CancellationToken, Task<TResult>?> resolver)
         {
             if (descriptor is null)
             {
@@ -239,7 +239,7 @@ namespace HotChocolate.Types
             return descriptor.Resolve(
                  async ctx =>
                 {
-                    Task<TResult> resolverTask = resolver(ctx, ctx.RequestAborted);
+                    Task<TResult>? resolverTask = resolver(ctx, ctx.RequestAborted);
                     if (resolverTask is null)
                     {
                         return default;


### PR DESCRIPTION
Async resolver methods are allowed to return null to bail out early, like this:

```c#
ctx.Field("somefield").Resolve(ctx => {
  var condition = ...;
  if(!condition) {
    return null;
  }
  return _service.RunSomeTask(); // returns Task
});
```

However, the typings of the Resolve methods involved here do not allow returning null instead of `Task<TResult>`, even when the code handles null fine. I've extended the typings to allow null explicitly.