### PR TITLE
fix: corrected 'hash' spelling in exception message

### DIFF
--- a/src/HotChocolate/Language/src/Language.Utf8/DocumentHashProviderBase.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/DocumentHashProviderBase.cs
@@ -35,7 +35,7 @@ namespace HotChocolate.Language
                             .Replace("-", string.Empty);
                     default:
                         throw new NotSupportedException(
-                            "The specified has format is not supported.");
+                            "The specified hash format is not supported.");
                 }
             }
             finally


### PR DESCRIPTION
- corrected 'hash' spelling in exception message
