### PR TITLE
Fix incorrect schema example in Mutation page, add notes regarding nested input types

### DIFF
--- a/website/src/docs/hotchocolate/defining-a-schema/input-object-types.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/input-object-types.md
@@ -154,3 +154,5 @@ public class Startup
 
 </ExampleTabs.Schema>
 </ExampleTabs>
+
+⚠ Object types nested inside of an input object type need to also be declared as input types.

--- a/website/src/docs/hotchocolate/defining-a-schema/mutations.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/mutations.md
@@ -136,8 +136,6 @@ public class Startup
 
 </ExampleTabs.Schema>
 </ExampleTabs>
-  
-**Please note**: If there are any nested object inside `input` types - they also should be declared as `input`. Otherwise this will lead to incorrect introspection schema.
 
 # Transactions
 

--- a/website/src/docs/hotchocolate/defining-a-schema/mutations.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/mutations.md
@@ -119,7 +119,7 @@ public class Startup
                   addBook(input: BookInput): Book
                 }
 
-                type BookInput {
+                input BookInput {
                   title: String
                   author: String
                 }
@@ -136,6 +136,8 @@ public class Startup
 
 </ExampleTabs.Schema>
 </ExampleTabs>
+  
+**Please note**: If there are any nested object inside `input` types - they also should be declared as `input`. Otherwise this will lead to incorrect introspection schema.
 
 # Transactions
 


### PR DESCRIPTION
Summary:

- Fix incorrect schema in Schema-first example of Mutations setup ([this page](https://chillicream.com/docs/hotchocolate/defining-a-schema/mutations/#usage))
- Add a note to describe a potential issue that will cause introspection schema to be invalid without proper validation and description from GraphQL/Playground side
Closes #3805