### PR TITLE
Edited typo in website's Subscriptions page - Publishing Events section

### DIFF
--- a/website/src/docs/hotchocolate/defining-a-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/subscriptions.md
@@ -186,7 +186,7 @@ Our Redis subscription provider uses the [StackExchange.Redis](https://github.co
 
 To publish events and trigger subscriptions, we can use the `ITopicEventSender`. The `ITopicEventSender` is an abstraction for the registered event publishing provider. Using this abstraction allows us to seamlessly switch between subscription providers, when necessary.
 
-Most of the time we will be publishing events for successful mutations. Therefor we can simply inject the `ITopicEventSender` into our mutations like we would with every other `Service`. Of course we can not only publish events from mutations, but everywhere we have access to the `ITopicEventSender` through the DI Container.
+Most of the time we will be publishing events for successful mutations. Therefore we can simply inject the `ITopicEventSender` into our mutations like we would with every other `Service`. Of course we can not only publish events from mutations, but everywhere we have access to the `ITopicEventSender` through the DI Container.
 
 ```csharp
 public class Mutation


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Edited typo in Publishing Events section in the Subscriptions page of the website

Closes #bugnumber (in this specific format) - N/A
