### PR TITLE
More robust CombinedServiceProvider

### DIFF
--- a/src/HotChocolate/Utilities/src/Utilities/CombinedServiceProvider.cs
+++ b/src/HotChocolate/Utilities/src/Utilities/CombinedServiceProvider.cs
@@ -55,7 +55,7 @@ namespace HotChocolate.Utilities
 
             MethodInfo info = _enumerableTypeInfo
                 .DeclaredMethods
-                .First(m => m.Name == _methodNameAny && m.IsStatic)
+                .First(m => m.Name == _methodNameAny && m.IsStatic && m.GetParameters().Length == 1)
                 .MakeGenericMethod(genericArgumentType);
 
             return (bool)info.Invoke(null, new[] { enumerable })!;

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/CombinedServiceProviderTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/CombinedServiceProviderTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace HotChocolate.Utilities
+{
+    public class CombinedServiceProviderTests
+    {
+        [Fact]
+        public void GetServiceWithoutError()
+        {
+            /***
+            Note
+            ==========
+            This code is adapted from `HotChocolate.SchemaBuilder.Setup.InitializeInterceptors<T>`,
+            which was the next relevant call down "down the stack" in the error traces which
+            motivate changes to the subject-under-test (i.e. CombinedServiceProvider).
+            ***/
+            IServiceProvider stringServices = new DictionaryServiceProvider(
+                (typeof(IEnumerable<string>), new List<string>(new[] { "one", "two" }))
+            );
+
+            IServiceProvider numberServices = new DictionaryServiceProvider(
+                (typeof(IEnumerable<int>), new List<int>(new[] { 1, 2, 3, 4, 5 }))
+            );
+
+            IServiceProvider services = new CombinedServiceProvider(stringServices, numberServices);
+
+            switch (services.GetService<IEnumerable<int>>())
+            {
+                case null:
+                    throw new Exception("Could not locate service!");
+
+                case var target:
+                    Assert.Equal(15, target.Sum());
+                    break;
+            }
+        }
+
+        [Fact(Skip = "For demonstration purposed only")]
+        public void ThrowRefelctionError()
+        {
+            var actual = AnyFailure(typeof(IEnumerable<int>), Array.Empty<int>());
+            Assert.False(actual);
+        }
+
+        /// This method simulates a rare -- but possible -- edge case in the
+        /// implementation of `CombinedServiceProvider.Any()`. Specifically,
+        /// there are occasions wherein the _wrong_ overload of `Enumerable.Any()`
+        /// is selected, which results in run-time exception. This method will
+        /// fail when run. It is intended for instructional purposes only.
+        private bool AnyFailure(Type enumerableType, object enumerable)
+        {
+            Type genericArgumentType = enumerableType
+                .GetTypeInfo()
+                .GenericTypeArguments[0];
+
+            MethodInfo info = typeof(Enumerable)
+                .GetTypeInfo()
+                .DeclaredMethods
+                .First(m =>
+                    m.IsStatic &&
+                    m.Name == nameof(Enumerable.Any) &&
+                    m.GetParameters().Length > 1)
+                    /***
+                     Note
+                     ==========
+                     There are two overloads of `Any` (arity 1 and arity 2).
+                     We only want the one which takes a single argument (arity 1).
+                     Explicitly selecting an overload with different arity will
+                     cause a TargetParameterCountException error when invoked (below).
+                     ***/
+                .MakeGenericMethod(genericArgumentType);
+
+            return (bool)info.Invoke(null, new[] { enumerable });
+        }
+    }
+}


### PR DESCRIPTION
This patch adds additional logic to guard against weird edge cases caused by the non-deterministic nature of LInQ + reflection. 

Specifically, it adds more logic to a predicate (used by a utility method, `Utilities.CombinedServiceProvider.Any`) to ensure the correct overload of `Enumerable.Any` is selected. In a very small -- but impactful! -- percentage of deployments, the order of the `MethodInfo` instances being processed changes. This change of order, though infrequent, leads to a `TargetParameterCountException` when the `MethodInfo` is ultimately invoked. Effectively, all this patch does is make certain assumptions _explicit_ (namely, that we want to use the arity-1 overload rather than a different overload).

This may (or may not) be related to the following issues:
+  #3073 
+  #3171 

But in any event, this was motivated by having three different services log run-time exceptions with the following stack trace:
```
System.Reflection.TargetParameterCountException: Parameter count mismatch.
   at System.Reflection.RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at HotChocolate.Utilities.CombinedServiceProvider.Any(Type enumerableType, Object enumerable)
   at HotChocolate.Utilities.CombinedServiceProvider.Concat(Type enumerableType, Object enumerableA, Object enumerableB)
   at HotChocolate.Utilities.CombinedServiceProvider.GetService(Type serviceType)
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService[T](IServiceProvider provider)
   at HotChocolate.SchemaBuilder.Setup.InitializeInterceptors[T](IServiceProvider services, IReadOnlyList`1 registered, List`1 interceptors)
   at HotChocolate.SchemaBuilder.Setup.CreateContext(SchemaBuilder builder, LazySchema lazySchema)
   at HotChocolate.SchemaBuilder.Setup.Create(SchemaBuilder builder)
   at HotChocolate.SchemaBuilder.Create()
   at HotChocolate.SchemaBuilder.HotChocolate.ISchemaBuilder.Create()
   at HotChocolate.Execution.RequestExecutorResolver.CreateSchemaAsync(NameString schemaName, RequestExecutorSetup options, IServiceProvider serviceProvider, CancellationToken cancellationToken)
   at HotChocolate.Execution.RequestExecutorResolver.CreateSchemaServicesAsync(NameString schemaName, RequestExecutorSetup options, CancellationToken cancellationToken)
   at HotChocolate.Execution.RequestExecutorResolver.GetRequestExecutorNoLockAsync(NameString schemaName, CancellationToken cancellationToken)
   at HotChocolate.Execution.RequestExecutorResolver.GetRequestExecutorAsync(NameString schemaName, CancellationToken cancellationToken)
   at HotChocolate.Execution.RequestExecutorProxy.GetRequestExecutorAsync(CancellationToken cancellationToken)
   at HotChocolate.AspNetCore.HttpPostMiddleware.HandleRequestAsync(HttpContext context, AllowedContentType contentType)
   at HotChocolate.AspNetCore.HttpPostMiddleware.InvokeAsync(HttpContext context)
   at HotChocolate.AspNetCore.WebSocketSubscriptionMiddleware.InvokeAsync(HttpContext context)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authorization.Policy.AuthorizationMiddlewareResultHandler.HandleAsync(RequestDelegate next, HttpContext context, AuthorizationPolicy policy, PolicyAuthorizationResult authorizeResult)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
```
Please note, the patch includes a (skipped) test which _simulates_ the behavior against which the proposed changes will protect. As the actual issue occurs frequently enough to be unavoidable -- but not in a consistent and readily-reproducible fashion -- I hope this is sufficient (in lieu of an actual minimal reproduction). 

Also, I am submitting this as a bugfix against the v11 branch, as that is what is currently deployed (we're hopeful for a small point-release in the near future :wink: ). However, I've noticed the v12 branch could also benefit from this patch.

Thanks!
