### PR TITLE
Use lowercasing on the documentation for the filtering

### DIFF
--- a/website/src/docs/hotchocolate/fetching-data/filtering.md
+++ b/website/src/docs/hotchocolate/fetching-data/filtering.md
@@ -199,12 +199,12 @@ public class QueryType : ObjectType<Query>
 </ExampleTabs.Schema>
 </ExampleTabs>
 
-# AND / OR Filter
+# "and" / "or" Filter
 
 There are two built in fields.
 
-- `AND`: Every condition has to be valid
-- `OR` : At least one condition has to be valid
+- `and`: Every condition has to be valid
+- `or` : At least one condition has to be valid
 
 Example:
 
@@ -213,7 +213,7 @@ query {
   posts(
     first: 5
     where: {
-      OR: [{ title: { contains: "Doe" } }, { title: { contains: "John" } }]
+      or: [{ title: { contains: "Doe" } }, { title: { contains: "John" } }]
     }
   ) {
     edges {
@@ -226,13 +226,13 @@ query {
 }
 ```
 
-**⚠️ OR does not work when you use it like this: **
+**⚠️ "or" does not work when you use it like this: **
 
 ```graphql
 query {
   posts(
     first: 5
-    where: { title: { contains: "John", OR: { title: { contains: "Doe" } } } }
+    where: { title: { contains: "John", or: { title: { contains: "Doe" } } } }
   ) {
     edges {
       node {


### PR DESCRIPTION
When I was using HotChocolate on my own implementation I realized the only way to use the *or* and the *and* operators are with lowercase instead of the example that is on the documentation with uppercasing.

The displayed message is: **"The specified input object field `OR` does not exist."**

![image](https://user-images.githubusercontent.com/11998636/124032719-51470a80-d9cf-11eb-80be-61b72f20e0ac.png)

This is very confusing because taking the example literally will not work.

Summary of the changes

- Replace "AND" and "OR" with "and" and "or" using lowercasing
