### PR TITLE
Expand enum documentation

### DIFF
--- a/website/src/docs/hotchocolate/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/enums.md
@@ -39,7 +39,7 @@ When querying for an enum value, it will be serialized as a string.
 
 **Response**
 
-```json
+````json
 {
   "data": {
     "role": "STANDARD"
@@ -57,7 +57,7 @@ When using an enum value as an argument, it is represented as a literal and **no
     id
   }
 }
-```
+````
 
 When used as a type for a variable, it is represented as a string in the variables object, since JSON does not offer support for literals.
 
@@ -139,7 +139,37 @@ public class QueryType : ObjectType
 }
 ```
 
-We can also bind the enumeration type to any other .NET type, for example a `string`.
+</ExampleTabs.Code>
+<ExampleTabs.Schema>
+
+```csharp
+services
+    .AddGraphQLServer()
+    .AddDocumentFromString(@"
+        type Query {
+          user(role: UserRole): User
+        }
+
+        enum UserRole {
+          GUEST,
+          DEFAULT,
+          ADMINISTRATOR
+        }
+    ")
+    .AddResolver("Query", "user", (context) =>-
+    {
+        var role = context.ArgumentValue<string>("role");
+
+        // Omitted code for brevity
+    })
+```
+
+</ExampleTabs.Schema>
+</ExampleTabs>
+
+## Non-enum values
+
+In Code-first we can also bind the enum type to any other .NET type, for example a `string`.
 
 ```csharp
 public class UserRoleType : EnumType<string>
@@ -174,34 +204,6 @@ public class QueryType : ObjectType
     }
 }
 ```
-
-</ExampleTabs.Code>
-<ExampleTabs.Schema>
-
-```csharp
-services
-    .AddGraphQLServer()
-    .AddDocumentFromString(@"
-        type Query {
-          user(role: UserRole): User
-        }
-
-        enum UserRole {
-          GUEST,
-          DEFAULT,
-          ADMINISTRATOR
-        }
-    ")
-    .AddResolver("Query", "user", (context) =>
-    {
-        var role = context.ArgumentValue<string>("role");
-
-        // Omitted code for brevity
-    })
-```
-
-</ExampleTabs.Schema>
-</ExampleTabs>
 
 # Binding behavior
 

--- a/website/src/docs/hotchocolate/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/enums.md
@@ -167,6 +167,99 @@ services
 </ExampleTabs.Schema>
 </ExampleTabs>
 
+# Binding behavior
+
+In the Annotation-based approach all enum values are implicitly included on the schema enum type. The same is true for `T` of `EnumType<T>` when using the Code-first approach.
+
+In the Code-first approach we can also enable explicit binding, where we have to opt-in enum values we want to include instead of them being implicitly included.
+
+<!-- todo: this should not be covered in each type documentation, rather once in a server configuration section -->
+
+We can configure our preferred binding behavior globally like the following.
+
+```csharp
+services
+    .AddGraphQLServer()
+    .ModifyOptions(options =>
+    {
+        options.DefaultBindingBehavior = BindingBehavior.Explicit;
+    });
+```
+
+> ⚠️ Note: This changes the binding behavior for all types, not only enum types.
+
+We can also override it on a per type basis:
+
+```csharp
+public class UserRoleType : EnumType<UserRole>
+{
+    protected override void Configure(IEnumTypeDescriptor<UserRole> descriptor)
+    {
+        descriptor.BindValues(BindingBehavior.Implicit);
+
+        // We could also use the following methods respectively
+        // descriptor.BindValuesExplicitly();
+        // descriptor.BindValuesImplicitly();
+    }
+}
+```
+
+## Ignoring values
+
+<ExampleTabs>
+<ExampleTabs.Annotation>
+
+In the Annotation-based approach we can ignore values using the `[GraphQLIgnore]` attribute.
+
+```csharp
+public enum UserRole
+{
+    [GraphQLIgnore]
+    Guest,
+    Standard,
+    Administrator
+}
+```
+
+</ExampleTabs.Annotation>
+<ExampleTabs.Code>
+
+In the Code-first approach we can ignore values using the `Ignore` method on the `IEnumTypeDescriptor`. This is only necessary, if the binding behavior of the enum type is implicit.
+
+```csharp
+public class UserRoleType : EnumType<UserRole>
+{
+    protected override void Configure(IEnumTypeDescriptor<UserRole> descriptor)
+    {
+        descriptor.Ignore(UserRole.Guest);
+    }
+}
+```
+
+</ExampleTabs.Code>
+<ExampleTabs.Schema>
+
+We do not have to ignore values in the Schema-first approach.
+
+</ExampleTabs.Schema>
+</ExampleTabs>
+
+## Including values
+
+In the Code-first approach we can explicitly include values using the `Value` method on the `IEnumTypeDescriptor`. This is only necessary, if the binding behavior of the enum type is explicit.
+
+```csharp
+public class UserRoleType : EnumType<UserRole>
+{
+    protected override void Configure(IEnumTypeDescriptor<UserRole> descriptor)
+    {
+        descriptor.BindValuesExplicitly();
+
+        descriptor.Value(UserRole.Guest);
+    }
+}
+```
+
 # Naming
 
 Unless specified explicitly, Hot Chocolate automatically infers the names of enums and their values. Per default the name of the enum becomes the name of the enum type. When using `EnumType<T>` in Code-first, the name of `T` is chosen as the name for the enum type.
@@ -199,14 +292,7 @@ public enum UserRole
 
 The `Name` method on the `IEnumTypeDescriptor` / `IEnumValueDescriptor` allows us to specify an explicit name.
 
-```csharp
-public enum UserRole
-{
-    Guest,
-    Standard,
-    Administrator
-}
-
+```csharp-
 public class UserRoleType : EnumType<UserRole>
 {
     protected override void Configure(IEnumTypeDescriptor<UserRole> descriptor)

--- a/website/src/docs/hotchocolate/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/enums.md
@@ -139,6 +139,26 @@ public class QueryType : ObjectType
 }
 ```
 
+Since there could be multiple enum types inheriting from `EnumType<UserRole>`, but differing in their name and values, it is not certain which of these types should be used when we return a `UserRole` CLR type from one of our resolvers.
+
+**Therefore it's important to note that Code-first enum types are not automatically inferred. They need to be explicitly specified or registered.**
+
+We can either [explicitly specify the type on a per-resolver basis](/docs/hotchocolate/defining-a-schema/object-types#explicit-types) or we can register the type once globally:
+
+```csharp
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services
+            .AddGraphQLServer()
+            .AddType<UserRoleType>();
+    }
+}
+```
+
+With this configuration each `UserRole` CLR type we return from our resovlers would be assumed to be a `UserRoleType`.
+
 </ExampleTabs.Code>
 <ExampleTabs.Schema>
 

--- a/website/src/docs/hotchocolate/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/enums.md
@@ -4,7 +4,7 @@ title: "Enums"
 
 import { ExampleTabs } from "../../../components/mdx/example-tabs"
 
-An Enum is a special kind of [scalar](/docs/hotchocolate/defining-a-schema/scalars) that is restricted to a particular set of allowed values.
+An Enum is a special kind of [scalar](/docs/hotchocolate/defining-a-schema/scalars) that is restricted to a particular set of allowed values. It can be used as both an input and an output type.
 
 ```sdl
 enum UserRole {
@@ -15,6 +15,71 @@ enum UserRole {
 ```
 
 Learn more about enums [here](https://graphql.org/learn/schema/#enumeration-types).
+
+# Usage
+
+Given is the following schema:
+
+```sdl
+type Query {
+  role: UserRole
+  usersByRole(role: UserRole): [User]
+}
+```
+
+When querying for an enum value, it will be serialized as a string.
+
+**Request**
+
+```graphql
+{
+  role
+}
+```
+
+**Response**
+
+```json
+{
+  "data": {
+    "role": "STANDARD"
+  }
+}
+```
+
+When using an enum value as an argument, it is represented as a literal and **not** a string.
+
+**Request**
+
+```graphql
+{
+  usersByRole(role: ADMINISTRATOR) {
+    id
+  }
+}
+```
+
+When used as a type for a variable, it is represented as a string in the variables object, since JSON does not offer support for literals.
+
+**Request**
+
+Operation:
+
+```graphql
+query ($role: UserRole) {
+  usersByRole(role: $role) {
+    id
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "role": "ADMINISTRATOR"
+}
+```
 
 # Definition
 

--- a/website/src/docs/hotchocolate/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/enums.md
@@ -166,3 +166,72 @@ services
 
 </ExampleTabs.Schema>
 </ExampleTabs>
+
+# Naming
+
+Unless specified explicitly, Hot Chocolate automatically infers the names of enums and their values. Per default the name of the enum becomes the name of the enum type. When using `EnumType<T>` in Code-first, the name of `T` is chosen as the name for the enum type.
+
+Enum values are automatically formatted to the UPPER_SNAIL_CASE according to the GraphQL specification:
+
+- `Guest` becomes `GUEST`
+- `HeadOfDepartment` becomes `HEAD_OF_DEPARTMENT`
+
+If we need to we can override these inferred names.
+
+<ExampleTabs>
+<ExampleTabs.Annotation>
+
+The `[GraphQLName]` attribute allows us to specify an explicit name.
+
+```csharp
+[GraphQLName("Role")]
+public enum UserRole
+{
+    [GraphQLName("VISITOR")]
+    Guest,
+    Standard,
+    Administrator
+}
+```
+
+</ExampleTabs.Annotation>
+<ExampleTabs.Code>
+
+The `Name` method on the `IEnumTypeDescriptor` / `IEnumValueDescriptor` allows us to specify an explicit name.
+
+```csharp
+public enum UserRole
+{
+    Guest,
+    Standard,
+    Administrator
+}
+
+public class UserRoleType : EnumType<UserRole>
+{
+    protected override void Configure(IEnumTypeDescriptor<UserRole> descriptor)
+    {
+        descriptor.Name("Role");
+
+        descriptor.Value(UserRole.Guest).Name("VISITOR");
+    }
+}
+```
+
+</ExampleTabs.Code>
+<ExampleTabs.Schema>
+
+Simply change the names in the schema.
+
+</ExampleTabs.Schema>
+</ExampleTabs>
+
+This would produce the following `Role` schema enum type:
+
+```sdl
+enum Role {
+  VISITOR,
+  STANDARD,
+  ADMINISTRATOR
+}
+```

--- a/website/src/docs/hotchocolate/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/enums.md
@@ -16,7 +16,7 @@ enum UserRole {
 
 Learn more about enums [here](https://graphql.org/learn/schema/#enumeration-types).
 
-# Usage
+# Definition
 
 We can define enums like the following.
 
@@ -37,19 +37,6 @@ public class Query
     {
         // Omitted code for brevity
     }
-}
-```
-
-We can also specify different names for the type and values to be used in the schema.
-
-```csharp
-[GraphQLName("NewUserRole")]
-public enum UserRole
-{
-    Guest,
-    [GraphQLName("Default")]
-    Standard,
-    Administrator
 }
 ```
 
@@ -87,23 +74,7 @@ public class QueryType : ObjectType
 }
 ```
 
-We can also specify different names for the type and values to be used in the schema.
-
-```csharp
-public class UserRoleType : EnumType<UserRole>
-{
-    protected override void Configure(IEnumTypeDescriptor<UserRole> descriptor)
-    {
-        descriptor.Name("NewUserRole");
-
-        descriptor
-            .Value(UserRole.Standard)
-            .Name("Default");
-    }
-}
-```
-
-We can also bind the enumeration type to any other .NET type.
+We can also bind the enumeration type to any other .NET type, for example a `string`.
 
 ```csharp
 public class UserRoleType : EnumType<string>
@@ -292,7 +263,7 @@ public enum UserRole
 
 The `Name` method on the `IEnumTypeDescriptor` / `IEnumValueDescriptor` allows us to specify an explicit name.
 
-```csharp-
+```csharp
 public class UserRoleType : EnumType<UserRole>
 {
     protected override void Configure(IEnumTypeDescriptor<UserRole> descriptor)

--- a/website/src/docs/hotchocolate/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/extending-types.md
@@ -366,7 +366,3 @@ public class PostExtensions
 
 > Note: The `IPost` is annotated with `[InterfaceType]` to include it in the GraphQL schema, but that isn't necessary for the type extension to work.
 > We can use any base type, like `object` or an `abstract` base class, as an extension point without necessarily exposing the base type in our GraphQL schema.
-
-# Enum Types
-
-TODO

--- a/website/src/docs/hotchocolate/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/extending-types.md
@@ -352,8 +352,8 @@ public interface IPost
     string Title { get; set; }
 }
 
-// this extends every type that implements the IPost interface
-// note: the interface itself is not extended in the schema
+// this extends every type that implements the IPost interface,
+// not the interface type itself
 [ExtendObjectType(typeof(IPost))]
 public class PostExtensions
 {
@@ -366,3 +366,7 @@ public class PostExtensions
 
 > Note: The `IPost` is annotated with `[InterfaceType]` to include it in the GraphQL schema, but that isn't necessary for the type extension to work.
 > We can use any base type, like `object` or an `abstract` base class, as an extension point without necessarily exposing the base type in our GraphQL schema.
+
+# Enum Types
+
+TODO

--- a/website/src/docs/hotchocolate/defining-a-schema/object-types.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/object-types.md
@@ -63,7 +63,7 @@ public class AuthorType : ObjectType<Author>
 }
 ```
 
-The `descriptor` gives us the ability to configure the object type. We will cover how to use it in the following chapters.
+The `IObjectTypeDescriptor` gives us the ability to configure the object type. We will cover how to use it in the following chapters.
 
 Since there could be multiple types inheriting from `ObjectType<Author>`, but differing in their name and fields, it is not certain which of these types should be used when we return an `Author` CLR type from one of our resolvers.
 
@@ -129,9 +129,11 @@ public class Startup
 
 # Binding behavior
 
-In the Annotation-based approach all public properties and methods are implicitly mapped to fields of the schema object type.
+In the Annotation-based approach all public properties and methods are implicitly mapped to fields on the schema object type. The same is true for `T` of `ObjectType<T>` when using the Code-first approach.
 
-In the Code-first approach we have a little more control over this behavior. By default all public properties and methods of our POCO are mapped to fields of the schema object type. This behavior is called implicit binding. There is also an explicit binding behavior, where we have to opt-in properties we want to include.
+In the Code-first approach we can also enable explicit binding, where we have to opt-in properties and methods we want to include instead of them being implicitly included.
+
+<!-- todo: this should not be covered in each type documentation, rather once in a server configuration section -->
 
 We can configure our preferred binding behavior globally like the following.
 
@@ -143,6 +145,8 @@ services
         options.DefaultBindingBehavior = BindingBehavior.Explicit;
     });
 ```
+
+> ⚠️ Note: This changes the binding behavior for all types, not only object types.
 
 We can also override it on a per type basis:
 
@@ -180,7 +184,7 @@ public class Book
 </ExampleTabs.Annotation>
 <ExampleTabs.Code>
 
-In the Code-first approach we can ignore certain properties of our POCO using the `Ignore` method on the `descriptor`. This is only necessary, if the binding behavior of the object type is implicit.
+In the Code-first approach we can ignore fields of our POCO using the `Ignore` method on the `IObjectTypeDescriptor`. This is only necessary, if the binding behavior of the object type is implicit.
 
 ```csharp
 public class BookType : ObjectType<Book>
@@ -202,7 +206,7 @@ We do not have to ignore fields in the Schema-first approach.
 
 ## Including fields
 
-In the Code-first approach we can explicitly include certain properties of our POCO using the `Field` method on the `descriptor`. This is only necessary, if the binding behavior of the object type is explicit.
+In the Code-first approach we can explicitly include properties of our POCO using the `Field` method on the `IObjectTypeDescriptor`. This is only necessary, if the binding behavior of the object type is explicit.
 
 ```csharp
 public class BookType : ObjectType<Book>

--- a/website/src/docs/hotchocolate/defining-a-schema/object-types.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/object-types.md
@@ -83,7 +83,7 @@ public class Startup
 }
 ```
 
-In the above example every `Author` CLR type we return from our resovlers would be assumed to be an `AuthorType`.
+With this configuration every `Author` CLR type we return from our resovlers would be assumed to be an `AuthorType`.
 
 We can also create schema object types without a backing POCO.
 

--- a/website/src/docs/hotchocolate/defining-a-schema/object-types.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/object-types.md
@@ -19,7 +19,7 @@ type Book {
 
 Learn more about object types [here](https://graphql.org/learn/schema/#object-types-and-fields).
 
-# Usage
+# Definition
 
 Object types can be defined like the following.
 


### PR DESCRIPTION
Now covers binding behavior, naming and gives some usage examples.

I'll be adding usage examples to all documentation of types, so users don't have to switch to other documentation to get this information.
