### PR TITLE
Rename ID to GlobalId

### DIFF
--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Attendees/AttendeeQueries.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Attendees/AttendeeQueries.cs
@@ -16,19 +16,19 @@ namespace HotChocolate.ConferencePlanner.Attendees
         [UseApplicationDbContext]
         [UsePaging]
         public IQueryable<Attendee> GetAttendees(
-            [ScopedService] ApplicationDbContext context) => 
+            [ScopedService] ApplicationDbContext context) =>
             context.Attendees;
 
         public Task<Attendee> GetAttendeeByIdAsync(
-            [ID(nameof(Attendee))]int id,
+            [GlobalId(nameof(Attendee))] int id,
             AttendeeByIdDataLoader attendeeById,
-            CancellationToken cancellationToken) => 
+            CancellationToken cancellationToken) =>
             attendeeById.LoadAsync(id, cancellationToken);
 
         public async Task<IEnumerable<Attendee>> GetAttendeesByIdAsync(
-            [ID(nameof(Attendee))]int[] ids,
+            [GlobalId(nameof(Attendee))] int[] ids,
             AttendeeByIdDataLoader attendeeById,
-            CancellationToken cancellationToken) => 
+            CancellationToken cancellationToken) =>
             await attendeeById.LoadAsync(ids, cancellationToken);
     }
 }

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Attendees/AttendeeSubscriptions.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Attendees/AttendeeSubscriptions.cs
@@ -15,7 +15,7 @@ namespace HotChocolate.ConferencePlanner.Attendees
     {
         [Subscribe(With = nameof(SubscribeToOnAttendeeCheckedInAsync))]
         public SessionAttendeeCheckIn OnAttendeeCheckedIn(
-            [ID(nameof(Session))] int sessionId,
+            [GlobalId(nameof(Session))] int sessionId,
             [EventMessage] int attendeeId,
             SessionByIdDataLoader sessionById,
             CancellationToken cancellationToken) =>

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Attendees/CheckInAttendeeInput.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Attendees/CheckInAttendeeInput.cs
@@ -4,8 +4,8 @@ using HotChocolate.Types.Relay;
 namespace HotChocolate.ConferencePlanner.Attendees
 {
     public record CheckInAttendeeInput(
-        [ID(nameof(Session))]
+        [GlobalId(nameof(Session))]
         int SessionId,
-        [ID(nameof(Attendee))]
+        [GlobalId(nameof(Attendee))]
         int AttendeeId);
 }

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Attendees/SessionAttendeeCheckIn.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Attendees/SessionAttendeeCheckIn.cs
@@ -17,10 +17,10 @@ namespace HotChocolate.ConferencePlanner.Attendees
             SessionId = sessionId;
         }
 
-        [ID(nameof(Attendee))]
+        [GlobalId(nameof(Attendee))]
         public int AttendeeId { get; }
 
-        [ID(nameof(Session))]
+        [GlobalId(nameof(Session))]
         public int SessionId { get; }
 
         [UseApplicationDbContext]

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/AddSessionInput.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/AddSessionInput.cs
@@ -7,6 +7,6 @@ namespace HotChocolate.ConferencePlanner.Sessions
     public record AddSessionInput(
         string Title,
         string? Abstract,
-        [ID(nameof(Speaker))]
+        [GlobalId(nameof(Speaker))]
         IReadOnlyList<int> SpeakerIds);
 }

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/RenameSessionInput.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/RenameSessionInput.cs
@@ -4,6 +4,6 @@ using HotChocolate.Types.Relay;
 namespace HotChocolate.ConferencePlanner.Sessions
 {
     public record RenameSessionInput(
-        [ID(nameof(Session))] int SessionId,
+        [GlobalId(nameof(Session))] int SessionId,
         string Title);
 }

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/ScheduleSessionInput.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/ScheduleSessionInput.cs
@@ -5,9 +5,9 @@ using HotChocolate.Types.Relay;
 namespace HotChocolate.ConferencePlanner.Sessions
 {
     public record ScheduleSessionInput(
-        [ID(nameof(Session))]
+        [GlobalId(nameof(Session))]
         int SessionId,
-        [ID(nameof(Track))]
+        [GlobalId(nameof(Track))]
         int TrackId,
         DateTimeOffset StartTime,
         DateTimeOffset EndTime);

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/SessionExtensions.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/SessionExtensions.cs
@@ -62,9 +62,9 @@ namespace HotChocolate.ConferencePlanner.Sessions
             return await trackById.LoadAsync(session.TrackId.Value, cancellationToken);
         }
 
