### PR TITLE
Use up-to-date versions in templates

### DIFF
--- a/.build/Build.Publish.cs
+++ b/.build/Build.Publish.cs
@@ -26,7 +26,12 @@ partial class Build : NukeBuild
         .DependsOn(PackLocal)
         .Produces(PackageDirectory / "*.nupkg")
         .Produces(PackageDirectory / "*.snupkg")
-        .Requires(() => Configuration.Equals(Release))
+        .Requires(() => Configuration.Equals(Release));
+        
+
+    Target PackLocal => _ => _
+        .Produces(PackageDirectory / "*.nupkg")
+        .Produces(PackageDirectory / "*.snupkg")
         .Executes(() =>
         {
             var projFile = File.ReadAllText(StarWarsProj);
@@ -34,11 +39,7 @@ partial class Build : NukeBuild
 
             projFile = File.ReadAllText(EmptyServerProj);
             File.WriteAllText(EmptyServerProj, projFile.Replace("11.1.0", GitVersion.SemVer));
-        });
-
-    Target PackLocal => _ => _
-        .Produces(PackageDirectory / "*.nupkg")
-        .Produces(PackageDirectory / "*.snupkg")
+        })
         .Executes(() =>
         {
             DotNetBuildSonarSolution(

--- a/templates/Server/content/Startup.cs
+++ b/templates/Server/content/Startup.cs
@@ -18,8 +18,6 @@ namespace HotChocolate.Server.Template
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            // If you need dependency injection with your query object add your query type as a services.
-            // services.AddSingleton<Query>();
             services
                 .AddGraphQLServer()
                 .AddQueryType<Query>();
@@ -37,9 +35,6 @@ namespace HotChocolate.Server.Template
 
             app.UseEndpoints(endpoints =>
             {
-                // By default the GraphQL server is mapped to /graphql
-                // This route also provides you with our GraphQL IDE. 
-                // In order to configure the GraphQL IDE use endpoints.MapGraphQL().WithToolOptions(...).
                 endpoints.MapGraphQL();
             });
         }


### PR DESCRIPTION
We were previously writing the current version into the `.csproj` files **AFTER** we had already packed the `.nupkg` files.
I moved the code to the `PackLocal` step and verified that the resulting `.nupkg` files contained the correct versions.

Closes #3896 
