### PR TITLE
Draft full scan skipping

### DIFF
--- a/src/HotChocolate/Core/src/Types.CursorPagination/CursorPagingHandler.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/CursorPagingHandler.cs
@@ -15,11 +15,15 @@ namespace HotChocolate.Types.Pagination
             {
                 DefaultPageSize = MaxPageSize;
             }
+
+            IncludeTotalCount = options.IncludeTotalCount ?? PagingDefaults.IncludeTotalCount;
         }
 
         protected int DefaultPageSize { get; }
 
         protected int MaxPageSize { get; }
+
+        protected bool IncludeTotalCount { get; }
 
         public void ValidateContext(IResolverContext context)
         {

--- a/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
@@ -59,10 +59,10 @@ namespace HotChocolate.Types.Pagination
                 .ConfigureAwait(false);
 
             var pageInfo = new ConnectionPageInfo(
-                lastEdge?.Index < totalCount - 1,
-                firstEdge?.Index > 0,
-                firstEdge?.Cursor,
-                lastEdge?.Cursor,
+                hasNextPage: lastEdge?.Index < totalCount - 1,
+                hasPreviousPage: firstEdge?.Index > 0,
+                startCursor: firstEdge?.Cursor,
+                endCursor: lastEdge?.Cursor,
                 totalCount);
 
             return new Connection<TEntity>(

--- a/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
@@ -55,7 +55,10 @@ namespace HotChocolate.Types.Pagination
                 ? null
                 : selectedEdges[selectedEdges.Count - 1];
 
-            var totalCount = await GetTotalCountAsync(source, lastEdge, cancellationToken)
+            var pageSize = arguments.First ?? arguments.Last ?? DefaultPageSize;
+
+            var totalCount = await GetTotalCountAsync(
+                    source, pageSize, lastEdge, cancellationToken)
                 .ConfigureAwait(false);
 
             var pageInfo = new ConnectionPageInfo(
@@ -116,7 +119,7 @@ namespace HotChocolate.Types.Pagination
             return edges;
         }
 
-        private async Task<int?> GetTotalCountAsync(IQueryable<TEntity> source, IndexEdge<TEntity>? lastEdge, CancellationToken cancellationToken)
+        private async Task<int?> GetTotalCountAsync(IQueryable<TEntity> source, int pageSize, IndexEdge<TEntity>? lastEdge, CancellationToken cancellationToken)
         {
             if (IncludeTotalCount)
             {
@@ -128,8 +131,7 @@ namespace HotChocolate.Types.Pagination
                 return null;
             }
 
-            // TODO: DefaultPageSize vs MaxPageSize
-            source = source.Skip(lastEdge.Index).Take(DefaultPageSize + 1);
+            source = source.Skip(lastEdge.Index).Take(pageSize + 1);
 
             var count = await Task.Run(source.Count, cancellationToken).ConfigureAwait(false);
 

--- a/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
@@ -116,7 +116,7 @@ namespace HotChocolate.Types.Pagination
             return edges;
         }
 
-        private async Task<int> GetTotalCountAsync(IQueryable<TEntity> source, IndexEdge<TEntity>? lastEdge, CancellationToken cancellationToken)
+        private async Task<int?> GetTotalCountAsync(IQueryable<TEntity> source, IndexEdge<TEntity>? lastEdge, CancellationToken cancellationToken)
         {
             if (IncludeTotalCount)
             {
@@ -125,7 +125,7 @@ namespace HotChocolate.Types.Pagination
 
             if (lastEdge is null)
             {
-                return 0;
+                return null;
             }
 
             // TODO: DefaultPageSize vs MaxPageSize

--- a/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
@@ -119,7 +119,11 @@ namespace HotChocolate.Types.Pagination
             return edges;
         }
 
-        private async Task<int?> GetTotalCountAsync(IQueryable<TEntity> source, int pageSize, IndexEdge<TEntity>? lastEdge, CancellationToken cancellationToken)
+        private async Task<int?> GetTotalCountAsync(
+            IQueryable<TEntity> source,
+            int pageSize,
+            IndexEdge<TEntity>? lastEdge,
+            CancellationToken cancellationToken)
         {
             if (IncludeTotalCount)
             {

--- a/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
@@ -55,7 +55,7 @@ namespace HotChocolate.Types.Pagination
                 ? null
                 : selectedEdges[selectedEdges.Count - 1];
 
-            var totalCount = await GetTotalCountAsync(source, lastEdge ?? firstEdge, cancellationToken)
+            var totalCount = await GetTotalCountAsync(source, lastEdge, cancellationToken)
                 .ConfigureAwait(false);
 
             var pageInfo = new ConnectionPageInfo(
@@ -116,24 +116,24 @@ namespace HotChocolate.Types.Pagination
             return edges;
         }
 
-        private async Task<int> GetTotalCountAsync(IQueryable<TEntity> source, IndexEdge<TEntity>? indexEdge, CancellationToken cancellationToken)
+        private async Task<int> GetTotalCountAsync(IQueryable<TEntity> source, IndexEdge<TEntity>? lastEdge, CancellationToken cancellationToken)
         {
             if (IncludeTotalCount)
             {
                 return await Task.Run(source.Count, cancellationToken).ConfigureAwait(false);
             }
 
-            if (indexEdge is not null)
+            if (lastEdge is null)
             {
-                source = source.Skip(indexEdge.Index);
+                return 0;
             }
 
             // TODO: DefaultPageSize vs MaxPageSize
-            source = source.Take(DefaultPageSize + 1);
+            source = source.Skip(lastEdge.Index).Take(DefaultPageSize + 1);
 
             var count = await Task.Run(source.Count, cancellationToken).ConfigureAwait(false);
 
-            return count + indexEdge?.Index ?? 0;
+            return count + lastEdge.Index;
         }
 
         protected virtual IQueryable<TEntity> GetFirstEdges(


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

Draft for limiting scan for `hasNextPage`

Closes #2934 

- if `IncludeTotalCount` - run as before
- If lastEdge is null - do not execute Count. `lastEdge?.Index < totalCount - 1` will always false
- If lastEdge exists - Take only slice + 1 after lastEdge.Index to check next page

TODOs:
- What is the next page? Does it `(first or last) ?? default`?