### PR TITLE
Replace NuGet references with Project references

### DIFF
--- a/src/StrawberryShake/SourceGenerator/StrawberryShake.SourceGenerator.sln
+++ b/src/StrawberryShake/SourceGenerator/StrawberryShake.SourceGenerator.sln
@@ -1,19 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{CAECD940-C3AE-4589-AD83-B3F9EA9CB80A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StrawberryShake.CodeGeneration.CSharp.Analyzers", "src\CodeGeneration.CSharp.Analyzers\StrawberryShake.CodeGeneration.CSharp.Analyzers.csproj", "{587B6DC4-BF55-4138-BB8A-F2F2503FDF00}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StrawberryShake.CodeGeneration.CSharp.Analyzers", "src\CodeGeneration.CSharp.Analyzers\StrawberryShake.CodeGeneration.CSharp.Analyzers.csproj", "{587B6DC4-BF55-4138-BB8A-F2F2503FDF00}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8F0BFA5F-E5A0-4586-9ED4-6189286F4D3B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StrawberryShake.CodeGeneration.CSharp.Analyzers.Tests", "test\CodeGeneration.CSharp.Analyzers.Tests\StrawberryShake.CodeGeneration.CSharp.Analyzers.Tests.csproj", "{C16A7FE1-E460-4B83-B093-012E9D27D5F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StrawberryShake.CodeGeneration.CSharp.Analyzers.Tests", "test\CodeGeneration.CSharp.Analyzers.Tests\StrawberryShake.CodeGeneration.CSharp.Analyzers.Tests.csproj", "{C16A7FE1-E460-4B83-B093-012E9D27D5F2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".referenced", ".referenced", "{9E66ECE3-81EF-4BCC-BE28-5AD884DB8572}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StrawberryShake.Tools.Configuration", "..\Tooling\src\Configuration\StrawberryShake.Tools.Configuration.csproj", "{B5BA7FA0-6BC2-48FC-8714-6C19A219C9A4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StrawberryShake.Tools.Configuration", "..\Tooling\src\Configuration\StrawberryShake.Tools.Configuration.csproj", "{B5BA7FA0-6BC2-48FC-8714-6C19A219C9A4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StrawberryShake.CodeGeneration.CSharp", "..\CodeGeneration\src\CodeGeneration.CSharp\StrawberryShake.CodeGeneration.CSharp.csproj", "{1B181916-1B8C-47A5-A654-0994104DE9F6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,9 +25,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{587B6DC4-BF55-4138-BB8A-F2F2503FDF00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -64,10 +63,29 @@ Global
 		{B5BA7FA0-6BC2-48FC-8714-6C19A219C9A4}.Release|x64.Build.0 = Release|Any CPU
 		{B5BA7FA0-6BC2-48FC-8714-6C19A219C9A4}.Release|x86.ActiveCfg = Release|Any CPU
 		{B5BA7FA0-6BC2-48FC-8714-6C19A219C9A4}.Release|x86.Build.0 = Release|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Debug|x64.Build.0 = Debug|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Debug|x86.Build.0 = Debug|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Release|x64.ActiveCfg = Release|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Release|x64.Build.0 = Release|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Release|x86.ActiveCfg = Release|Any CPU
+		{1B181916-1B8C-47A5-A654-0994104DE9F6}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{587B6DC4-BF55-4138-BB8A-F2F2503FDF00} = {CAECD940-C3AE-4589-AD83-B3F9EA9CB80A}
 		{C16A7FE1-E460-4B83-B093-012E9D27D5F2} = {8F0BFA5F-E5A0-4586-9ED4-6189286F4D3B}
 		{B5BA7FA0-6BC2-48FC-8714-6C19A219C9A4} = {9E66ECE3-81EF-4BCC-BE28-5AD884DB8572}
+		{1B181916-1B8C-47A5-A654-0994104DE9F6} = {9E66ECE3-81EF-4BCC-BE28-5AD884DB8572}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8C5E364A-30B1-4B2B-931B-C1394C86A119}
 	EndGlobalSection
 EndGlobal

--- a/src/StrawberryShake/SourceGenerator/src/CodeGeneration.CSharp.Analyzers/StrawberryShake.CodeGeneration.CSharp.Analyzers.csproj
+++ b/src/StrawberryShake/SourceGenerator/src/CodeGeneration.CSharp.Analyzers/StrawberryShake.CodeGeneration.CSharp.Analyzers.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StrawberryShake.CodeGeneration.CSharp" Version="12.0.0-preview.26" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="DotNet.Glob" Version="3.1.2" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
@@ -35,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\CodeGeneration\src\CodeGeneration.CSharp\StrawberryShake.CodeGeneration.CSharp.csproj" />
     <ProjectReference Include="..\..\..\Tooling\src\Configuration\StrawberryShake.Tools.Configuration.csproj" />
   </ItemGroup>
 

--- a/src/StrawberryShake/SourceGenerator/test/CodeGeneration.CSharp.Analyzers.Tests/StrawberryShake.CodeGeneration.CSharp.Analyzers.Tests.csproj
+++ b/src/StrawberryShake/SourceGenerator/test/CodeGeneration.CSharp.Analyzers.Tests/StrawberryShake.CodeGeneration.CSharp.Analyzers.Tests.csproj
@@ -10,15 +10,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-    <PackageReference Include="StrawberryShake.CodeGeneration.CSharp.Analyzers" Version="12.0.0-local.2001" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.4" />
-    <PackageReference Include="StrawberryShake.CodeGeneration.CSharp" Version="11.2.0-local.602" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Client\src\Core\StrawberryShake.Core.csproj" />
     <ProjectReference Include="..\..\..\Client\src\Transport.Http\StrawberryShake.Transport.Http.csproj" />
     <ProjectReference Include="..\..\..\Client\src\Transport.WebSockets\StrawberryShake.Transport.WebSockets.csproj" />
+    <ProjectReference Include="..\..\..\CodeGeneration\src\CodeGeneration.CSharp\StrawberryShake.CodeGeneration.CSharp.csproj" />
+    <ProjectReference Include="..\..\src\CodeGeneration.CSharp.Analyzers\StrawberryShake.CodeGeneration.CSharp.Analyzers.csproj" />
   </ItemGroup>
 
   <!--For Visual Studio for Mac Test Explorer we need this reference here-->


### PR DESCRIPTION
I could not build StrawberryShake.SourceGenerator.sln and I noticed some project files contained references to StrawberryShake projects via NuGet instead of as project references. I replaced those and building worked again.

I am wondering how this situation did not cause build failures for others.