### PR TITLE
Adding missing setter to ResolveXmlDocumentationFileName property on …

### DIFF
--- a/src/HotChocolate/Core/src/Types/ISchemaOptions.cs
+++ b/src/HotChocolate/Core/src/Types/ISchemaOptions.cs
@@ -42,7 +42,7 @@ namespace HotChocolate
          /// A delegate which resolves the name of the XML documentation file to be read.
          /// Only used if <seealso cref="UseXmlDocumentation"/> is true.
          /// </summary>
-        new Func<Assembly, string>? ResolveXmlDocumentationFileName { get; }
+        new Func<Assembly, string>? ResolveXmlDocumentationFileName { get; set; }
 
         /// <summary>
         /// Defines if fields shall be sorted by name.


### PR DESCRIPTION
…ISchemaOptions

Summary of the changes (Less than 80 chars)

- Adding a missing setter
