### PR TITLE
Update CustomHeaderHelper.cs

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/CustomHeaderHelper.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/CustomHeaderHelper.cs
@@ -11,7 +11,7 @@ namespace StrawberryShake.Tools
 
             foreach (var argument in arguments)
             {
-                var argumentParts = argument?.Trim().Split("=");
+                var argumentParts = argument?.Trim().Split("=", 2);
                 if (argumentParts?.Length != 2)
                 {
                     continue;


### PR DESCRIPTION
Updated to allow value to contain '=' for instance, when a Base64 encoded value has to be submitted as a header.
These can end with ==.
The current version will fail and not add the requested header to the request.

Currently, when using dotnet graphql init --header my-header-value=somehashedvalue== the key-value pair will not be added to the request.
