### PR TITLE
Correctly display scrollbar in navigation

### DIFF
--- a/website/src/components/doc-page/doc-page-navigation.tsx
+++ b/website/src/components/doc-page/doc-page-navigation.tsx
@@ -1,4 +1,4 @@
-import { graphql } from "gatsby";
+import { graphql, Link } from "gatsby";
 import React, {
   FC,
   MouseEvent,
@@ -17,7 +17,6 @@ import { BoxShadow, IsTablet } from "../../shared-style";
 import { State } from "../../state";
 import { closeTOC } from "../../state/common";
 import { IconContainer } from "../misc/icon-container";
-import { Link } from "../misc/link";
 import {
   DocPageStickySideBarStyle,
   MostProminentSection,
@@ -196,7 +195,10 @@ export const DocPageNavigation: FC<DocPageNavigationProps> = ({
       />
 
       <ProductSwitcher>
-        <ProductSwitcherButton onClick={toggleProductSwitcher}>
+        <ProductSwitcherButton
+          fullWidth={!hasVersions}
+          onClick={toggleProductSwitcher}
+        >
           {activeProduct?.title}
 
           <IconContainer size={16}>
@@ -204,18 +206,21 @@ export const DocPageNavigation: FC<DocPageNavigationProps> = ({
           </IconContainer>
         </ProductSwitcherButton>
 
-        <ProductSwitcherButton
-          disabled={!hasVersions}
-          onClick={toggleVersionSwitcher}
-        >
-          {activeVersion?.title}
+        {hasVersions && (
+          <ProductSwitcherButton onClick={toggleVersionSwitcher}>
+            {activeVersion?.title}
 
-          {hasVersions && (
-            <IconContainer size={12}>
-              {versionSwitcherOpen ? <ArrowUpIconSvg /> : <ArrowDownIconSvg />}
-            </IconContainer>
-          )}
-        </ProductSwitcherButton>
+            {hasVersions && (
+              <IconContainer size={12}>
+                {versionSwitcherOpen ? (
+                  <ArrowUpIconSvg />
+                ) : (
+                  <ArrowDownIconSvg />
+                )}
+              </IconContainer>
+            )}
+          </ProductSwitcherButton>
+        )}
       </ProductSwitcher>
 
       <ProductSwitcherDialog
@@ -255,15 +260,17 @@ export const DocPageNavigation: FC<DocPageNavigationProps> = ({
       </ProductVersionDialog>
 
       {!productSwitcherOpen && activeVersion?.items && (
-        <MostProminentSection>
-          <NavigationContainer
-            basePath={`/docs/${activeProduct!.path!}${
-              !!activeVersion?.path?.length ? "/" + activeVersion.path! : ""
-            }`}
-            items={subItems}
-            selectedPath={selectedPath}
-          />
-        </MostProminentSection>
+        <ScrollContainer>
+          <MostProminentSection>
+            <NavigationContainer
+              basePath={`/docs/${activeProduct!.path!}${
+                !!activeVersion?.path?.length ? "/" + activeVersion.path! : ""
+              }`}
+              items={subItems}
+              selectedPath={selectedPath}
+            />
+          </MostProminentSection>
+        </ScrollContainer>
       )}
     </Navigation>
   );
@@ -319,13 +326,17 @@ export const Navigation = styled.nav<{ height: string; show: boolean }>`
   padding: 25px 0 0;
   transition: margin-left 250ms;
   background-color: white;
+  overflow-y: hidden;
+  margin-bottom: 50px;
+  display: flex;
+  flex-direction: column;
 
   ${({ show }) => show && `margin-left: 0 !important;`}
 
   ${({ height }) =>
     IsTablet(`
-      margin-left: -105%;
       height: ${height};
+      margin-left: -105%;
       position: fixed;
       top: 60px;
       left: 0;
@@ -333,7 +344,7 @@ export const Navigation = styled.nav<{ height: string; show: boolean }>`
   `)}
 `;
 
-const ProductSwitcherButton = styled.button`
+const ProductSwitcherButton = styled.button<{ fullWidth?: number }>`
   display: flex;
   flex: 0 0 auto;
   flex-direction: row;
@@ -344,6 +355,7 @@ const ProductSwitcherButton = styled.button`
   height: 38px;
   font-size: 0.833em;
   transition: background-color 0.2s ease-in-out;
+  ${({ fullWidth }) => fullWidth && `width: 100%;`}
 
   > ${IconContainer} {
     margin-left: auto;
@@ -368,6 +380,7 @@ const ProductSwitcher = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-shrink: 0;
 
   > ${ProductSwitcherButton}:not(:last-child) {
     margin-right: 4px;
@@ -543,4 +556,8 @@ const NavigationItem = styled.li<{ active: boolean }>`
         font-weight: bold;
       }
     `}
+`;
+
+const ScrollContainer = styled.div`
+  overflow-y: auto;
 `;

--- a/website/src/components/doc-page/doc-page-navigation.tsx
+++ b/website/src/components/doc-page/doc-page-navigation.tsx
@@ -1,4 +1,4 @@
-import { graphql, Link } from "gatsby";
+import { graphql } from "gatsby";
 import React, {
   FC,
   MouseEvent,
@@ -17,6 +17,7 @@ import { BoxShadow, IsTablet } from "../../shared-style";
 import { State } from "../../state";
 import { closeTOC } from "../../state/common";
 import { IconContainer } from "../misc/icon-container";
+import { Link } from "../misc/link";
 import {
   DocPageStickySideBarStyle,
   MostProminentSection,
@@ -335,8 +336,8 @@ export const Navigation = styled.nav<{ height: string; show: boolean }>`
 
   ${({ height }) =>
     IsTablet(`
-      height: ${height};
       margin-left: -105%;
+      height: ${height};
       position: fixed;
       top: 60px;
       left: 0;

--- a/website/src/components/doc-page/doc-page-navigation.tsx
+++ b/website/src/components/doc-page/doc-page-navigation.tsx
@@ -211,15 +211,9 @@ export const DocPageNavigation: FC<DocPageNavigationProps> = ({
           <ProductSwitcherButton onClick={toggleVersionSwitcher}>
             {activeVersion?.title}
 
-            {hasVersions && (
-              <IconContainer size={12}>
-                {versionSwitcherOpen ? (
-                  <ArrowUpIconSvg />
-                ) : (
-                  <ArrowDownIconSvg />
-                )}
-              </IconContainer>
-            )}
+            <IconContainer size={12}>
+              {versionSwitcherOpen ? <ArrowUpIconSvg /> : <ArrowDownIconSvg />}
+            </IconContainer>
           </ProductSwitcherButton>
         )}
       </ProductSwitcher>
@@ -345,7 +339,7 @@ export const Navigation = styled.nav<{ height: string; show: boolean }>`
   `)}
 `;
 
-const ProductSwitcherButton = styled.button<{ fullWidth?: number }>`
+const ProductSwitcherButton = styled.button<{ readonly fullWidth?: boolean }>`
   display: flex;
   flex: 0 0 auto;
   flex-direction: row;

--- a/website/src/components/doc-page/doc-page.tsx
+++ b/website/src/components/doc-page/doc-page.tsx
@@ -23,12 +23,14 @@ import {
   ArticleHeader,
   ArticleTitle,
 } from "../articles/article-elements";
+import { ArticleSections } from "../articles/article-sections";
 import { TabGroupProvider } from "../mdx/tabs/tab-groups";
 import {
   ArticleWrapper,
   ArticleWrapperElement,
 } from "./doc-page-article-wrapper";
-import { Aside } from "./doc-page-aside";
+import { Aside, DocPageAside } from "./doc-page-aside";
+import { DocPageCommunity } from "./doc-page-community";
 import { DocPageLegacy } from "./doc-page-legacy";
 import { DocPageNavigation, Navigation } from "./doc-page-navigation";
 
@@ -122,10 +124,10 @@ export const DocPage: FC<DocPageProps> = ({ data, originPath }) => {
             {false && <ArticleComments data={data} path={slug} title={title} />}
           </ArticleContainer>
         </ArticleWrapper>
-        {/* <DocPageAside>
+        <DocPageAside>
           <DocPageCommunity data={data} originPath={originPath} />
           <ArticleSections data={data.file!.childMdx!} />
-        </DocPageAside> */}
+        </DocPageAside>
       </Container>
     </TabGroupProvider>
   );

--- a/website/src/components/doc-page/doc-page.tsx
+++ b/website/src/components/doc-page/doc-page.tsx
@@ -23,14 +23,12 @@ import {
   ArticleHeader,
   ArticleTitle,
 } from "../articles/article-elements";
-import { ArticleSections } from "../articles/article-sections";
 import { TabGroupProvider } from "../mdx/tabs/tab-groups";
 import {
   ArticleWrapper,
   ArticleWrapperElement,
 } from "./doc-page-article-wrapper";
-import { Aside, DocPageAside } from "./doc-page-aside";
-import { DocPageCommunity } from "./doc-page-community";
+import { Aside } from "./doc-page-aside";
 import { DocPageLegacy } from "./doc-page-legacy";
 import { DocPageNavigation, Navigation } from "./doc-page-navigation";
 
@@ -124,10 +122,10 @@ export const DocPage: FC<DocPageProps> = ({ data, originPath }) => {
             {false && <ArticleComments data={data} path={slug} title={title} />}
           </ArticleContainer>
         </ArticleWrapper>
-        <DocPageAside>
+        {/* <DocPageAside>
           <DocPageCommunity data={data} originPath={originPath} />
           <ArticleSections data={data.file!.childMdx!} />
-        </DocPageAside>
+        </DocPageAside> */}
       </Container>
     </TabGroupProvider>
   );

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -44,7 +44,6 @@ import SwissLifeLogoSvg from "../images/companies/swiss-life.svg";
 import SytadelleLogoSvg from "../images/companies/sytadelle.svg";
 import XMLogoSvg from "../images/companies/xm.svg";
 import ZioskLogoSvg from "../images/companies/ziosk.svg";
-import XMLogoSvg from "../images/companies/xm.svg"
 // Images
 import ContactUsSvg from "../images/contact-us.svg";
 import DashboardSvg from "../images/dashboard.svg";


### PR DESCRIPTION
### Changes

- Don't display version selector if only one version is present
- Correctly display scrollbar in left navigation

|Before|After|
|---|---|
|![Screenshot_20210828_212002](https://user-images.githubusercontent.com/45513122/131228630-e69c398e-a09f-47ad-8c14-ae1cc37a1e95.png)|![Screenshot_20210828_212119](https://user-images.githubusercontent.com/45513122/131228650-fe6181ab-0c71-4b2f-8846-29991d22b3dc.png)|