-        [ID(nameof(Track))]
+        [GlobalId(nameof(Track))]
         [BindMember(nameof(Session.TrackId))]
-        public int? TrackId([Parent] Session session) => session.TrackId; 
+        public int? TrackId([Parent] Session session) => session.TrackId;
 
         [NodeResolver]
         public Task<Session> GetSessionAsync(

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/SessionQueries.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Sessions/SessionQueries.cs
@@ -24,13 +24,13 @@ namespace HotChocolate.ConferencePlanner.Sessions
             context.Sessions;
 
         public Task<Session> GetSessionByIdAsync(
-            [ID(nameof(Session))] int id,
+            [GlobalId(nameof(Session))] int id,
             SessionByIdDataLoader sessionById,
             CancellationToken cancellationToken) =>
             sessionById.LoadAsync(id, cancellationToken);
 
         public async Task<IEnumerable<Session>> GetSessionsByIdAsync(
-            [ID(nameof(Session))] int[] ids,
+            [GlobalId(nameof(Session))] int[] ids,
             SessionByIdDataLoader sessionById,
             CancellationToken cancellationToken) =>
             await sessionById.LoadAsync(ids, cancellationToken);

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Speakers/ModifySpeakerInput.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Speakers/ModifySpeakerInput.cs
@@ -5,7 +5,7 @@ using HotChocolate.Types.Relay;
 namespace HotChocolate.ConferencePlanner.Speakers
 {
     public record ModifySpeakerInput(
-        [ID(nameof(Speaker))] 
+        [GlobalId(nameof(Speaker))]
         int Id,
         Optional<string?> Name,
         Optional<string?> Bio,

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Speakers/SpeakerQueries.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Speakers/SpeakerQueries.cs
@@ -19,13 +19,13 @@ namespace HotChocolate.ConferencePlanner.Speakers
             context.Speakers.OrderBy(t => t.Name);
 
         public Task<Speaker> GetSpeakerByIdAsync(
-            [ID(nameof(Speaker))]int id,
+            [GlobalId(nameof(Speaker))] int id,
             SpeakerByIdDataLoader dataLoader,
             CancellationToken cancellationToken) =>
             dataLoader.LoadAsync(id, cancellationToken);
 
         public async Task<IEnumerable<Speaker>> GetSpeakersByIdAsync(
-            [ID(nameof(Speaker))]int[] ids,
+            [GlobalId(nameof(Speaker))] int[] ids,
             SpeakerByIdDataLoader dataLoader,
             CancellationToken cancellationToken) =>
             await dataLoader.LoadAsync(ids, cancellationToken);

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Tracks/RenameTrackInput.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Tracks/RenameTrackInput.cs
@@ -3,5 +3,5 @@ using HotChocolate.Types.Relay;
 
 namespace HotChocolate.ConferencePlanner.Tracks
 {
-    public record RenameTrackInput([ID(nameof(Track))] int Id, string Name);
+    public record RenameTrackInput([GlobalId(nameof(Track))] int Id, string Name);
 }

--- a/src/HotChocolate/Benchmarks/src/ConferenceApp/Tracks/TrackQueries.cs
+++ b/src/HotChocolate/Benchmarks/src/ConferenceApp/Tracks/TrackQueries.cs
@@ -35,13 +35,13 @@ namespace HotChocolate.ConferencePlanner.Tracks
             await context.Tracks.Where(t => names.Contains(t.Name)).ToListAsync(cancellationToken);
 
         public Task<Track> GetTrackByIdAsync(
-            [ID(nameof(Track))] int id,
+            [GlobalId(nameof(Track))] int id,
             TrackByIdDataLoader trackById,
             CancellationToken cancellationToken) =>
             trackById.LoadAsync(id, cancellationToken);
 
         public async Task<IEnumerable<Track>> GetSessionsByIdAsync(
-            [ID(nameof(Track))] int[] ids,
+            [GlobalId(nameof(Track))] int[] ids,
             TrackByIdDataLoader trackById,
             CancellationToken cancellationToken) =>
             await trackById.LoadAsync(ids, cancellationToken);

--- a/src/HotChocolate/Core/src/Execution/PublicAPI.Unshipped.txt
+++ b/src/HotChocolate/Core/src/Execution/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ HotChocolate.Execution.Configuration.RequestExecutorSetup.TypeModules.get -> Sys
 HotChocolate.Execution.Instrumentation.IDiagnosticEvents.DispatchBatch(HotChocolate.Execution.IRequestContext! context) -> HotChocolate.Execution.Instrumentation.IActivityScope!
 HotChocolate.Execution.Instrumentation.IDiagnosticEvents.StartProcessing(HotChocolate.Execution.IRequestContext! context) -> void
 HotChocolate.Execution.Instrumentation.IDiagnosticEvents.StopProcessing(HotChocolate.Execution.IRequestContext! context) -> void
+HotChocolate.Execution.IRequestContext.Clone() -> HotChocolate.Execution.IRequestContext!
+HotChocolate.Execution.IRequestContext.IsValidDocument.get -> bool
 HotChocolate.Execution.Options.ComplexityAnalyzerSettings
 HotChocolate.Execution.Options.ComplexityAnalyzerSettings.ApplyDefaults.get -> bool
 HotChocolate.Execution.Options.ComplexityAnalyzerSettings.ApplyDefaults.set -> void

--- a/src/HotChocolate/Core/src/Types.CursorPagination/PublicAPI.Unshipped.txt
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/PublicAPI.Unshipped.txt
@@ -4,7 +4,7 @@
 *REMOVED*virtual HotChocolate.Types.Pagination.QueryableCursorPagingHandler<TEntity>.GetLastEdges(System.Linq.IQueryable<TEntity>! edges, int last, ref int offset) -> System.Linq.IQueryable<TEntity>!
 HotChocolate.Types.UsePagingAttribute.AllowBackwardPagination.get -> bool
 HotChocolate.Types.UsePagingAttribute.AllowBackwardPagination.set -> void
-static HotChocolate.Types.PagingObjectFieldDescriptorExtensions.AddPagingArguments(this HotChocolate.Types.IInterfaceFieldDescriptor! descriptor, bool allowBackwardPagination = true) -> HotChocolate.Types.IInterfaceFieldDescriptor!
-static HotChocolate.Types.PagingObjectFieldDescriptorExtensions.AddPagingArguments(this HotChocolate.Types.IObjectFieldDescriptor! descriptor, bool allowBackwardPagination = true) -> HotChocolate.Types.IObjectFieldDescriptor!
+static HotChocolate.Types.PagingObjectFieldDescriptorExtensions.AddPagingArguments(this HotChocolate.Types.IInterfaceFieldDescriptor! descriptor, bool allowBackwardPagination) -> HotChocolate.Types.IInterfaceFieldDescriptor!
 *REMOVED*static HotChocolate.Types.PagingObjectFieldDescriptorExtensions.AddPagingArguments(this HotChocolate.Types.IInterfaceFieldDescriptor! descriptor) -> HotChocolate.Types.IInterfaceFieldDescriptor!
 *REMOVED*static HotChocolate.Types.PagingObjectFieldDescriptorExtensions.AddPagingArguments(this HotChocolate.Types.IObjectFieldDescriptor! descriptor) -> HotChocolate.Types.IObjectFieldDescriptor!
+static HotChocolate.Types.PagingObjectFieldDescriptorExtensions.AddPagingArguments(this HotChocolate.Types.IObjectFieldDescriptor! descriptor, bool allowBackwardPagination) -> HotChocolate.Types.IObjectFieldDescriptor!

--- a/src/HotChocolate/Core/src/Types/PublicAPI.Unshipped.txt
+++ b/src/HotChocolate/Core/src/Types/PublicAPI.Unshipped.txt
@@ -141,3 +141,19 @@ static HotChocolate.Types.ResolveObjectFieldDescriptorExtensions.Resolve<TResult
 ~HotChocolate.Types.Relay.MutationPayloadOptions.QueryFieldName.set -> void
 ~HotChocolate.Types.Relay.MutationPayloadOptions.MutationPayloadPredicate.get -> System.Func<HotChocolate.Types.INamedType, bool>
 ~HotChocolate.Types.Relay.MutationPayloadOptions.MutationPayloadPredicate.set -> void
+*REMOVED*static HotChocolate.Types.RelayIdFieldExtensions.ID(this HotChocolate.Types.IArgumentDescriptor! descriptor, HotChocolate.NameString typeName = default(HotChocolate.NameString)) -> HotChocolate.Types.IArgumentDescriptor!
+*REMOVED*static HotChocolate.Types.RelayIdFieldExtensions.ID(this HotChocolate.Types.IInputFieldDescriptor! descriptor, HotChocolate.NameString typeName = default(HotChocolate.NameString)) -> HotChocolate.Types.IInputFieldDescriptor!
+*REMOVED*static HotChocolate.Types.RelayIdFieldExtensions.ID(this HotChocolate.Types.IInterfaceFieldDescriptor! descriptor) -> HotChocolate.Types.IInterfaceFieldDescriptor!
+*REMOVED*static HotChocolate.Types.RelayIdFieldExtensions.ID(this HotChocolate.Types.IObjectFieldDescriptor! descriptor, HotChocolate.NameString typeName = default(HotChocolate.NameString)) -> HotChocolate.Types.IObjectFieldDescriptor!
+*REMOVED*HotChocolate.Types.Relay.IDAttribute
+*REMOVED*HotChocolate.Types.Relay.IDAttribute.IDAttribute(string? typeName = null) -> void
+*REMOVED*HotChocolate.Types.Relay.IDAttribute.TypeName.get -> HotChocolate.NameString
+*REMOVED*override HotChocolate.Types.Relay.IDAttribute.TryConfigure(HotChocolate.Types.Descriptors.IDescriptorContext! context, HotChocolate.Types.IDescriptor! descriptor, System.Reflection.ICustomAttributeProvider! element) -> void
+static HotChocolate.Types.RelayIdFieldExtensions.GlobalId(this HotChocolate.Types.IArgumentDescriptor! descriptor, HotChocolate.NameString typeName = default(HotChocolate.NameString)) -> HotChocolate.Types.IArgumentDescriptor!
+static HotChocolate.Types.RelayIdFieldExtensions.GlobalId(this HotChocolate.Types.IInputFieldDescriptor! descriptor, HotChocolate.NameString typeName = default(HotChocolate.NameString)) -> HotChocolate.Types.IInputFieldDescriptor!
+static HotChocolate.Types.RelayIdFieldExtensions.GlobalId(this HotChocolate.Types.IInterfaceFieldDescriptor! descriptor) -> HotChocolate.Types.IInterfaceFieldDescriptor!
+static HotChocolate.Types.RelayIdFieldExtensions.GlobalId(this HotChocolate.Types.IObjectFieldDescriptor! descriptor, HotChocolate.NameString typeName = default(HotChocolate.NameString)) -> HotChocolate.Types.IObjectFieldDescriptor!
+HotChocolate.Types.Relay.GlobalIdAttribute
+HotChocolate.Types.Relay.GlobalIdAttribute.GlobalIdAttribute(string? typeName = null) -> void
+HotChocolate.Types.Relay.GlobalIdAttribute.TypeName.get -> HotChocolate.NameString
+override HotChocolate.Types.Relay.GlobalIdAttribute.TryConfigure(HotChocolate.Types.Descriptors.IDescriptorContext! context, HotChocolate.Types.IDescriptor! descriptor, System.Reflection.ICustomAttributeProvider! element) -> void

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Attributes/GlobalIdAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Attributes/GlobalIdAttribute.cs
@@ -10,9 +10,9 @@ namespace HotChocolate.Types.Relay
         AttributeTargets.Parameter |
         AttributeTargets.Property |
         AttributeTargets.Method)]
-    public class IDAttribute : DescriptorAttribute
+    public class GlobalIdAttribute : DescriptorAttribute
     {
-        public IDAttribute(string? typeName = null)
+        public GlobalIdAttribute(string? typeName = null)
         {
             TypeName = typeName;
         }
@@ -27,16 +27,16 @@ namespace HotChocolate.Types.Relay
             switch (descriptor)
             {
                 case IInputFieldDescriptor d when element is PropertyInfo:
-                    d.ID(TypeName);
+                    d.GlobalId(TypeName);
                     break;
                 case IArgumentDescriptor d when element is ParameterInfo:
-                    d.ID(TypeName);
+                    d.GlobalId(TypeName);
                     break;
                 case IObjectFieldDescriptor d when element is MemberInfo:
-                    d.ID(TypeName);
+                    d.GlobalId(TypeName);
                     break;
                 case IInterfaceFieldDescriptor d when element is MemberInfo:
-                    d.ID();
+                    d.GlobalId();
                     break;
             }
         }

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Extensions/RelayIdFieldExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Extensions/RelayIdFieldExtensions.cs
@@ -18,7 +18,7 @@ namespace HotChocolate.Types
     {
         private static IdSerializer? _idSerializer;
 
-        public static IInputFieldDescriptor ID(
+        public static IInputFieldDescriptor GlobalId(
             this IInputFieldDescriptor descriptor,
             NameString typeName = default)
         {
@@ -34,7 +34,7 @@ namespace HotChocolate.Types
             return descriptor;
         }
 
-        public static IArgumentDescriptor ID(
+        public static IArgumentDescriptor GlobalId(
             this IArgumentDescriptor descriptor,
             NameString typeName = default)
         {
@@ -50,7 +50,7 @@ namespace HotChocolate.Types
             return descriptor;
         }
 
-        public static IObjectFieldDescriptor ID(
+        public static IObjectFieldDescriptor GlobalId(
             this IObjectFieldDescriptor descriptor,
             NameString typeName = default)
         {
@@ -69,7 +69,7 @@ namespace HotChocolate.Types
             return descriptor;
         }
 
-        public static IInterfaceFieldDescriptor ID(
+        public static IInterfaceFieldDescriptor GlobalId(
             this IInterfaceFieldDescriptor descriptor)
         {
             if (descriptor is null)

--- a/src/HotChocolate/Core/test/Types.Records.Tests/RecordsTests.cs
+++ b/src/HotChocolate/Core/test/Types.Records.Tests/RecordsTests.cs
@@ -58,7 +58,7 @@ namespace HotChocolate.Types
             public Person GetPerson() => new Person(1, "Michael");
         }
 
-        public record Person([ID] int Id, string Name);
+        public record Person([GlobalId] int Id, string Name);
 
         public class Query2
         {
@@ -66,6 +66,6 @@ namespace HotChocolate.Types
                 new DefaultValueTest(1, "Test");
         }
 
-        public record DefaultValueTest([ID] int Id, string Name = "ShouldBeDefaultValue");
+        public record DefaultValueTest([GlobalId] int Id, string Name = "ShouldBeDefaultValue");
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdAttributeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdAttributeTests.cs
@@ -309,32 +309,32 @@ namespace HotChocolate.Types.Relay
         [SuppressMessage("Performance", "CA1822:Mark members as static")]
         public class Query
         {
-            public string IntId([ID] int id) => id.ToString();
-            public string IntIdList([ID] int[] id) =>
+            public string IntId([GlobalId] int id) => id.ToString();
+            public string IntIdList([GlobalId] int[] id) =>
                 string.Join(", ", id.Select(t => t.ToString()));
 
-            public string NullableIntId([ID] int? id) => id?.ToString() ?? "null";
-            public string NullableIntIdList([ID] int?[] id) =>
+            public string NullableIntId([GlobalId] int? id) => id?.ToString() ?? "null";
+            public string NullableIntIdList([GlobalId] int?[] id) =>
                 string.Join(", ", id.Select(t => t?.ToString() ?? "null"));
 
-            public string StringId([ID] string id) => id;
-            public string StringIdList([ID] string[] id) =>
+            public string StringId([GlobalId] string id) => id;
+            public string StringIdList([GlobalId] string[] id) =>
                 string.Join(", ", id.Select(t => t.ToString()));
 
-            public string NullableStringId([ID] string? id) => id ?? "null";
-            public string NullableStringIdList([ID] string?[] id) =>
+            public string NullableStringId([GlobalId] string? id) => id ?? "null";
+            public string NullableStringIdList([GlobalId] string?[] id) =>
                 string.Join(", ", id.Select(t => t?.ToString() ?? "null"));
 
-            public string GuidId([ID] Guid id) => id.ToString();
-            public string GuidIdList([ID] IReadOnlyList<Guid> id) =>
+            public string GuidId([GlobalId] Guid id) => id.ToString();
+            public string GuidIdList([GlobalId] IReadOnlyList<Guid> id) =>
                 string.Join(", ", id.Select(t => t.ToString()));
 
-            public string NullableGuidId([ID] Guid? id) => id?.ToString() ?? "null";
-            public string NullableGuidIdList([ID] IReadOnlyList<Guid?> id) =>
+            public string NullableGuidId([GlobalId] Guid? id) => id?.ToString() ?? "null";
+            public string NullableGuidIdList([GlobalId] IReadOnlyList<Guid?> id) =>
                 string.Join(", ", id.Select(t => t?.ToString() ?? "null"));
 
-            public string InterceptedId([InterceptedID] [ID] int id) => id.ToString();
-            public string InterceptedIds([InterceptedID] [ID] int[] id) =>
+            public string InterceptedId([InterceptedID] [GlobalId] int id) => id.ToString();
+            public string InterceptedIds([InterceptedID] [GlobalId] int[] id) =>
                 string.Join(", ", id.Select(t => t.ToString()));
 
             public IFooPayload Foo(FooInput input) =>
@@ -365,18 +365,18 @@ namespace HotChocolate.Types.Relay
                 InterceptedIds = interceptedIds;
             }
 
-            [ID("Some")] public string SomeId { get; }
+            [GlobalId("Some")] public string SomeId { get; }
 
-            [ID("Some")] public string? SomeNullableId { get; }
+            [GlobalId("Some")] public string? SomeNullableId { get; }
 
-            [ID("Some")] public IReadOnlyList<int> SomeIds { get; }
+            [GlobalId("Some")] public IReadOnlyList<int> SomeIds { get; }
 
-            [ID("Some")] public IReadOnlyList<int?>? SomeNullableIds { get; }
+            [GlobalId("Some")] public IReadOnlyList<int?>? SomeNullableIds { get; }
 
-            [ID, InterceptedID]
+            [GlobalId, InterceptedID]
             public int? InterceptedId { get; }
 
-            [ID, InterceptedID]
+            [GlobalId, InterceptedID]
             public IReadOnlyList<int>? InterceptedIds { get; }
         }
 
@@ -398,13 +398,13 @@ namespace HotChocolate.Types.Relay
                 InterceptedIds = interceptedIds;
             }
 
-            [ID("Bar")] public string SomeId { get; }
+            [GlobalId("Bar")] public string SomeId { get; }
 
-            [ID("Bar")] public IReadOnlyList<int> SomeIds { get; }
+            [GlobalId("Bar")] public IReadOnlyList<int> SomeIds { get; }
 
-            [ID("Bar")] public string? SomeNullableId { get; }
+            [GlobalId("Bar")] public string? SomeNullableId { get; }
 
-            [ID("Bar")] public IReadOnlyList<int?>? SomeNullableIds { get; }
+            [GlobalId("Bar")] public IReadOnlyList<int?>? SomeNullableIds { get; }
 
             public int? InterceptedId { get; }
 
@@ -421,13 +421,13 @@ namespace HotChocolate.Types.Relay
 
         public interface IFooPayload
         {
-            [ID] string SomeId { get; }
+            [GlobalId] string SomeId { get; }
 
-            [ID] public string? SomeNullableId { get; }
+            [GlobalId] public string? SomeNullableId { get; }
 
-            [ID] IReadOnlyList<int> SomeIds { get; }
+            [GlobalId] IReadOnlyList<int> SomeIds { get; }
 
-            [ID] IReadOnlyList<int?>? SomeNullableIds { get; }
+            [GlobalId] IReadOnlyList<int?>? SomeNullableIds { get; }
 
             int? InterceptedId { get; }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdDescriptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdDescriptorTests.cs
@@ -91,15 +91,15 @@ namespace HotChocolate.Types.Relay
             {
                 descriptor
                     .Field(t => t.IntId(default))
-                    .Argument("id", a => a.ID());
+                    .Argument("id", a => a.GlobalId());
 
                 descriptor
                     .Field(t => t.StringId(default))
-                    .Argument("id", a => a.ID());
+                    .Argument("id", a => a.GlobalId());
 
                 descriptor
                     .Field(t => t.GuidId(default))
-                    .Argument("id", a => a.ID());
+                    .Argument("id", a => a.GlobalId());
 
                 descriptor
                     .Field(t => t.Foo(default))
@@ -114,7 +114,7 @@ namespace HotChocolate.Types.Relay
             {
                 descriptor
                     .Field(t => t.SomeId)
-                    .ID("Some");
+                    .GlobalId("Some");
             }
         }
 
@@ -126,7 +126,7 @@ namespace HotChocolate.Types.Relay
 
                 descriptor
                     .Field(t => t.SomeId)
-                    .ID("Bar");
+                    .GlobalId("Bar");
             }
         }
 
@@ -136,7 +136,7 @@ namespace HotChocolate.Types.Relay
             {
                 descriptor
                     .Field(t => t.SomeId)
-                    .ID();
+                    .GlobalId();
             }
         }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdMiddlewareTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdMiddlewareTests.cs
@@ -26,7 +26,7 @@ namespace HotChocolate.Types.Relay
 
         public class SomeQuery
         {
-            [ID]
+            [GlobalId]
             public string GetId() => "Hello";
 
             public string GetString() => "Hello";


### PR DESCRIPTION
- Renames `IDAttribute` to `GlobalIdAttribute`
- Renames `.ID()` to `.GlobalId()`

Closes #4001 
