### PR TITLE
randyridge/subscription findings

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/KeepConnectionAliveJob.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/KeepConnectionAliveJob.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using HotChocolate.AspNetCore.Subscriptions.Messages;
@@ -51,6 +52,10 @@ namespace HotChocolate.AspNetCore.Subscriptions
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // the message processing was canceled.
+            }
+            catch (WebSocketException)
+            {
+                // we will just stop receiving
             }
         }
     }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/MessageProcessor.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/MessageProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.IO.Pipelines;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -67,6 +68,10 @@ namespace HotChocolate.AspNetCore.Subscriptions
                 }
             }
             catch(OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
+            catch (WebSocketException)
+            {
+                // we will just stop receiving
+            }
             finally
             {
                 // reader should be completed always, so that related pipe writer can

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/WebSocketConnection.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/WebSocketConnection.cs
@@ -63,7 +63,7 @@ namespace HotChocolate.AspNetCore.Subscriptions
         {
             WebSocket? webSocket = _webSocket;
 
-            if (_disposed || webSocket == null)
+            if (_disposed || webSocket == null || webSocket.State != WebSocketState.Open)
             {
                 return Task.CompletedTask;
             }
@@ -95,6 +95,11 @@ namespace HotChocolate.AspNetCore.Subscriptions
 
                     if (success)
                     {
+                        if (webSocket.State != WebSocketState.Open)
+                        {
+                            break;
+                        }
+
                         try
                         {
                             socketResult = await webSocket.ReceiveAsync(buffer, cancellationToken);
@@ -122,6 +127,10 @@ namespace HotChocolate.AspNetCore.Subscriptions
             {
                 // we will just stop receiving
             }
+            catch (WebSocketException)
+            {
+	            // we will just stop receiving
+            }
         }
 
         public async Task CloseAsync(
@@ -133,7 +142,7 @@ namespace HotChocolate.AspNetCore.Subscriptions
             {
                 WebSocket? webSocket = _webSocket;
 
-                if (_disposed || Closed || webSocket is null)
+                if (_disposed || Closed || webSocket is null || webSocket.State != WebSocketState.Open)
                 {
                     return;
                 }

--- a/src/HotChocolate/Core/src/Fetching/BatchScheduler.cs
+++ b/src/HotChocolate/Core/src/Fetching/BatchScheduler.cs
@@ -110,7 +110,13 @@ namespace HotChocolate.Fetching
                 finally
                 {
                     IsCanceled = cancellationToken.IsCancellationRequested;
-                    _context.Completed();
+                    try
+                    {
+                        _context.Completed();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
                 }
             }
         }


### PR DESCRIPTION
various catches to prevent unobserved task exceptions, tried to prevent the exceptions by checking websocket state

See #3891 
