### PR TITLE
Fixed typo in filtering.md

### DIFF
--- a/website/src/docs/hotchocolate/fetching-data/filtering.md
+++ b/website/src/docs/hotchocolate/fetching-data/filtering.md
@@ -52,7 +52,7 @@ To use filtering you need to register it on the schema:
 
 ```csharp
 services.AddGraphQLServer()
-  // Your schmea configuration
+  // Your schema configuration
   .AddFiltering();
 ```
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Detail 1
- Detail 2

Closes #bugnumber (in this specific format)
