### PR TITLE
Fixed wrong class used for IObjectTypeDescriptor in class TodoType in Documentation

### DIFF
--- a/website/src/docs/hotchocolate/fetching-data/fetching-from-rest.md
+++ b/website/src/docs/hotchocolate/fetching-data/fetching-from-rest.md
@@ -152,7 +152,7 @@ public class QueryType : ObjectType<Query>
 // TodoType.cs
 public class TodoType : ObjectType<Todo>
 {
-    protected override void Configure(IObjectTypeDescriptor<Query> descriptor)
+    protected override void Configure(IObjectTypeDescriptor<Todo> descriptor)
     {
         descriptor
             .Field(f => f.Id)


### PR DESCRIPTION
Fixed wrong class used for IObjectTypeDescriptor in class TodoType in Documentation


Closes #4251
