### PR TITLE
Fix issue with Public API analyzer

### DIFF
--- a/.build/Build.PublicApiAnalyzer.cs
+++ b/.build/Build.PublicApiAnalyzer.cs
@@ -28,7 +28,13 @@ partial class Build : NukeBuild
         .DependsOn(Restore)
         .Executes(() =>
         {
-            DotNetBuildSonarSolution(AllSolutionFile);
+            Helpers.TryDelete(AllSolutionFile);
+            
+            DotNetBuildSonarSolution(
+                AllSolutionFile,
+                include: file =>
+                    !Path.GetFileNameWithoutExtension(file)
+                        .EndsWith("tests", StringComparison.OrdinalIgnoreCase));
 
             DotNetBuild(c => c
                 .SetProjectFile(AllSolutionFile)
@@ -38,10 +44,16 @@ partial class Build : NukeBuild
         });
 
     Target AddUnshippedApi => _ => _
-        .DependsOn(Restore)
+        .DependsOn(Restore) 
         .Executes(() =>
         {
-            DotNetBuildSonarSolution(AllSolutionFile);
+            Helpers.TryDelete(AllSolutionFile);
+
+            DotNetBuildSonarSolution(
+                AllSolutionFile,
+                include: file =>
+                    !Path.GetFileNameWithoutExtension(file)
+                        .EndsWith("tests", StringComparison.OrdinalIgnoreCase));
 
             // new we restore our local dotnet tools including dotnet-format
             DotNetToolRestore(c => c.SetProcessWorkingDirectory(RootDirectory));

--- a/.build/Build.PublicApiAnalyzer.cs
+++ b/.build/Build.PublicApiAnalyzer.cs
@@ -47,7 +47,7 @@ partial class Build : NukeBuild
         .DependsOn(Restore) 
         .Executes(() =>
         {
-            Helpers.TryDelete(AllSolutionFile);
+            TryDelete(AllSolutionFile);
 
             DotNetBuildSonarSolution(
                 AllSolutionFile,

--- a/.build/Build.cs
+++ b/.build/Build.cs
@@ -76,20 +76,14 @@ partial class Build : NukeBuild
     Target Reset => _ => _
         .Executes(() =>
         {
-            TryDelete(AllSolutionFile);
-            TryDelete(SonarSolutionFile);
-            TryDelete(TestSolutionFile);
-            TryDelete(PackSolutionFile);
+            Helpers.TryDelete(AllSolutionFile);
+            Helpers.TryDelete(SonarSolutionFile);
+            Helpers.TryDelete(TestSolutionFile);
+            Helpers.TryDelete(PackSolutionFile);
 
             DotNetBuildSonarSolution(AllSolutionFile);
             DotNetRestore(c => c.SetProjectFile(AllSolutionFile));
         });
 
-    private static void TryDelete(string fileName) 
-    {
-        if(File.Exists(fileName))
-        {
-            File.Delete(fileName);
-        }
-    }
+    
 }

--- a/.build/Build.cs
+++ b/.build/Build.cs
@@ -76,10 +76,10 @@ partial class Build : NukeBuild
     Target Reset => _ => _
         .Executes(() =>
         {
-            Helpers.TryDelete(AllSolutionFile);
-            Helpers.TryDelete(SonarSolutionFile);
-            Helpers.TryDelete(TestSolutionFile);
-            Helpers.TryDelete(PackSolutionFile);
+            TryDelete(AllSolutionFile);
+            TryDelete(SonarSolutionFile);
+            TryDelete(TestSolutionFile);
+            TryDelete(PackSolutionFile);
 
             DotNetBuildSonarSolution(AllSolutionFile);
             DotNetRestore(c => c.SetProjectFile(AllSolutionFile));

--- a/.build/Helpers.cs
+++ b/.build/Helpers.cs
@@ -96,4 +96,12 @@ class Helpers
 
         return list;
     }
+
+    public static void TryDelete(string fileName) 
+    {
+        if(File.Exists(fileName))
+        {
+            File.Delete(fileName);
+        }
+    }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <Authors>ChilliCream authors and contributors</Authors>
     <Company>ChilliCream</Company>
     <Copyright>Copyright &#169; 2021 ChilliCream (Michael &amp; Rafael Staib)</Copyright>
-    <PackageLicenseUrl>https://github.com/ChilliCream/hotchocolate/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/ChilliCream/hotchocolate/blob/main/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://chillicream.com</PackageProjectUrl>
     <PackageReleaseNotes>Release notes: https://github.com/ChilliCream/hotchocolate/releases/$(PackageVersion)</PackageReleaseNotes>
     <PackageTags>GraphQL ChilliCream</PackageTags>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
     <Version Condition="$(Version) == ''">0.0.0</Version>
-    <NoWarn>$(NoWarn);CS0436;RS0041</NoWarn>
+    <NoWarn>$(NoWarn);CS0436;RS0026;RS0027;RS0041</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/GreenDonut/src/Core/PublicAPI.Unshipped.txt
+++ b/src/GreenDonut/src/Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,16 @@
+abstract GreenDonut.BatchDataLoader<TKey, TValue>.LoadBatchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>!>!
+abstract GreenDonut.CacheDataLoader<TKey, TValue>.LoadSingleAsync(TKey key, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TValue>!
+abstract GreenDonut.GroupedDataLoader<TKey, TValue>.LoadGroupedBatchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Linq.ILookup<TKey, TValue>!>!
+GreenDonut.AutoBatchScheduler
+GreenDonut.AutoBatchScheduler.AutoBatchScheduler() -> void
+GreenDonut.AutoBatchScheduler.Schedule(System.Func<System.Threading.Tasks.ValueTask>! dispatch) -> void
+GreenDonut.BatchDataLoader<TKey, TValue>
+GreenDonut.BatchDataLoader<TKey, TValue>.BatchDataLoader(GreenDonut.IBatchScheduler! batchScheduler, GreenDonut.DataLoaderOptions<TKey>? options = null) -> void
+GreenDonut.CacheDataLoader<TKey, TValue>
+GreenDonut.CacheDataLoader<TKey, TValue>.CacheDataLoader(int cacheSize) -> void
+GreenDonut.GroupedDataLoader<TKey, TValue>
+GreenDonut.GroupedDataLoader<TKey, TValue>.GroupedDataLoader(GreenDonut.IBatchScheduler! batchScheduler, GreenDonut.DataLoaderOptions<TKey>? options = null) -> void
+override sealed GreenDonut.BatchDataLoader<TKey, TValue>.FetchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<GreenDonut.Result<TValue>>!>
+override sealed GreenDonut.CacheDataLoader<TKey, TValue>.FetchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<GreenDonut.Result<TValue>>!>
+override sealed GreenDonut.GroupedDataLoader<TKey, TValue>.FetchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<GreenDonut.Result<TValue[]!>>!>
+static GreenDonut.AutoBatchScheduler.Default.get -> GreenDonut.AutoBatchScheduler!

--- a/src/HotChocolate/Core/src/Fetching/PublicAPI.Unshipped.txt
+++ b/src/HotChocolate/Core/src/Fetching/PublicAPI.Unshipped.txt
@@ -1,14 +1,7 @@
-abstract HotChocolate.Fetching.BatchDataLoader<TKey, TValue>.LoadBatchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>!>!
-abstract HotChocolate.Fetching.CacheDataLoader<TKey, TValue>.LoadSingleAsync(TKey key, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TValue>!
-abstract HotChocolate.Fetching.GroupedDataLoader<TKey, TValue>.LoadGroupedBatchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Linq.ILookup<TKey, TValue>!>!
-HotChocolate.Fetching.BatchDataLoader<TKey, TValue>
-HotChocolate.Fetching.BatchDataLoader<TKey, TValue>.BatchDataLoader(GreenDonut.IBatchScheduler! batchScheduler, GreenDonut.DataLoaderOptions<TKey>? options = null) -> void
 HotChocolate.Fetching.BatchScheduler.Dispatch() -> void
 HotChocolate.Fetching.BatchScheduler.DispatchOnSchedule.get -> bool
 HotChocolate.Fetching.BatchScheduler.DispatchOnSchedule.set -> void
 HotChocolate.Fetching.BatchScheduler.Initialize(HotChocolate.Execution.IExecutionTaskContext! context) -> void
-HotChocolate.Fetching.CacheDataLoader<TKey, TValue>
-HotChocolate.Fetching.CacheDataLoader<TKey, TValue>.CacheDataLoader(int cacheSize) -> void
 HotChocolate.Fetching.DataLoaderParameterExpressionBuilder
 HotChocolate.Fetching.DataLoaderParameterExpressionBuilder.DataLoaderParameterExpressionBuilder() -> void
 HotChocolate.Fetching.DefaultDataLoaderRegistry
@@ -19,8 +12,6 @@ HotChocolate.Fetching.DefaultDataLoaderRegistry.GetOrRegister<T>(System.Func<T>!
 HotChocolate.Fetching.FetchBatch<TKey, TValue>
 HotChocolate.Fetching.FetchCacheCt<TKey, TValue>
 HotChocolate.Fetching.FetchGroup<TKey, TValue>
-HotChocolate.Fetching.GroupedDataLoader<TKey, TValue>
-HotChocolate.Fetching.GroupedDataLoader<TKey, TValue>.GroupedDataLoader(GreenDonut.IBatchScheduler! batchScheduler, GreenDonut.DataLoaderOptions<TKey>? options = null) -> void
 HotChocolate.Fetching.IBatchDispatcher.Dispatch() -> void
 HotChocolate.Fetching.IBatchDispatcher.DispatchOnSchedule.get -> bool
 HotChocolate.Fetching.IBatchDispatcher.DispatchOnSchedule.set -> void
@@ -37,9 +28,6 @@ HotChocolate.Types.UseDataLoaderAttribute.UseDataLoaderAttribute(System.Type! da
 override HotChocolate.Fetching.DataLoaderParameterExpressionBuilder.Build(System.Reflection.ParameterInfo! parameter, System.Linq.Expressions.Expression! context) -> System.Linq.Expressions.Expression!
 override HotChocolate.Fetching.DataLoaderParameterExpressionBuilder.CanHandle(System.Reflection.ParameterInfo! parameter) -> bool
 override HotChocolate.Types.UseDataLoaderAttribute.OnConfigure(HotChocolate.Types.Descriptors.IDescriptorContext! context, HotChocolate.Types.IObjectFieldDescriptor! descriptor, System.Reflection.MemberInfo! member) -> void
-override sealed HotChocolate.Fetching.BatchDataLoader<TKey, TValue>.FetchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<GreenDonut.Result<TValue>>!>
-override sealed HotChocolate.Fetching.CacheDataLoader<TKey, TValue>.FetchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<GreenDonut.Result<TValue>>!>
-override sealed HotChocolate.Fetching.GroupedDataLoader<TKey, TValue>.FetchAsync(System.Collections.Generic.IReadOnlyList<TKey>! keys, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<GreenDonut.Result<TValue[]!>>!>
 static HotChocolate.Types.DataLoaderObjectFieldExtensions.UseDataloader(this HotChocolate.Types.IObjectFieldDescriptor! descriptor, System.Type! dataLoaderType) -> HotChocolate.Types.IObjectFieldDescriptor!
 static HotChocolate.Types.DataLoaderObjectFieldExtensions.UseDataloader<TDataLoader>(this HotChocolate.Types.IObjectFieldDescriptor! descriptor) -> HotChocolate.Types.IObjectFieldDescriptor!
 static HotChocolate.Types.DataLoaderResolverContextExtensions.BatchDataLoader<TKey, TValue>(this HotChocolate.Resolvers.IResolverContext! context, HotChocolate.Fetching.FetchBatch<TKey, TValue>! fetch, string? key = null) -> GreenDonut.IDataLoader<TKey, TValue>!
@@ -56,3 +44,8 @@ static HotChocolate.Types.DataLoaderResolverContextExtensions.GroupDataLoader<TK
 *REMOVED*HotChocolate.Fetching.IAdHocDataLoaderRegistrar.GetOrAddDataLoader<TDataLoader>(string! name, System.Func<GreenDonut.IBatchScheduler!, TDataLoader>! factory) -> TDataLoader
 *REMOVED*HotChocolate.Fetching.BatchScheduler.Dispatch(System.Action<HotChocolate.Execution.IExecutionTaskDefinition!>! enqueue) -> void
 *REMOVED*HotChocolate.Fetching.IBatchDispatcher.Dispatch(System.Action<HotChocolate.Execution.IExecutionTaskDefinition!>! enqueue) -> void
+*REMOVED*HotChocolate.Fetching.AutoBatchScheduler
+*REMOVED*HotChocolate.Fetching.AutoBatchScheduler.AutoBatchScheduler() -> void
+*REMOVED*HotChocolate.Fetching.AutoBatchScheduler.Schedule(System.Func<System.Threading.Tasks.ValueTask>! dispatch) -> void
+*REMOVED*HotChocolate.Fetching.IAutoBatchDispatcher
+*REMOVED*static HotChocolate.Fetching.AutoBatchScheduler.Default.get -> HotChocolate.Fetching.AutoBatchScheduler!


### PR DESCRIPTION
### Changes
- Ignore Test projects when building to prevent source generator issues
  What's weird is that the source generator issue seems to not be related to the analyzer. It's essentially just a regular build and it fails on the source generator. I thought maybe it's that the build config is Release and the `HotChocolateBin_Dir` used in the tests points at a Debug folder, but I can't get the build error reproduced locally...
- Ignore other Public API warnings, so their code-fix is not attempted. Normally only the code-fix for adding an API should be executed, but this seems to be a [known issue of dotnet-format](https://github.com/dotnet/format/issues/1239)