### PR TITLE
When reading a channel, use TryRead() instead of ReadAsync() for speed and glory

### DIFF
--- a/src/HotChocolate/Core/src/Subscriptions.InMemory/InMemorySourceStream.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.InMemory/InMemorySourceStream.cs
@@ -75,8 +75,10 @@ namespace HotChocolate.Subscriptions.InMemory
                         yield break;
                     }
 
-                    yield return await _channel.Reader.ReadAsync(cancellationToken)
-                        .ConfigureAwait(false);
+                    while (_channel.Reader.TryRead(out T? value))
+                    {
+                        yield return value;
+                    }
                 }
             }
 


### PR DESCRIPTION
Proving Yoda wrong, There is for sure a `Try`

Also, this change makes the code path a bit faster when there are multiple reads performed within one wait, actually faster when there's only a single read too.

This whole method can probably be replaced with `_channel.Reader.ReadAllAsync()`
