### PR TITLE
Fix UrlSerializer for absolute Urls

### DIFF
--- a/src/StrawberryShake/Client/src/Core/Serialization/UrlSerializer.cs
+++ b/src/StrawberryShake/Client/src/Core/Serialization/UrlSerializer.cs
@@ -28,6 +28,6 @@ namespace StrawberryShake.Serialization
             return uri;
         }
 
-        protected override string Format(Uri runtimeValue) => runtimeValue.AbsolutePath;
+        protected override string Format(Uri runtimeValue) => runtimeValue.ToString();
     }
 }


### PR DESCRIPTION
Current code always serializes Url as relative, but the proposed code serializes both relative and absolute Urls correctly.