### PR TITLE
Spec: Client-Controlled Nullability

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -5,3 +5,4 @@ rootDir=$(dirname "$0")
 
 $rootDir/src/HotChocolate/AspNetCore/format.sh
 $rootDir/src/HotChocolate/Data/format.sh
+$rootDir/src/HotChocolate/Language/format.sh

--- a/src/GreenDonut/test/Core.Tests/AutoBatchSchedulerTests.cs
+++ b/src/GreenDonut/test/Core.Tests/AutoBatchSchedulerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using Xunit;
 
 namespace GreenDonut
@@ -7,12 +9,20 @@ namespace GreenDonut
         [Fact]
         public void DispatchOnEnqueue()
         {
+            // arrange
             var dispatched = false;
+            var waitHandle = new AutoResetEvent(false);
+
+            // act
             AutoBatchScheduler.Default.Schedule(() =>
             {
                 dispatched = true;
+                waitHandle.Set();
                 return default;
             });
+
+            // assert
+            waitHandle.WaitOne(TimeSpan.FromSeconds(5));
             Assert.True(dispatched);
         }
     }

--- a/src/HotChocolate/Core/src/Abstractions/Properties/AbstractionResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Properties/AbstractionResources.Designer.cs
@@ -200,5 +200,11 @@ namespace HotChocolate.Properties {
                 return ResourceManager.GetString("QueryResult_DataAndResultAreNull", resourceCulture);
             }
         }
+        
+        internal static string ThrowHelper_TryRewriteNullability_InvalidNullabilityStructure {
+            get {
+                return ResourceManager.GetString("ThrowHelper_TryRewriteNullability_InvalidNullabilityStructure", resourceCulture);
+            }
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Abstractions/Properties/AbstractionResources.resx
+++ b/src/HotChocolate/Core/src/Abstractions/Properties/AbstractionResources.resx
@@ -195,4 +195,7 @@
   <data name="QueryResult_DataAndResultAreNull" xml:space="preserve">
     <value>data and errors cannot be null at the same time.</value>
   </data>
+  <data name="ThrowHelper_TryRewriteNullability_InvalidNullabilityStructure" xml:space="preserve">
+    <value>The nullability modifier does not match the field type structure.</value>
+  </data>
 </root>

--- a/src/HotChocolate/Core/src/Execution/Processing/Operation.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Operation.cs
@@ -158,6 +158,7 @@ internal sealed class Operation : IPreparedOperation
             null,
             selection.SyntaxNode.Name,
             selection.SyntaxNode.Alias,
+            null,
             directives,
             selection.SyntaxNode.Arguments,
             selectionSet);

--- a/src/HotChocolate/Core/src/Execution/Processing/Operation.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Operation.cs
@@ -170,9 +170,9 @@ internal sealed class Operation : IPreparedOperation
         arguments[0] = new ArgumentNode("id", new IntValueNode(selection.Id));
         arguments[1] = new ArgumentNode("kind", new EnumValueNode(selection.Strategy));
 
-        if (selection.Field.Type.IsListType())
+        if (selection.Type.IsListType())
         {
-            if (selection.Field.Type.NamedType().IsLeafType())
+            if (selection.Type.NamedType().IsLeafType())
             {
                 arguments[2] = new ArgumentNode("type", new EnumValueNode("LEAF_LIST"));
             }
@@ -181,11 +181,11 @@ internal sealed class Operation : IPreparedOperation
                 arguments[2] = new ArgumentNode("type", new EnumValueNode("COMPOSITE_LIST"));
             }
         }
-        else if (selection.Field.Type.IsCompositeType())
+        else if (selection.Type.IsCompositeType())
         {
             arguments[2] = new ArgumentNode("type", new EnumValueNode("COMPOSITE"));
         }
-        else if (selection.Field.Type.IsLeafType())
+        else if (selection.Type.IsLeafType())
         {
             arguments[2] = new ArgumentNode("type", new EnumValueNode("LEAF"));
         }

--- a/src/HotChocolate/Core/src/Execution/Processing/OperationCompiler.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/OperationCompiler.cs
@@ -232,7 +232,7 @@ public sealed partial class OperationCompiler
             else
             {
                 Func<object, IAsyncEnumerable<object?>>? createStream = null;
-                bool isStreamable = selection.IsStreamable();
+                var isStreamable = selection.IsStreamable();
 
                 if (field.MaybeStream || field.Type.IsListType() && isStreamable)
                 {

--- a/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
@@ -298,6 +298,7 @@ public class Selection : ISelection
             first.Location,
             first.Name,
             first.Alias,
+            null,
             MergeDirectives(selections),
             first.Arguments,
             MergeSelections(first, selections));

--- a/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
@@ -38,6 +38,41 @@ public class Selection : ISelection
         SelectionExecutionStrategy? strategy = null,
         Func<object, IAsyncEnumerable<object?>>? createStream = null,
         bool isStreamable = false)
+        : this(
+            id,
+            declaringType,
+            field,
+            field.Type,
+            selection,
+            resolverPipeline,
+            pureResolver,
+            responseName,
+            arguments,
+            includeCondition,
+            internalSelection,
+            strategy,
+            createStream,
+            isStreamable)
+    {
+
+    }
+
+
+    public Selection(
+        int id,
+        IObjectType declaringType,
+        IObjectField field,
+        IType type,
+        FieldNode selection,
+        FieldDelegate? resolverPipeline,
+        PureFieldDelegate? pureResolver = null,
+        NameString? responseName = null,
+        IReadOnlyDictionary<NameString, ArgumentValue>? arguments = null,
+        SelectionIncludeCondition? includeCondition = null,
+        bool internalSelection = false,
+        SelectionExecutionStrategy? strategy = null,
+        Func<object, IAsyncEnumerable<object?>>? createStream = null,
+        bool isStreamable = false)
     {
         if (resolverPipeline is null && pureResolver is null)
         {
@@ -51,6 +86,7 @@ public class Selection : ISelection
             ?? throw new ArgumentNullException(nameof(declaringType));
         Field = field
             ?? throw new ArgumentNullException(nameof(field));
+        Type = type;
         SyntaxNode = selection
             ?? throw new ArgumentNullException(nameof(selection));
         ResponseName = responseName ??
@@ -80,7 +116,7 @@ public class Selection : ISelection
 
         IsStreamable = isStreamable && createStream is not null;
         MaybeStream = Field.MaybeStream && createStream is not null;
-        IsList = Field.Type.IsListType();
+        IsList = type.IsListType();
 
         if (includeCondition is not null)
         {
@@ -103,6 +139,7 @@ public class Selection : ISelection
         _isReadOnly = selection._isReadOnly;
         DeclaringType = selection.DeclaringType;
         Field = selection.Field;
+        Type = selection.Type;
         SyntaxNode = selection.SyntaxNode;
         _selections = selection._selections;
         _syntaxNodes = selection._syntaxNodes;
@@ -132,10 +169,10 @@ public class Selection : ISelection
     // Note: this field was introduced to allow rewriting the type of a selection
     // in the operation compiler.
     /// <inheritdoc />
-    public IType Type => Field.Type;
+    public IType Type { get; }
 
     /// <inheritdoc />
-    public TypeKind TypeKind => Field.Type.Kind;
+    public TypeKind TypeKind => Type.Kind;
 
     /// <inheritdoc />
     public FieldNode SyntaxNode { get; private set; }

--- a/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.cs
@@ -138,8 +138,9 @@ internal sealed partial class ResolverTask : IExecutionTask
         }
 
         CompletedValue = completedValue;
+        var isNonNullType = _selection.Type.IsNonNullType();
 
-        if (completedValue is null && _selection.Type.IsNonNullType())
+        if (completedValue is null && isNonNullType)
         {
             // if we detect a non-null violation we will stash it for later.
             // the non-null propagation is delayed so that we can parallelize better.
@@ -156,7 +157,7 @@ internal sealed partial class ResolverTask : IExecutionTask
                 _resolverContext.ResponseIndex,
                 _resolverContext.ResponseName,
                 completedValue,
-                _resolverContext.Field.Type.IsNullableType());
+                !isNonNullType);
         }
     }
 

--- a/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTaskFactory.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTaskFactory.cs
@@ -341,9 +341,9 @@ internal static class ResolverTaskFactory
         ResultMap resultMap,
         object? completedValue)
     {
-        var isNullable = selection.Type.IsNonNullType();
+        var isNonNullType = selection.Type.IsNonNullType();
 
-        if (completedValue is null && isNullable)
+        if (completedValue is null && isNonNullType)
         {
             // if we detect a non-null violation we will stash it for later.
             // the non-null propagation is delayed so that we can parallelize better.
@@ -358,7 +358,7 @@ internal static class ResolverTaskFactory
                 responseIndex,
                 selection.ResponseName,
                 completedValue,
-                isNullable);
+                !isNonNullType);
         }
     }
 

--- a/src/HotChocolate/Core/src/Types/Utilities/ThrowHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ThrowHelper.cs
@@ -402,4 +402,7 @@ internal static class ThrowHelper
                 .Build(),
             type,
             path);
+
+    public static InvalidOperationException RewriteNullability_InvalidNullabilityStructure()
+        => new(AbstractionResources.ThrowHelper_TryRewriteNullability_InvalidNullabilityStructure);
 }

--- a/src/HotChocolate/Core/src/Validation/Rules/FieldVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/FieldVisitor.cs
@@ -228,7 +228,9 @@ internal sealed class FieldVisitor : TypeDocumentValidatorVisitor
                             fieldB.ResponseName,
                             StringComparison.Ordinal))
                     {
-                        if (SameResponseShape(fieldA.Type, fieldB.Type))
+                        if (SameResponseShape(
+                            fieldA.Type.RewriteNullability(fieldA.Field.Required),
+                            fieldB.Type.RewriteNullability(fieldB.Field.Required)))
                         {
                             if (IsParentTypeAligned(fieldA, fieldB))
                             {

--- a/src/HotChocolate/Core/test/Abstractions.Tests/Execution/__snapshots__/QueryRequestBuilderTests.BuildRequest_OnlyQueryDocIsSet_RequestHasOnlyQuery.snap
+++ b/src/HotChocolate/Core/test/Abstractions.Tests/Execution/__snapshots__/QueryRequestBuilderTests.BuildRequest_OnlyQueryDocIsSet_RequestHasOnlyQuery.snap
@@ -34,6 +34,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 2,

--- a/src/HotChocolate/Core/test/Execution.Tests/ClientControlledNullabilityTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/ClientControlledNullabilityTests.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using HotChocolate.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Snapshooter.Xunit;
 using Xunit;
+
+#nullable enable
 
 namespace HotChocolate.Execution;
 
@@ -19,5 +22,57 @@ public class ClientControlledNullabilityTests
             .AddResolver("Query", "field", _ => null)
             .ExecuteRequestAsync("{ field! }")
             .MatchSnapshotAsync();
+    }
+
+    [Fact]
+    public async Task ErrorBoundary_Bio_NonNull_Person_Nullable()
+    {
+        Snapshot.FullName();
+
+        await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<Query>()
+            .ExecuteRequestAsync(@"
+                {
+                    persons? {
+                        name
+                        bio!
+                    }
+                }")
+            .MatchSnapshotAsync();
+    }
+
+    [Fact]
+    public async Task ErrorBoundary_Bio_NonNull_Person_Element_Nullable()
+    {
+        Snapshot.FullName();
+
+        await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<Query>()
+            .ExecuteRequestAsync(@"
+                {
+                    persons[?] {
+                        name
+                        bio!
+                    }
+                }")
+            .MatchSnapshotAsync();
+    }
+
+    public class Query
+    {
+        public List<Person> Persons { get; } = new()
+        {
+            new Person {Name = "Abc", Bio = "Def"},
+            new Person {Name = "Ghi", Bio = null}
+        };
+    }
+
+    public class Person
+    {
+        public string Name { get; set; }
+
+        public string? Bio { get; set; }
     }
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/ClientControlledNullabilityTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/ClientControlledNullabilityTests.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using HotChocolate.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace HotChocolate.Execution;
+
+public class ClientControlledNullabilityTests
+{
+    [Fact]
+    public async Task Make_NullableField_NonNull_And_Return_Null()
+    {
+        Snapshot.FullName();
+
+        await new ServiceCollection()
+            .AddGraphQL()
+            .AddDocumentFromString("type Query { field: String }")
+            .AddResolver("Query", "field", _ => null)
+            .ExecuteRequestAsync("{ field! }")
+            .MatchSnapshotAsync();
+    }
+}

--- a/src/HotChocolate/Core/test/Execution.Tests/MiddlewareContextTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/MiddlewareContextTests.cs
@@ -141,12 +141,12 @@ namespace HotChocolate.Execution
             IFieldSelection selection,
             ICollection<IFieldSelection> collected)
         {
-            if (selection.Field.Type.IsLeafType())
+            if (selection.Type.IsLeafType())
             {
                 collected.Add(selection);
             }
 
-            if (selection.Field.Type.NamedType() is ObjectType objectType)
+            if (selection.Type.NamedType() is ObjectType objectType)
             {
                 foreach (IFieldSelection child in context.GetSelections(
                     objectType, selection.SyntaxNode.SelectionSet))

--- a/src/HotChocolate/Core/test/Execution.Tests/Processing/OperationCompilerTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Processing/OperationCompilerTests.cs
@@ -1261,6 +1261,7 @@ namespace HotChocolate.Execution.Processing
                         context.GetNextId(),
                         context.Type,
                         baz,
+                        baz.Type,
                         bazSelection,
                         bazPipeline,
                         internalSelection: true);

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/ClientControlledNullabilityTests.ErrorBoundary_Bio_NonNull_Person_Element_Nullable.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/ClientControlledNullabilityTests.ErrorBoundary_Bio_NonNull_Person_Element_Nullable.snap
@@ -1,0 +1,30 @@
+﻿{
+  "errors": [
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 5,
+          "column": 25
+        }
+      ],
+      "path": [
+        "persons",
+        1,
+        "bio"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    }
+  ],
+  "data": {
+    "persons": [
+      {
+        "name": "Abc",
+        "bio": "Def"
+      },
+      null
+    ]
+  }
+}

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/ClientControlledNullabilityTests.ErrorBoundary_Bio_NonNull_Person_Nullable.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/ClientControlledNullabilityTests.ErrorBoundary_Bio_NonNull_Person_Nullable.snap
@@ -1,0 +1,24 @@
+﻿{
+  "errors": [
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 5,
+          "column": 25
+        }
+      ],
+      "path": [
+        "persons",
+        1,
+        "bio"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    }
+  ],
+  "data": {
+    "persons": null
+  }
+}

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/ClientControlledNullabilityTests.Make_NullableField_NonNull_And_Return_Null.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/ClientControlledNullabilityTests.Make_NullableField_NonNull_And_Return_Null.snap
@@ -1,0 +1,19 @@
+﻿{
+  "errors": [
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 1,
+          "column": 3
+        }
+      ],
+      "path": [
+        "field"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    }
+  ]
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/ResolverCompilerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/ResolverCompilerTests.cs
@@ -505,6 +505,7 @@ namespace HotChocolate.Resolvers
                 null,
                 new NameNode("foo"),
                 null,
+                null,
                 Array.Empty<DirectiveNode>(),
                 Array.Empty<ArgumentNode>(),
                 null);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/TypeExtensionsTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/TypeExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using HotChocolate.Language;
 using Moq;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace HotChocolate.Types
             var y = new NonNullType(new StringType());
 
             // act
-            bool result = x.IsEqualTo(y);
+            var result = x.IsEqualTo(y);
 
             // assert
             Assert.True(result);
@@ -28,7 +29,7 @@ namespace HotChocolate.Types
             var y = new ListType(new StringType());
 
             // act
-            bool result = x.IsEqualTo(y);
+            var result = x.IsEqualTo(y);
 
             // assert
             Assert.True(result);
@@ -42,7 +43,7 @@ namespace HotChocolate.Types
             var y = new NonNullType(new ListType(new StringType()));
 
             // act
-            bool result = x.IsEqualTo(y);
+            var result = x.IsEqualTo(y);
 
             // assert
             Assert.True(result);
@@ -56,7 +57,7 @@ namespace HotChocolate.Types
             var y = new ListType(new StringType());
 
             // act
-            bool result = x.IsEqualTo(y);
+            var result = x.IsEqualTo(y);
 
             // assert
             Assert.False(result);
@@ -69,7 +70,7 @@ namespace HotChocolate.Types
             var x = new StringType();
 
             // act
-            bool result = x.IsEqualTo(x);
+            var result = x.IsEqualTo(x);
 
             // assert
             Assert.True(result);
@@ -83,7 +84,7 @@ namespace HotChocolate.Types
             var y = new ListType(new IntType());
 
             // act
-            bool result = x.IsEqualTo(y);
+            var result = x.IsEqualTo(y);
 
             // assert
             Assert.False(result);
@@ -99,7 +100,7 @@ namespace HotChocolate.Types
                         new StringType())));
 
             // act
-            StringType stringType = type.NamedType() as StringType;
+            var stringType = type.NamedType() as StringType;
 
             // assert
             Assert.NotNull(stringType);
@@ -109,10 +110,10 @@ namespace HotChocolate.Types
         public static void NamedType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.NamedType(null);
+            void Action() => TypeExtensions.NamedType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -122,7 +123,7 @@ namespace HotChocolate.Types
             var type = new NonNullType(new StringType());
 
             // act
-            bool result = type.IsNonNullType();
+            var result = type.IsNonNullType();
 
             // assert
             Assert.True(result);
@@ -135,7 +136,7 @@ namespace HotChocolate.Types
             var type = new StringType();
 
             // act
-            bool result = type.IsNonNullType();
+            var result = type.IsNonNullType();
 
             // assert
             Assert.False(result);
@@ -145,10 +146,10 @@ namespace HotChocolate.Types
         public static void IsNonNullType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsNonNullType(null);
+            void Action() => TypeExtensions.IsNonNullType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -158,7 +159,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<ObjectType>();
 
             // act
-            bool result = type.IsCompositeType();
+            var result = type.IsCompositeType();
 
             // assert
             Assert.True(result);
@@ -171,7 +172,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<InterfaceType>();
 
             // act
-            bool result = type.IsCompositeType();
+            var result = type.IsCompositeType();
 
             // assert
             Assert.True(result);
@@ -184,7 +185,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsCompositeType();
+            var result = type.IsCompositeType();
 
             // assert
             Assert.True(result);
@@ -197,7 +198,7 @@ namespace HotChocolate.Types
             var type = new StringType();
 
             // act
-            bool result = type.IsCompositeType();
+            var result = type.IsCompositeType();
 
             // assert
             Assert.False(result);
@@ -207,10 +208,10 @@ namespace HotChocolate.Types
         public static void IsCompositeType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsCompositeType(null);
+            void Action() => TypeExtensions.IsCompositeType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -220,7 +221,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<ObjectType>();
 
             // act
-            bool result = type.IsComplexType();
+            var result = type.IsComplexType();
 
             // assert
             Assert.True(result);
@@ -233,7 +234,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<InterfaceType>();
 
             // act
-            bool result = type.IsComplexType();
+            var result = type.IsComplexType();
 
             // assert
             Assert.True(result);
@@ -247,7 +248,7 @@ namespace HotChocolate.Types
             type.SetupGet(t => t.Kind).Returns(TypeKind.Union);
 
             // act
-            bool result = type.Object.IsComplexType();
+            var result = type.Object.IsComplexType();
 
             // assert
             Assert.False(result);
@@ -260,7 +261,7 @@ namespace HotChocolate.Types
             var type = new StringType();
 
             // act
-            bool result = type.IsComplexType();
+            var result = type.IsComplexType();
 
             // assert
             Assert.False(result);
@@ -270,10 +271,10 @@ namespace HotChocolate.Types
         public static void IsComplexType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsComplexType(null);
+            void Action() => TypeExtensions.IsComplexType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -283,7 +284,7 @@ namespace HotChocolate.Types
             var type = new StringType();
 
             // act
-            bool result = type.IsLeafType();
+            var result = type.IsLeafType();
 
             // assert
             Assert.True(result);
@@ -297,7 +298,7 @@ namespace HotChocolate.Types
             type.SetupGet(t => t.Kind).Returns(TypeKind.Enum);
 
             // act
-            bool result = type.Object.IsLeafType();
+            var result = type.Object.IsLeafType();
 
             // assert
             Assert.True(result);
@@ -310,7 +311,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsLeafType();
+            var result = type.IsLeafType();
 
             // assert
             Assert.False(result);
@@ -320,10 +321,10 @@ namespace HotChocolate.Types
         public static void IsLeafType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsLeafType(null);
+            void Action() => TypeExtensions.IsLeafType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -333,7 +334,7 @@ namespace HotChocolate.Types
             IType type = new ListType(new StringType());
 
             // act
-            bool result = type.IsListType();
+            var result = type.IsListType();
 
             // assert
             Assert.True(result);
@@ -346,7 +347,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsListType();
+            var result = type.IsListType();
 
             // assert
             Assert.False(result);
@@ -356,10 +357,10 @@ namespace HotChocolate.Types
         public static void IsListType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsListType(null);
+            void Action() => TypeExtensions.IsListType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -369,7 +370,7 @@ namespace HotChocolate.Types
             IType type = new StringType();
 
             // act
-            bool result = type.IsScalarType();
+            var result = type.IsScalarType();
 
             // assert
             Assert.True(result);
@@ -382,7 +383,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsScalarType();
+            var result = type.IsScalarType();
 
             // assert
             Assert.False(result);
@@ -392,10 +393,10 @@ namespace HotChocolate.Types
         public static void IsScalarType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsScalarType(null);
+            void Action() => TypeExtensions.IsScalarType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -406,7 +407,7 @@ namespace HotChocolate.Types
             type.SetupGet(t => t.Kind).Returns(TypeKind.Object);
 
             // act
-            bool result = type.Object.IsObjectType();
+            var result = type.Object.IsObjectType();
 
             // assert
             Assert.True(result);
@@ -419,7 +420,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsObjectType();
+            var result = type.IsObjectType();
 
             // assert
             Assert.False(result);
@@ -429,10 +430,10 @@ namespace HotChocolate.Types
         public static void IsObjectType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsObjectType(null);
+            void Action() => TypeExtensions.IsObjectType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -442,7 +443,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<InterfaceType>();
 
             // act
-            bool result = type.IsInterfaceType();
+            var result = type.IsInterfaceType();
 
             // assert
             Assert.True(result);
@@ -456,7 +457,7 @@ namespace HotChocolate.Types
             type.SetupGet(t => t.Kind).Returns(TypeKind.Union);
 
             // act
-            bool result = type.Object.IsScalarType();
+            var result = type.Object.IsScalarType();
 
             // assert
             Assert.False(result);
@@ -466,10 +467,10 @@ namespace HotChocolate.Types
         public static void IsInterfaceType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsInterfaceType(null);
+            void Action() => TypeExtensions.IsInterfaceType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -480,7 +481,7 @@ namespace HotChocolate.Types
             type.SetupGet(t => t.Kind).Returns(TypeKind.Enum);
 
             // act
-            bool result = type.Object.IsEnumType();
+            var result = type.Object.IsEnumType();
 
             // assert
             Assert.True(result);
@@ -493,7 +494,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsEnumType();
+            var result = type.IsEnumType();
 
             // assert
             Assert.False(result);
@@ -503,10 +504,10 @@ namespace HotChocolate.Types
         public static void IsEnumType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsEnumType(null);
+            void Action() => TypeExtensions.IsEnumType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -517,7 +518,7 @@ namespace HotChocolate.Types
             type.SetupGet(t => t.Kind).Returns(TypeKind.Union);
 
             // act
-            bool result = type.Object.IsUnionType();
+            var result = type.Object.IsUnionType();
 
             // assert
             Assert.True(result);
@@ -530,7 +531,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<ObjectType>();
 
             // act
-            bool result = type.IsUnionType();
+            var result = type.IsUnionType();
 
             // assert
             Assert.False(result);
@@ -540,10 +541,10 @@ namespace HotChocolate.Types
         public static void IsUnionType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsUnionType(null);
+            void Action() => TypeExtensions.IsUnionType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -554,7 +555,7 @@ namespace HotChocolate.Types
             type.SetupGet(t => t.Kind).Returns(TypeKind.InputObject);
 
             // act
-            bool result = type.Object.IsInputObjectType();
+            var result = type.Object.IsInputObjectType();
 
             // assert
             Assert.True(result);
@@ -567,7 +568,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsInputObjectType();
+            var result = type.IsInputObjectType();
 
             // assert
             Assert.False(result);
@@ -577,10 +578,10 @@ namespace HotChocolate.Types
         public static void IsInputObjectType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsInputObjectType(null);
+            void Action() => TypeExtensions.IsInputObjectType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -590,7 +591,7 @@ namespace HotChocolate.Types
             IType type = new StringType();
 
             // act
-            bool result = type.IsInputType();
+            var result = type.IsInputType();
 
             // assert
             Assert.True(result);
@@ -603,7 +604,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsInputType();
+            var result = type.IsInputType();
 
             // assert
             Assert.False(result);
@@ -613,10 +614,10 @@ namespace HotChocolate.Types
         public static void IsInputType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsInputType(null);
+            void Action() => TypeExtensions.IsInputType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -626,7 +627,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsOutputType();
+            var result = type.IsOutputType();
 
             // assert
             Assert.True(result);
@@ -639,7 +640,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<InputObjectType>();
 
             // act
-            bool result = type.IsOutputType();
+            var result = type.IsOutputType();
 
             // assert
             Assert.False(result);
@@ -649,10 +650,10 @@ namespace HotChocolate.Types
         public static void IsOutputType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsOutputType(null);
+            void Action() => TypeExtensions.IsOutputType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -662,7 +663,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<InterfaceType>();
 
             // act
-            bool result = type.IsAbstractType();
+            var result = type.IsAbstractType();
 
             // assert
             Assert.True(result);
@@ -675,7 +676,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<UnionType>();
 
             // act
-            bool result = type.IsAbstractType();
+            var result = type.IsAbstractType();
 
             // assert
             Assert.True(result);
@@ -689,7 +690,7 @@ namespace HotChocolate.Types
             type.SetupGet(t => t.Kind).Returns(TypeKind.InputObject);
 
             // act
-            bool result = type.Object.IsAbstractType();
+            var result = type.Object.IsAbstractType();
 
             // assert
             Assert.False(result);
@@ -699,10 +700,10 @@ namespace HotChocolate.Types
         public static void IsAbstractType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsAbstractType(null);
+            void Action() => TypeExtensions.IsAbstractType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
         }
 
         [Fact]
@@ -712,7 +713,7 @@ namespace HotChocolate.Types
             IType type = new StringType();
 
             // act
-            bool result = type.IsType(TypeKind.Scalar);
+            var result = type.IsType(TypeKind.Scalar);
 
             // assert
             Assert.True(result);
@@ -725,7 +726,7 @@ namespace HotChocolate.Types
             IType type = new NonNullType(new StringType());
 
             // act
-            bool result = type.IsType(TypeKind.Scalar);
+            var result = type.IsType(TypeKind.Scalar);
 
             // assert
             Assert.True(result);
@@ -738,7 +739,7 @@ namespace HotChocolate.Types
             IType type = Mock.Of<InputObjectType>();
 
             // act
-            bool result = type.IsType(TypeKind.Scalar);
+            var result = type.IsType(TypeKind.Scalar);
 
             // assert
             Assert.False(result);
@@ -748,10 +749,150 @@ namespace HotChocolate.Types
         public static void IsType_Type_Is_Null()
         {
             // act
-            Action action = () => TypeExtensions.IsAbstractType(null);
+            void Action() => TypeExtensions.IsAbstractType(null!);
 
             // assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.Throws<ArgumentNullException>(Action);
+        }
+
+        [Fact]
+        public void RewriteType_NonNull_To_Nullable()
+        {
+            // arrange
+            var type = new NonNullType(new StringType());
+            var nullability = new OptionalModifierNode(null, null);
+
+            // act
+            IType rewritten = type.RewriteNullability(nullability);
+
+            // assert
+            Assert.IsType<StringType>(rewritten);
+        }
+
+        [Fact]
+        public void RewriteType_NonNull_To_NonNull()
+        {
+            // arrange
+            var type = new NonNullType(new StringType());
+            var nullability = new RequiredModifierNode(null, null);
+
+            // act
+            IType rewritten = type.RewriteNullability(nullability);
+
+            // assert
+            Assert.IsType<StringType>(Assert.IsType<NonNullType>(rewritten).Type);
+        }
+
+        [Fact]
+        public void RewriteType_Nullable_To_NonNull()
+        {
+            // arrange
+            var type = new StringType();
+            var nullability = new RequiredModifierNode(null, null);
+
+            // act
+            IType rewritten = type.RewriteNullability(nullability);
+
+            // assert
+            Assert.IsType<StringType>(Assert.IsType<NonNullType>(rewritten).Type);
+        }
+
+        [Fact]
+        public void RewriteType_Nullable_To_Nullable()
+        {
+            // arrange
+            var type = new StringType();
+            var nullability = new OptionalModifierNode(null, null);
+
+            // act
+            IType rewritten = type.RewriteNullability(nullability);
+
+            // assert
+            Assert.IsType<StringType>(rewritten);
+        }
+
+        [Fact]
+        public void RewriteType_ListNonNull_To_ListNullable()
+        {
+            // arrange
+            var type = new ListType(new NonNullType(new StringType()));
+            var nullability = new ListNullabilityNode(null, new OptionalModifierNode(null, null));
+
+            // act
+            IType rewritten = type.RewriteNullability(nullability);
+
+            // assert
+            Assert.IsType<StringType>(
+                Assert.IsType<ListType>(rewritten).ElementType);
+        }
+
+        [Fact]
+        public void RewriteType_NonNullListNonNull_To_NonNullListNullable()
+        {
+            // arrange
+            var type = new NonNullType(new ListType(new NonNullType(new StringType())));
+            var nullability = new ListNullabilityNode(null, new OptionalModifierNode(null, null));
+
+            // act
+            IType rewritten = type.RewriteNullability(nullability);
+
+            // assert
+            Assert.IsType<StringType>(
+                Assert.IsType<ListType>(
+                    Assert.IsType<NonNullType>(rewritten).Type).ElementType);
+        }
+
+        [Fact]
+        public void RewriteType_DoNothing()
+        {
+            // arrange
+            var type = new NonNullType(
+                new ListType(
+                    new ListType(
+                        new NonNullType(
+                            new StringType()))));
+
+            var nullability = new ListNullabilityNode(null, new ListNullabilityNode(null, null));
+
+            // act
+            IType rewritten = type.RewriteNullability(nullability);
+
+            // assert
+            Assert.IsType<StringType>(
+                Assert.IsType<NonNullType>(
+                    Assert.IsType<ListType>(
+                        Assert.IsType<ListType>(
+                            Assert.IsType<NonNullType>(rewritten).Type)
+                                .ElementType)
+                                    .ElementType)
+                                        .Type);
+        }
+
+        [Fact]
+        public void RewriteType_Modifier_Structure_Does_Not_Match_Type_Structure()
+        {
+            // arrange
+            var type = new StringType();
+            var nullability = new ListNullabilityNode(null, null);
+
+            // act
+            void Fail() => type.RewriteNullability(nullability);
+
+            // assert
+            Assert.Throws<InvalidOperationException>(Fail);
+        }
+
+        [Fact]
+        public void RewriteType_No_Nullable_Modifier()
+        {
+            // arrange
+            var type = new StringType();
+
+            // act
+            IType rewritten = type.RewriteNullability(null);
+
+            // assert
+            Assert.IsType<StringType>(rewritten);
         }
     }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/FieldSelectionMergingRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/FieldSelectionMergingRuleTests.cs
@@ -1062,6 +1062,46 @@ namespace HotChocolate.Validation
                 }");
         }
 
+        [Fact]
+        public void ConflictingDifferingResponse()
+        {
+            ExpectErrors(@"
+                {
+                    catOrDog {
+                        ... conflictingDifferingResponses
+                    }
+                }
+
+                fragment conflictingDifferingResponses on Pet {
+                    ... on Dog {
+                        someValue: nickname
+                    }
+                    ... on Cat {
+                        someValue: nickname!
+                    }
+                }");
+        }
+
+        [Fact]
+        public void MergeableNullabilityChange()
+        {
+            ExpectValid(@"
+                {
+                    catOrDog {
+                        ... conflictingDifferingResponses
+                    }
+                }
+
+                fragment conflictingDifferingResponses on Pet {
+                    ... on Dog {
+                        someValue: nickname!
+                    }
+                    ... on Cat {
+                        someValue: nickname!
+                    }
+                }");
+        }
+
         private static readonly ISchema TestSchema =
             SchemaBuilder.New()
                 .AddDocumentFromString(@"

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.QueryWithExtraVar.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.QueryWithExtraVar.snap
@@ -148,6 +148,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VariableNotUsedWithinFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VariableNotUsedWithinFragment.snap
@@ -98,6 +98,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VariableUnused.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VariableUnused.snap
@@ -98,6 +98,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -111,6 +112,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 114,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VariableUsedAndNotDeclared.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VariableUsedAndNotDeclared.snap
@@ -47,6 +47,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -100,6 +101,7 @@
                       }
                     }
                   ],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 109,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VariableUsedAndNotDeclared2.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VariableUsedAndNotDeclared2.snap
@@ -47,6 +47,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VarsMustBeDefinedInAllOperationsInWhichAFragmentIsUsedErr.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.VarsMustBeDefinedInAllOperationsInWhichAFragmentIsUsedErr.snap
@@ -47,6 +47,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.InvalidFieldArgName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.InvalidFieldArgName.snap
@@ -105,6 +105,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 204,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.MisspelledFieldArgsAreReported.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.MisspelledFieldArgsAreReported.snap
@@ -105,6 +105,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 203,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.UnknownArgsDeeply.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.UnknownArgsDeeply.snap
@@ -105,6 +105,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 69,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.ConflictingBecauseAlias.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.ConflictingBecauseAlias.snap
@@ -58,6 +58,7 @@
               "Value": "name"
             },
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 79,
@@ -81,6 +82,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 114,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.DisallowedSecondRootField.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.DisallowedSecondRootField.snap
@@ -47,6 +47,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -60,6 +61,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 93,
@@ -83,6 +85,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 122,
@@ -126,6 +129,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 171,
@@ -170,6 +174,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 171,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.DuplicateFragments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.DuplicateFragments.snap
@@ -49,6 +49,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -62,6 +63,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 313,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.FieldIsNotDefinedOnTypeInFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.FieldIsNotDefinedOnTypeInFragment.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 262,
@@ -78,6 +79,7 @@
         "Value": "barkVolume"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 380,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.FragmentDoesNotMatchType.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.FragmentDoesNotMatchType.snap
@@ -55,6 +55,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 219,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.InlineFragOnScalar.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.InlineFragOnScalar.snap
@@ -59,6 +59,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 246,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.InvalidFieldArgName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.InvalidFieldArgName.snap
@@ -105,6 +105,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 198,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.MaxDepthRuleIsIncluded.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.MaxDepthRuleIsIncluded.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -89,6 +90,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 161,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.NotExistingTypeOnInlineFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.NotExistingTypeOnInlineFragment.snap
@@ -59,6 +59,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 256,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.QueryWithOneAnonymousAndOneNamedOperation.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.QueryWithOneAnonymousAndOneNamedOperation.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -52,6 +53,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 69,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.QueryWithTypeSystemDefinitions.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.QueryWithTypeSystemDefinitions.snap
@@ -103,6 +103,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 115,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.ScalarSelectionsNotAllowedOnInt.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.ScalarSelectionsNotAllowedOnInt.snap
@@ -25,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -38,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 110,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.SkipDirectiveIsInTheWrongPlace.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.SkipDirectiveIsInTheWrongPlace.snap
@@ -21,6 +21,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 61,
@@ -216,6 +217,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 61,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.TwoQueryOperationsWithTheSameName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.TwoQueryOperationsWithTheSameName.snap
@@ -48,6 +48,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -61,6 +62,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -74,6 +76,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 247,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.UnusedFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.UnusedFragment.snap
@@ -49,6 +49,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 77,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.VariableNotUsedWithinFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.VariableNotUsedWithinFragment.snap
@@ -98,6 +98,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldMustBeDefinedRuleTests.DefinedOnImplementorsButNotInterfaceOnPet.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldMustBeDefinedRuleTests.DefinedOnImplementorsButNotInterfaceOnPet.snap
@@ -23,6 +23,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 248,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldMustBeDefinedRuleTests.DirectFieldSelectionOnUnion.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldMustBeDefinedRuleTests.DirectFieldSelectionOnUnion.snap
@@ -30,6 +30,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 240,
@@ -53,6 +54,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 265,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldMustBeDefinedRuleTests.FieldIsNotDefinedOnTypeInFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldMustBeDefinedRuleTests.FieldIsNotDefinedOnTypeInFragment.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 268,
@@ -78,6 +79,7 @@
         "Value": "barkVolume"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 386,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.AliasMaskingDirectFieldAccess.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.AliasMaskingDirectFieldAccess.snap
@@ -29,6 +29,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 268,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ComparesDeepTypesIncludingList.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ComparesDeepTypesIncludingList.snap
@@ -38,6 +38,7 @@
         "Value": "id"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 161,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgNames.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgNames.snap
@@ -54,6 +54,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 205,
@@ -129,6 +130,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 244,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgValues.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgValues.snap
@@ -59,6 +59,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 258,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgsOnValues.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgsOnValues.snap
@@ -59,6 +59,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 269,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgsValueAndVar.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgsValueAndVar.snap
@@ -69,6 +69,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 307,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgsWithVars.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingArgsWithVars.snap
@@ -69,6 +69,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 322,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingBecauseAlias.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingBecauseAlias.snap
@@ -29,6 +29,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 251,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingDifferingResponse.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingDifferingResponse.snap
@@ -1,0 +1,71 @@
+﻿[
+  {
+    "Message": "Encountered fields for the same object that cannot be merged.",
+    "Code": null,
+    "Path": null,
+    "Locations": [
+      {
+        "Line": 10,
+        "Column": 25
+      },
+      {
+        "Line": 13,
+        "Column": 25
+      }
+    ],
+    "Extensions": {
+      "declaringTypeA": "Dog",
+      "declaringTypeB": "Cat",
+      "fieldA": "nickname",
+      "fieldB": "nickname",
+      "typeA": "String",
+      "typeB": "String",
+      "responseNameA": "someValue",
+      "responseNameB": "someValue",
+      "specifiedBy": "http://spec.graphql.org/June2018/#sec-Field-Selection-Merging"
+    },
+    "Exception": null,
+    "SyntaxNode": {
+      "Kind": "Field",
+      "Alias": {
+        "Kind": "Name",
+        "Location": {
+          "Start": 369,
+          "End": 379,
+          "Line": 13,
+          "Column": 25
+        },
+        "Value": "someValue"
+      },
+      "Arguments": [],
+      "Required": {
+        "Kind": "RequiredDesignator",
+        "Location": {
+          "Start": 388,
+          "End": 411,
+          "Line": 13,
+          "Column": 44
+        },
+        "Element": null
+      },
+      "SelectionSet": null,
+      "Location": {
+        "Start": 369,
+        "End": 411,
+        "Line": 13,
+        "Column": 25
+      },
+      "Name": {
+        "Kind": "Name",
+        "Location": {
+          "Start": 380,
+          "End": 389,
+          "Line": 13,
+          "Column": 36
+        },
+        "Value": "nickname"
+      },
+      "Directives": []
+    }
+  }
+]

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingDifferingResponses.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingDifferingResponses.snap
@@ -38,6 +38,7 @@
         "Value": "someValue"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 364,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingReturnTypesWhichPotentiallyOverlap.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ConflictingReturnTypesWhichPotentiallyOverlap.snap
@@ -29,6 +29,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 227,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DeepConflict.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DeepConflict.snap
@@ -38,6 +38,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 144,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DeepConflictWithMultipleIssues.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DeepConflictWithMultipleIssues.snap
@@ -38,6 +38,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 174,
@@ -97,6 +98,7 @@
         "Value": "y"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 203,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DifferentArgsSecondAddsAnArgument.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DifferentArgsSecondAddsAnArgument.snap
@@ -59,6 +59,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 241,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DifferentArgsSecondMissingAnArgument.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DifferentArgsSecondMissingAnArgument.snap
@@ -29,6 +29,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 258,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DifferingArgs.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DifferingArgs.snap
@@ -29,6 +29,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 249,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingReturnTypeListDespiteNoOverlap.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingReturnTypeListDespiteNoOverlap.snap
@@ -38,6 +38,7 @@
         "Value": "box"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -51,6 +52,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 353,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingReturnTypeListDespiteNoOverlapReverse.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingReturnTypeListDespiteNoOverlapReverse.snap
@@ -38,6 +38,7 @@
         "Value": "box"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -51,6 +52,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 353,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingReturnTypeNullabilityDespiteNoOverlap.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingReturnTypeNullabilityDespiteNoOverlap.snap
@@ -29,6 +29,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 232,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingReturnTypesDespiteNoOverlap.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingReturnTypesDespiteNoOverlap.snap
@@ -29,6 +29,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 193,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingSubfields.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.DisallowsDifferingSubfields.snap
@@ -38,6 +38,7 @@
         "Value": "val"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 193,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.EncountersConflictInFragments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.EncountersConflictInFragments.snap
@@ -38,6 +38,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 228,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.FindsInvalidCaseEvenWithImmediatelyRecursiveFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.FindsInvalidCaseEvenWithImmediatelyRecursiveFragment.snap
@@ -38,6 +38,7 @@
         "Value": "fido"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 340,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ReportsDeepConflictInNestedFragments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ReportsDeepConflictInNestedFragments.snap
@@ -38,6 +38,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 544,
@@ -97,6 +98,7 @@
         "Value": "y"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 437,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ReportsDeepConflictToNearestCommonAncestor.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ReportsDeepConflictToNearestCommonAncestor.snap
@@ -38,6 +38,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 189,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ReportsDeepConflictToNearestCommonAncestorInFragments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ReportsDeepConflictToNearestCommonAncestorInFragments.snap
@@ -38,6 +38,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 397,
@@ -97,6 +98,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 309,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ReportsEachConflictOnce.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ReportsEachConflictOnce.snap
@@ -38,6 +38,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 522,
@@ -97,6 +98,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 440,
@@ -156,6 +158,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 336,
@@ -215,6 +218,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 336,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.SameAliasesAllowedOnNonOverlappingFields.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.SameAliasesAllowedOnNonOverlappingFields.snap
@@ -38,6 +38,7 @@
         "Value": "name"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 368,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.SameAliasesWithDifferentFieldTargets.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.SameAliasesWithDifferentFieldTargets.snap
@@ -38,6 +38,7 @@
         "Value": "fido"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 278,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.SameResponseNameDifferentFieldName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.SameResponseNameDifferentFieldName.snap
@@ -38,6 +38,7 @@
         "Value": "catOrDog"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ShortHandQueryWithDuplicateFieldInSecondLevelFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.ShortHandQueryWithDuplicateFieldInSecondLevelFragment.snap
@@ -59,6 +59,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 343,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.VeryDeepConflict.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldSelectionMergingRuleTests.VeryDeepConflict.snap
@@ -38,6 +38,7 @@
         "Value": "x"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 236,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadAliasedFieldTargetNotDefined.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadAliasedFieldTargetNotDefined.snap
@@ -33,6 +33,7 @@
         "Value": "volume"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 84,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadAliasedLyingFieldTargetNotDefined.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadAliasedLyingFieldTargetNotDefined.snap
@@ -33,6 +33,7 @@
         "Value": "barkVolume"
       },
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 89,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadFieldNotDefinedOnFragement.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadFieldNotDefinedOnFragement.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 71,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadFieldNotDefinedOnInlineFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadFieldNotDefinedOnInlineFragment.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 108,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadIgnoresDeeplyUnknownField.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadIgnoresDeeplyUnknownField.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -37,6 +38,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 115,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadNotDefinedOnInterface.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadNotDefinedOnInterface.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 77,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadReportsErrorWhenTypeIsKnown.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadReportsErrorWhenTypeIsKnown.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -74,6 +75,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 155,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadSubFieldNotDefined.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.BadSubFieldNotDefined.snap
@@ -28,6 +28,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 107,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.DefinedOnImplementorQueriedOnUnion.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.DefinedOnImplementorQueriedOnUnion.snap
@@ -31,6 +31,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 95,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.DefinedOnImplementorsButNotOnInterface.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.DefinedOnImplementorsButNotOnInterface.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 92,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.DireftFieldSelectionOnUnion.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.DireftFieldSelectionOnUnion.snap
@@ -31,6 +31,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 88,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.WrongFieldsOnUnionTypeList.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FieldsOnCorrectTypeRuleTests.WrongFieldsOnUnionTypeList.snap
@@ -31,6 +31,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 76,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentNameUniquenessRuleTests.DuplicateFragments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentNameUniquenessRuleTests.DuplicateFragments.snap
@@ -49,6 +49,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -62,6 +63,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 313,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentNameUniquenessRuleTests.FragmentsNamedTheSame.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentNameUniquenessRuleTests.FragmentsNamedTheSame.snap
@@ -49,6 +49,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -62,6 +63,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 342,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentNameUniquenessRuleTests.FragmentsNamedTheSameWithoutBeingReferenced.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentNameUniquenessRuleTests.FragmentsNamedTheSameWithoutBeingReferenced.snap
@@ -49,6 +49,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -62,6 +63,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 260,
@@ -172,6 +174,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -185,6 +188,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 260,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.DifferentObjectIntoObject.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.DifferentObjectIntoObject.snap
@@ -59,6 +59,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 325,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.DifferentObjectIntoObjectInInlineFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.DifferentObjectIntoObjectInInlineFragment.snap
@@ -64,6 +64,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 303,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.FragmentDoesNotMatchType.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.FragmentDoesNotMatchType.snap
@@ -55,6 +55,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 219,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.InterfaceIntoNonImplementingObject.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.InterfaceIntoNonImplementingObject.snap
@@ -55,6 +55,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 297,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.InterfaceIntoNonOverlappingInterface.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.InterfaceIntoNonOverlappingInterface.snap
@@ -59,6 +59,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 397,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.InterfaceIntoNonOverlappingInterfaceInInlineFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.InterfaceIntoNonOverlappingInterfaceInInlineFragment.snap
@@ -64,6 +64,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 322,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.InterfaceIntoNonOverlappingUnion.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.InterfaceIntoNonOverlappingUnion.snap
@@ -55,6 +55,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 285,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.ObjectIntoNotContainingUnion.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.ObjectIntoNotContainingUnion.snap
@@ -55,6 +55,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -68,6 +69,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 283,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.ObjectIntoNotImplementingInterface.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.ObjectIntoNotImplementingInterface.snap
@@ -59,6 +59,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -72,6 +73,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 344,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.UnionIntoNonOverlappingInterface.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.UnionIntoNonOverlappingInterface.snap
@@ -59,6 +59,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 356,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.UnionIntoNonOverlappingUnion.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.UnionIntoNonOverlappingUnion.snap
@@ -55,6 +55,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 295,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.UnionIntoNotContainedObject.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadIsPossibleRuleTests.UnionIntoNotContainedObject.snap
@@ -55,6 +55,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 279,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadTypeExistenceRuleTests.NotExistingTypeOnInlineFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadTypeExistenceRuleTests.NotExistingTypeOnInlineFragment.snap
@@ -59,6 +59,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 256,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadTypeExistenceRuleTests.NotOnExistingTypeOnFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentSpreadTypeExistenceRuleTests.NotOnExistingTypeOnFragment.snap
@@ -54,6 +54,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 211,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentsMustBeUsedRuleTests.UnusedFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentsMustBeUsedRuleTests.UnusedFragment.snap
@@ -49,6 +49,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 77,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentsOnCompositeTypesRuleTests.Fragment_On_Scalar_Is_Invalid.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentsOnCompositeTypesRuleTests.Fragment_On_Scalar_Is_Invalid.snap
@@ -54,6 +54,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 193,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentsOnCompositeTypesRuleTests.InlineFragment_On_Scalar_Is_Invalid.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/FragmentsOnCompositeTypesRuleTests.InlineFragment_On_Scalar_Is_Invalid.snap
@@ -59,6 +59,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 246,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/IntrospectionRuleTests.IntrospectionNotAllowed_Schema_Field.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/IntrospectionRuleTests.IntrospectionNotAllowed_Schema_Field.snap
@@ -27,6 +27,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 39,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/IntrospectionRuleTests.IntrospectionNotAllowed_Schema_Field_Custom_Message.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/IntrospectionRuleTests.IntrospectionNotAllowed_Schema_Field_Custom_Message.snap
@@ -27,6 +27,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 39,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/IntrospectionRuleTests.IntrospectionNotAllowed_Schema_Field_Custom_MessageFactory.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/IntrospectionRuleTests.IntrospectionNotAllowed_Schema_Field_Custom_MessageFactory.snap
@@ -27,6 +27,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 39,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/IntrospectionRuleTests.IntrospectionNotAllowed_Type_Field.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/IntrospectionRuleTests.IntrospectionNotAllowed_Type_Field.snap
@@ -58,6 +58,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 39,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/KnownFragmentNamesTests.DuplicateFragments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/KnownFragmentNamesTests.DuplicateFragments.snap
@@ -129,6 +129,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 319,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnInterfaceWithoutSubFields.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnInterfaceWithoutSubFields.snap
@@ -21,6 +21,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 84,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnInterfaceWithoutSubFieldsEmptySelection.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnInterfaceWithoutSubFieldsEmptySelection.snap
@@ -21,6 +21,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnObjectWithoutSubFields.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnObjectWithoutSubFields.snap
@@ -21,6 +21,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 81,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnObjectWithoutSubFieldsEmptySelection.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnObjectWithoutSubFieldsEmptySelection.snap
@@ -21,6 +21,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnUnionWithoutSubFields.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnUnionWithoutSubFields.snap
@@ -21,6 +21,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 80,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnUnionWithoutSubFieldsEmptySelection.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.DirectQueryOnUnionWithoutSubFieldsEmptySelection.snap
@@ -21,6 +21,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.InterfaceTypeMissingSelection.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.InterfaceTypeMissingSelection.snap
@@ -25,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 47,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.InterfaceTypeMissingSelectionEmptySelection.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.InterfaceTypeMissingSelectionEmptySelection.snap
@@ -25,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedOnBoolean.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedOnBoolean.snap
@@ -25,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -38,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 105,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedOnEnum.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedOnEnum.snap
@@ -25,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -38,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 158,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedWithArgs.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedWithArgs.snap
@@ -55,6 +55,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -68,6 +69,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 104,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedWithDirectives.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedWithDirectives.snap
@@ -25,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -38,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 96,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedWithDirectivesAndArgs.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionNotAllowedWithDirectivesAndArgs.snap
@@ -55,6 +55,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -68,6 +69,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 124,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionsNotAllowedOnInt.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LeafFieldSelectionsRuleTests.ScalarSelectionsNotAllowedOnInt.snap
@@ -25,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": {
         "Kind": "SelectionSet",
         "Location": {
@@ -38,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 110,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LoneAnonymousOperationRuleTests.AnonymoutOperationWithAMutation.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LoneAnonymousOperationRuleTests.AnonymoutOperationWithAMutation.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -52,6 +53,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 69,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LoneAnonymousOperationRuleTests.AnonymoutOperationWithASubscription.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LoneAnonymousOperationRuleTests.AnonymoutOperationWithASubscription.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -52,6 +53,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 69,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LoneAnonymousOperationRuleTests.QueryWithOneAnonymousAndOneNamedOperation.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LoneAnonymousOperationRuleTests.QueryWithOneAnonymousAndOneNamedOperation.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -52,6 +53,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 69,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LoneAnonymousOperationRuleTests.QueryWithTwoAnonymousOperations.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/LoneAnonymousOperationRuleTests.QueryWithTwoAnonymousOperations.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -52,6 +53,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 183,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/MaxDepthRuleTests.MaxDepth3_QueryWith4LevelsViaFragments_MaxDepthReached.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/MaxDepthRuleTests.MaxDepth3_QueryWith4LevelsViaFragments_MaxDepthReached.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/MaxDepthRuleTests.MaxDepth3_QueryWith4LevelsWithInlineFragment_MaxDepthReached.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/MaxDepthRuleTests.MaxDepth3_QueryWith4LevelsWithInlineFragment_MaxDepthReached.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -89,6 +90,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -139,6 +141,7 @@
                                     "Kind": "Field",
                                     "Alias": null,
                                     "Arguments": [],
+                                    "Required": null,
                                     "SelectionSet": {
                                       "Kind": "SelectionSet",
                                       "Location": {
@@ -152,6 +155,7 @@
                                           "Kind": "Field",
                                           "Alias": null,
                                           "Arguments": [],
+                                          "Required": null,
                                           "SelectionSet": null,
                                           "Location": {
                                             "Start": 306,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/MaxDepthRuleTests.MaxDepth3_QueryWith4Levels_MaxDepthReached.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/MaxDepthRuleTests.MaxDepth3_QueryWith4Levels_MaxDepthReached.snap
@@ -39,6 +39,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -52,6 +53,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -65,6 +67,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -78,6 +81,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 162,
@@ -161,6 +165,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 267,
@@ -184,6 +189,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -197,6 +203,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 351,
@@ -220,6 +227,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -233,6 +241,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 447,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUndefinedVariablesRuleTests.MultipleVariablesNotDefined.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUndefinedVariablesRuleTests.MultipleVariablesNotDefined.snap
@@ -216,6 +216,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 61,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUndefinedVariablesRuleTests.VariableNotDefined.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUndefinedVariablesRuleTests.VariableNotDefined.snap
@@ -355,6 +355,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 85,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUndefinedVariablesRuleTests.VariableNotDefinedByUnNamedQuery.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUndefinedVariablesRuleTests.VariableNotDefinedByUnNamedQuery.snap
@@ -355,6 +355,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 85,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUnusedFragmentsRuleTests.ContainsUnknownAndUndefFragments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUnusedFragmentsRuleTests.ContainsUnknownAndUndefFragments.snap
@@ -89,6 +89,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 190,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUnusedFragmentsRuleTests.ContainsUnknownFragments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUnusedFragmentsRuleTests.ContainsUnknownFragments.snap
@@ -49,6 +49,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 655,
@@ -139,6 +140,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 742,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUnusedFragmentsRuleTests.ContainsUnknownFragmentsWithRefCycle.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUnusedFragmentsRuleTests.ContainsUnknownFragmentsWithRefCycle.snap
@@ -49,6 +49,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 655,
@@ -159,6 +160,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 773,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUnusedVariablesRuleTests.MultipleVariablesNotUsed.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/NoUnusedVariablesRuleTests.MultipleVariablesNotUsed.snap
@@ -238,6 +238,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 85,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.MultipleOperationsOfSameName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.MultipleOperationsOfSameName.snap
@@ -48,6 +48,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 139,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.MultipleOpsOfSameNameOfDifferentTypesMutation.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.MultipleOpsOfSameNameOfDifferentTypesMutation.snap
@@ -48,6 +48,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 142,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.MultipleOpsOfSameNameOfDifferentTypesSubscription.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.MultipleOpsOfSameNameOfDifferentTypesSubscription.snap
@@ -48,6 +48,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -61,6 +62,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 183,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.TwoOperationsWithTheSameName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.TwoOperationsWithTheSameName.snap
@@ -48,6 +48,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -61,6 +62,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 230,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.TwoQueryOperationsWithTheSameName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/OperationNameUniquenessRuleTests.TwoQueryOperationsWithTheSameName.snap
@@ -48,6 +48,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -61,6 +62,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -74,6 +76,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 247,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.IncorrectValueAndMissingArgument.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.IncorrectValueAndMissingArgument.snap
@@ -107,6 +107,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 75,
@@ -183,6 +184,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 75,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.MissingMultipleNonNullableArguments.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.MissingMultipleNonNullableArguments.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 75,
@@ -69,6 +70,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 75,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.MissingOneNonNullableArgument.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.MissingOneNonNullableArgument.snap
@@ -105,6 +105,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 75,
@@ -180,6 +181,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 75,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.MissingRequiredArg.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.MissingRequiredArg.snap
@@ -24,6 +24,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 224,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/SubscriptionSingleRootFieldRuleTests.DisallowedIntrospectionField.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/SubscriptionSingleRootFieldRuleTests.DisallowedIntrospectionField.snap
@@ -47,6 +47,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -60,6 +61,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 93,
@@ -83,6 +85,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 122,
@@ -126,6 +129,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 171,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/SubscriptionSingleRootFieldRuleTests.DisallowedSecondRootField.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/SubscriptionSingleRootFieldRuleTests.DisallowedSecondRootField.snap
@@ -47,6 +47,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -60,6 +61,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 93,
@@ -83,6 +85,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 122,
@@ -126,6 +129,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 171,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/SubscriptionSingleRootFieldRuleTests.DisallowedSecondRootFieldAnonymous.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/SubscriptionSingleRootFieldRuleTests.DisallowedSecondRootFieldAnonymous.snap
@@ -47,6 +47,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -60,6 +61,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 93,
@@ -83,6 +85,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 122,
@@ -126,6 +129,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 171,

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/SubscriptionSingleRootFieldRuleTests.FailsWithManyMoreThanOneRootField.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/SubscriptionSingleRootFieldRuleTests.FailsWithManyMoreThanOneRootField.snap
@@ -47,6 +47,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -60,6 +61,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 93,
@@ -83,6 +85,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 122,
@@ -126,6 +129,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 171,
@@ -149,6 +153,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 217,

--- a/src/HotChocolate/Data/src/Data/Filters/Expressions/QueryableFilterProvider.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Expressions/QueryableFilterProvider.cs
@@ -71,7 +71,7 @@ public class QueryableFilterProvider : FilterProvider<QueryableFilterContext>
 
             // if no filter is defined we can stop here and yield back control.
             var skipFiltering =
-            context.LocalContextData.TryGetValue(SkipFilteringKey, out object? skip) &&
+            context.LocalContextData.TryGetValue(SkipFilteringKey, out var skip) &&
             skip is true;
 
             // ensure filtering is only applied once
@@ -86,7 +86,7 @@ public class QueryableFilterProvider : FilterProvider<QueryableFilterContext>
             if (argument.Type is IFilterInputType filterInput &&
                 context.Selection.Field.ContextData.TryGetValue(
                     ContextVisitFilterArgumentKey,
-                    out object? executorObj) &&
+                    out var executorObj) &&
                 executorObj is VisitFilterArgument executor)
             {
                 var inMemory =

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Extensions/QueryableProjectionExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Extensions/QueryableProjectionExtensions.cs
@@ -65,7 +65,7 @@ public static class QueryableProjectExtensions
                 return result;
             }
 
-            throw ThrowHelper.Projection_TypeMissmatch(
+            throw ThrowHelper.Projection_TypeMismatch(
                 context,
                 expectedType,
                 resultObj!.GetType());

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionFieldHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionFieldHandler.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using HotChocolate.Execution.Processing;
@@ -23,15 +21,9 @@ public class QueryableProjectionFieldHandler
         [NotNullWhen(true)] out ISelectionVisitorAction? action)
     {
         IObjectField field = selection.Field;
-
-        if (field.RuntimeType is null)
-        {
-            action = null;
-            return false;
-        }
-
         Expression nestedProperty;
         Type memberType;
+
         if (field.Member is PropertyInfo { CanWrite: true } propertyInfo)
         {
             memberType = propertyInfo.PropertyType;
@@ -61,7 +53,7 @@ public class QueryableProjectionFieldHandler
     {
         IObjectField field = selection.Field;
 
-        if (field.RuntimeType is null || field.Member is null)
+        if (field.Member is null)
         {
             action = null;
             return false;
@@ -70,7 +62,7 @@ public class QueryableProjectionFieldHandler
         // Deque last
         ProjectionScope<Expression> scope = context.PopScope();
 
-        if (!(scope is QueryableProjectionScope queryableScope))
+        if (scope is not QueryableProjectionScope queryableScope)
         {
             action = null;
             return false;

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionListHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionListHandler.cs
@@ -12,8 +12,8 @@ public class QueryableProjectionListHandler
 {
     public override bool CanHandle(ISelection selection) =>
         selection.Field.Member is { } &&
-        selection.Field.Type is ListType ||
-        selection.Field.Type is NonNullType nonNullType &&
+        selection.Type is ListType ||
+        selection.Type is NonNullType nonNullType &&
         nonNullType.InnerType() is ListType;
 
     public override QueryableProjectionContext OnBeforeEnter(
@@ -38,16 +38,10 @@ public class QueryableProjectionListHandler
     {
         IObjectField field = selection.Field;
 
-        if (!(field.Member is PropertyInfo { CanWrite: true }))
+        if (field.Member is not PropertyInfo { CanWrite: true })
         {
             action = SelectionVisitor.Skip;
             return true;
-        }
-
-        if (field.RuntimeType is null)
-        {
-            action = null;
-            return false;
         }
 
         IOutputType type = field.Type;
@@ -70,7 +64,7 @@ public class QueryableProjectionListHandler
     {
         IObjectField field = selection.Field;
 
-        if (field.RuntimeType is null || field.Member is null)
+        if (field.Member is null)
         {
             action = null;
             return false;

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Interceptor/QueryableFilterInterceptor.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Interceptor/QueryableFilterInterceptor.cs
@@ -31,9 +31,9 @@ public class QueryableFilterInterceptor : IProjectionFieldInterceptor<QueryableP
         IObjectField field = selection.Field;
         IReadOnlyDictionary<string, object?> contextData = field.ContextData;
 
-        if (contextData.TryGetValue(ContextArgumentNameKey, out object? arg) &&
+        if (contextData.TryGetValue(ContextArgumentNameKey, out var arg) &&
             arg is NameString argumentName &&
-            contextData.TryGetValue(ContextVisitFilterArgumentKey, out object? argVisitor) &&
+            contextData.TryGetValue(ContextVisitFilterArgumentKey, out var argVisitor) &&
             argVisitor is VisitFilterArgument argumentVisitor &&
             context.Selection.Count > 0 &&
             context.Selection.Peek()

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Interceptor/QueryableTakeHandlerInterceptor.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Interceptor/QueryableTakeHandlerInterceptor.cs
@@ -22,8 +22,7 @@ public abstract class QueryableTakeHandlerInterceptor
     }
 
     public bool CanHandle(ISelection selection) =>
-        selection.Field.Member is PropertyInfo propertyInfo &&
-        propertyInfo.CanWrite &&
+        selection.Field.Member is PropertyInfo { CanWrite: true } &&
         selection.Field.ContextData.ContainsKey(_contextDataKey);
 
     public void BeforeProjection(
@@ -32,7 +31,7 @@ public abstract class QueryableTakeHandlerInterceptor
     {
         IObjectField? field = selection.Field;
         if (field.ContextData.ContainsKey(_contextDataKey) &&
-            selection.Field.Type.InnerType() is ListType lt &&
+            selection.Type.InnerType() is ListType lt &&
             lt.ElementType.InnerType() is { } elementType)
         {
             Expression instance = context.PopInstance();

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Optimizers/QueryablePagingProjectionOptimizer.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Optimizers/QueryablePagingProjectionOptimizer.cs
@@ -47,12 +47,13 @@ public class QueryablePagingProjectionOptimizer : IProjectionOptimizer
         IPageType pageType,
         IReadOnlyList<ISelectionNode> selections)
     {
-        (string? fieldName, IObjectField? nodesField) = TryGetObjectField(pageType);
+        (var fieldName, IObjectField? nodesField) = TryGetObjectField(pageType);
 
         var combinedField = new FieldNode(
             null,
             new NameNode(fieldName),
             new NameNode(CombinedEdgeField),
+            null,
             Array.Empty<DirectiveNode>(),
             Array.Empty<ArgumentNode>(),
             new SelectionSetNode(selections));

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionProvider.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionProvider.cs
@@ -71,7 +71,7 @@ public class QueryableProjectionProvider : ProjectionProvider
                 new QueryableProjectionContext(
                     context,
                     context.ObjectType,
-                    context.Selection.Field.Type.UnwrapRuntimeType());
+                    context.Selection.Type.UnwrapRuntimeType());
             var visitor = new QueryableProjectionVisitor();
             visitor.Visit(visitorContext);
 

--- a/src/HotChocolate/Data/src/Data/Projections/Optimizers/IsProjectedProjectionOptimizer.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Optimizers/IsProjectedProjectionOptimizer.cs
@@ -47,6 +47,7 @@ public class IsProjectedProjectionOptimizer : IProjectionOptimizer
                 null,
                 new NameNode(fields[i]),
                 new NameNode(alias),
+                null,
                 Array.Empty<DirectiveNode>(),
                 Array.Empty<ArgumentNode>(),
                 null);

--- a/src/HotChocolate/Data/src/Data/ThrowHelper.cs
+++ b/src/HotChocolate/Data/src/Data/ThrowHelper.cs
@@ -79,7 +79,7 @@ internal static class ThrowHelper
                 .SetMessage(DataResources.Filtering_FilteringWasNotFound)
                 .SetPath(context.Path)
                 .SetExtension("fieldName", context.Selection.Field.Name)
-                .SetExtension("typeName", context.Selection.Field.Type.NamedType().Name)
+                .SetExtension("typeName", context.Selection.Type.NamedType().Name)
                 .Build());
 
     public static SchemaException Filtering_TypeMissmatch(
@@ -94,7 +94,7 @@ internal static class ThrowHelper
                     resultType.FullName ?? resultType.Name)
                 .SetPath(context.Path)
                 .SetExtension("fieldName", context.Selection.Field.Name)
-                .SetExtension("typeName", context.Selection.Field.Type.NamedType().Name)
+                .SetExtension("typeName", context.Selection.Type.NamedType().Name)
                 .Build());
 
     public static SchemaException FilterInterceptor_NoHandlerFoundForField(
@@ -299,7 +299,7 @@ internal static class ThrowHelper
                 .SetMessage(DataResources.Sorting_SortingWasNotFound)
                 .SetPath(context.Path)
                 .SetExtension("fieldName", context.Selection.Field.Name)
-                .SetExtension("typeName", context.Selection.Field.Type.NamedType().Name)
+                .SetExtension("typeName", context.Selection.Type.NamedType().Name)
                 .Build());
 
     public static SchemaException Sorting_TypeMissmatch(
@@ -314,7 +314,7 @@ internal static class ThrowHelper
                     resultType.FullName ?? resultType.Name)
                 .SetPath(context.Path)
                 .SetExtension("fieldName", context.Selection.Field.Name)
-                .SetExtension("typeName", context.Selection.Field.Type.NamedType().Name)
+                .SetExtension("typeName", context.Selection.Type.NamedType().Name)
                 .Build());
 
     public static SchemaException ProjectionProvider_NoHandlersConfigured(
@@ -351,10 +351,10 @@ internal static class ThrowHelper
                 .SetMessage(DataResources.Projection_ProjectionWasNotFound)
                 .SetPath(context.Path)
                 .SetExtension("fieldName", context.Selection.Field.Name)
-                .SetExtension("typeName", context.Selection.Field.Type.NamedType().Name)
+                .SetExtension("typeName", context.Selection.Type.NamedType().Name)
                 .Build());
 
-    public static SchemaException Projection_TypeMissmatch(
+    public static SchemaException Projection_TypeMismatch(
         IResolverContext context,
         Type expectedType,
         Type resultType) =>
@@ -366,7 +366,7 @@ internal static class ThrowHelper
                     resultType.FullName ?? resultType.Name)
                 .SetPath(context.Path)
                 .SetExtension("fieldName", context.Selection.Field.Name)
-                .SetExtension("typeName", context.Selection.Field.Type.NamedType().Name)
+                .SetExtension("typeName", context.Selection.Type.NamedType().Name)
                 .Build());
 
     public static InvalidOperationException PagingProjectionOptimizer_NotAPagingField(

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/QueryableFilteringExtensionsTests.Extension_Should_BeMissingMiddleware.snap
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/QueryableFilteringExtensionsTests.Extension_Should_BeMissingMiddleware.snap
@@ -25,6 +25,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -38,6 +39,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 22,
@@ -61,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 26,

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/QueryableFilteringExtensionsTests.Extension_Should_BeTypeMissMatch.snap
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/QueryableFilteringExtensionsTests.Extension_Should_BeTypeMissMatch.snap
@@ -115,6 +115,7 @@
             }
           }
         ],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -128,6 +129,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 44,
@@ -151,6 +153,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 48,

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionExtensionsTests.Extension_Should_BeMissingMiddleware.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionExtensionsTests.Extension_Should_BeMissingMiddleware.snap
@@ -25,6 +25,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -38,6 +39,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 22,
@@ -61,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 26,

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionExtensionsTests.Extension_Should_BeTypeMissMatch.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionExtensionsTests.Extension_Should_BeTypeMissMatch.snap
@@ -25,6 +25,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -38,6 +39,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 18,
@@ -61,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 22,

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/QueryableSortingExtensionsTests.Extension_Should_BeMissingMiddleware.snap
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/QueryableSortingExtensionsTests.Extension_Should_BeMissingMiddleware.snap
@@ -25,6 +25,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -38,6 +39,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 22,
@@ -61,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 26,

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/QueryableSortingExtensionsTests.Extension_Should_BeTypeMissMatch.snap
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/QueryableSortingExtensionsTests.Extension_Should_BeTypeMissMatch.snap
@@ -85,6 +85,7 @@
             }
           }
         ],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -98,6 +99,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 38,
@@ -121,6 +123,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 42,

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/FieldNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/FieldNode.cs
@@ -14,6 +14,8 @@ namespace HotChocolate.Language;
 /// 
 /// All GraphQL operations must specify their selections down to fields 
 /// which return scalar values to ensure an unambiguously shaped response.
+/// 
+/// Field : Alias? Name Arguments? Nullability? Directives? SelectionSet?
 /// </summary>
 public sealed class FieldNode
     : NamedSyntaxNode
@@ -23,28 +25,33 @@ public sealed class FieldNode
         Location? location,
         NameNode name,
         NameNode? alias,
+        INullabilityNode? required,
         IReadOnlyList<DirectiveNode> directives,
         IReadOnlyList<ArgumentNode> arguments,
         SelectionSetNode? selectionSet)
         : base(location, name, directives)
     {
         Alias = alias;
-        Arguments = arguments
-            ?? throw new ArgumentNullException(nameof(arguments));
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        Required = required;
         SelectionSet = selectionSet;
     }
 
-    public override SyntaxKind Kind { get; } = SyntaxKind.Field;
+    /// <inheritdoc />
+    public override SyntaxKind Kind => SyntaxKind.Field;
 
     public NameNode? Alias { get; }
 
     public IReadOnlyList<ArgumentNode> Arguments { get; }
 
+    public INullabilityNode? Required { get; }
+
     public SelectionSetNode? SelectionSet { get; }
 
+    /// <inheritdoc />
     public override IEnumerable<ISyntaxNode> GetNodes()
     {
-        if (Alias is { })
+        if (Alias is not null)
         {
             yield return Alias;
         }
@@ -56,12 +63,17 @@ public sealed class FieldNode
             yield return argument;
         }
 
+        if (Required is not null)
+        {
+            yield return Required;
+        }
+
         foreach (DirectiveNode directive in Directives)
         {
             yield return directive;
         }
 
-        if (SelectionSet is { })
+        if (SelectionSet is not null)
         {
             yield return SelectionSet;
         }
@@ -88,41 +100,94 @@ public sealed class FieldNode
     /// </returns>
     public override string ToString(bool indented) => SyntaxPrinter.Print(this, indented);
 
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the 
+    /// <see cref="Location" /> with <paramref name="location" />.
+    /// </summary>
+    /// <param name="location">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="location" />.
+    /// </returns>
     public FieldNode WithLocation(Location? location)
-    {
-        return new FieldNode(location, Name, Alias,
-            Directives, Arguments, SelectionSet);
-    }
+        => new(location, Name, Alias, Required, Directives, Arguments, SelectionSet);
 
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the 
+    /// <see cref="Name" /> with <paramref name="name" />.
+    /// </summary>
+    /// <param name="name">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="name" />.
+    /// </returns>
     public FieldNode WithName(NameNode name)
-    {
-        return new FieldNode(Location, name, Alias,
-            Directives, Arguments, SelectionSet);
-    }
+        => new(Location, name, Alias, Required, Directives, Arguments, SelectionSet);
 
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the 
+    /// <see cref="Alias" /> with <paramref name="alias" />.
+    /// </summary>
+    /// <param name="alias">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="alias" />.
+    /// </returns>
     public FieldNode WithAlias(NameNode? alias)
-    {
-        return new FieldNode(Location, Name, alias,
-            Directives, Arguments, SelectionSet);
-    }
+        => new(Location, Name, alias, Required, Directives, Arguments, SelectionSet);
 
-    public FieldNode WithDirectives(
-        IReadOnlyList<DirectiveNode> directives)
-    {
-        return new FieldNode(Location, Name, Alias,
-            directives, Arguments, SelectionSet);
-    }
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the 
+    /// <see cref="Directives" /> with <paramref name="directives" />.
+    /// </summary>
+    /// <param name="directives">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="directives" />.
+    /// </returns>
+    public FieldNode WithDirectives(IReadOnlyList<DirectiveNode> directives)
+        => new(Location, Name, Alias, Required, directives, Arguments, SelectionSet);
 
-    public FieldNode WithArguments(
-        IReadOnlyList<ArgumentNode> arguments)
-    {
-        return new FieldNode(Location, Name, Alias,
-            Directives, arguments, SelectionSet);
-    }
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the 
+    /// <see cref="Arguments" /> with <paramref name="arguments" />.
+    /// </summary>
+    /// <param name="arguments">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="arguments" />.
+    /// </returns>
+    public FieldNode WithArguments(IReadOnlyList<ArgumentNode> arguments)
+        => new(Location, Name, Alias, Required, Directives, arguments, SelectionSet);
 
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the 
+    /// <see cref="SelectionSet" /> with <paramref name="selectionSet" />.
+    /// </summary>
+    /// <param name="selectionSet">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="selectionSet" />.
+    /// </returns>
     public FieldNode WithSelectionSet(SelectionSetNode? selectionSet)
-    {
-        return new FieldNode(Location, Name, Alias,
-            Directives, Arguments, selectionSet);
-    }
+        => new(Location, Name, Alias, Required, Directives, Arguments, selectionSet);
+
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the 
+    /// <see cref="Required" /> with <paramref name="required" />.
+    /// </summary>
+    /// <param name="required">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="required" />.
+    /// </returns>
+    public FieldNode WithRequired(INullabilityNode? required)
+        => new(Location, Name, Alias, required, Directives, Arguments, SelectionSet);
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/INullabilityModifierNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/INullabilityModifierNode.cs
@@ -1,0 +1,12 @@
+namespace HotChocolate.Language;
+
+/// <summary>
+/// Represents the nullability modifier which is expressed by ! or ?
+/// </summary>
+public interface INullabilityModifierNode : INullabilityNode
+{
+    /// <summary>
+    /// Gets the inner nullability status.
+    /// </summary>
+    public new ListNullabilityNode? Element { get; }
+}

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/INullabilityNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/INullabilityNode.cs
@@ -1,0 +1,12 @@
+namespace HotChocolate.Language;
+
+/// <summary>
+/// Represents the nullability status which is expressed by !, ? or []
+/// </summary>
+public interface INullabilityNode : ISyntaxNode
+{
+    /// <summary>
+    /// Gets the inner nullability status.
+    /// </summary>
+    public INullabilityNode? Element { get; }
+}

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/ListNullabilityNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/ListNullabilityNode.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using HotChocolate.Language.Utilities;
+
+namespace HotChocolate.Language;
+
+public sealed class ListNullabilityNode : INullabilityNode
+{
+    public ListNullabilityNode(INullabilityNode element) : this(null, element) { }
+
+    public ListNullabilityNode(Location location) : this(location, null) { }
+
+    public ListNullabilityNode(Location? location, INullabilityNode? element)
+    {
+        Location = location;
+        Element = element;
+    }
+
+    /// <inheritdoc />
+    public SyntaxKind Kind => SyntaxKind.ListNullability;
+
+    /// <inheritdoc />
+    public Location? Location { get; }
+
+    /// <inheritdoc />
+    public INullabilityNode? Element { get; }
+
+    /// <inheritdoc />
+    public IEnumerable<ISyntaxNode> GetNodes()
+    {
+        if (Element is not null)
+        {
+            yield return Element;
+        }
+    }
+
+    /// <summary>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </summary>
+    /// <returns>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </returns>
+    public override string ToString() => SyntaxPrinter.Print(this, true);
+
+    /// <summary>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </summary>
+    /// <param name="indented">
+    /// A value that indicates whether the GraphQL output should be formatted,
+    /// which includes indenting nested GraphQL tokens, adding
+    /// new lines, and adding white space between property names and values.
+    /// </param>
+    /// <returns>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </returns>
+    public string ToString(bool indented) => SyntaxPrinter.Print(this, indented);
+}

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/OptionalModifierNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/OptionalModifierNode.cs
@@ -16,7 +16,7 @@ public sealed class OptionalModifierNode : INullabilityModifierNode
     }
 
     /// <inheritdoc />
-    public SyntaxKind Kind => SyntaxKind.RequiredDesignator;
+    public SyntaxKind Kind => SyntaxKind.OptionalDesignator;
 
     /// <inheritdoc />
     public Location? Location { get; }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/OptionalModifierNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/OptionalModifierNode.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using HotChocolate.Language.Utilities;
+
+namespace HotChocolate.Language;
+
+public sealed class OptionalModifierNode : INullabilityModifierNode
+{
+    public OptionalModifierNode(ListNullabilityNode element) : this(null, element) { }
+
+    public OptionalModifierNode(Location location) : this(location, null) { }
+
+    public OptionalModifierNode(Location? location, ListNullabilityNode? element)
+    {
+        Location = location;
+        Element = element;
+    }
+
+    /// <inheritdoc />
+    public SyntaxKind Kind => SyntaxKind.RequiredDesignator;
+
+    /// <inheritdoc />
+    public Location? Location { get; }
+
+    /// <inheritdoc />
+    public ListNullabilityNode? Element { get; }
+
+    INullabilityNode? INullabilityNode.Element => Element;
+
+    /// <inheritdoc />
+    public IEnumerable<ISyntaxNode> GetNodes()
+    {
+        if (Element is not null)
+        {
+            yield return Element;
+        }
+    }
+
+    /// <summary>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </summary>
+    /// <returns>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </returns>
+    public override string ToString() => SyntaxPrinter.Print(this, true);
+
+    /// <summary>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </summary>
+    /// <param name="indented">
+    /// A value that indicates whether the GraphQL output should be formatted,
+    /// which includes indenting nested GraphQL tokens, adding
+    /// new lines, and adding white space between property names and values.
+    /// </param>
+    /// <returns>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </returns>
+    public string ToString(bool indented) => SyntaxPrinter.Print(this, indented);
+}

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/RequiredModifierNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/RequiredModifierNode.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using HotChocolate.Language.Utilities;
+
+namespace HotChocolate.Language;
+
+public sealed class RequiredModifierNode : INullabilityModifierNode
+{
+    public RequiredModifierNode(ListNullabilityNode element) : this(null, element) { }
+
+    public RequiredModifierNode(Location location) : this(location, null) { }
+
+    public RequiredModifierNode(Location? location, ListNullabilityNode? element)
+    {
+        Location = location;
+        Element = element;
+    }
+
+    /// <inheritdoc />
+    public SyntaxKind Kind => SyntaxKind.RequiredDesignator;
+
+    /// <inheritdoc />
+    public Location? Location { get; }
+
+    /// <inheritdoc />
+    public ListNullabilityNode? Element { get; }
+
+    INullabilityNode? INullabilityNode.Element => Element;
+
+    /// <inheritdoc />
+    public IEnumerable<ISyntaxNode> GetNodes()
+    {
+        if (Element is not null)
+        {
+            yield return Element;
+        }
+    }
+
+    /// <summary>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </summary>
+    /// <returns>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </returns>
+    public override string ToString() => SyntaxPrinter.Print(this, true);
+
+    /// <summary>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </summary>
+    /// <param name="indented">
+    /// A value that indicates whether the GraphQL output should be formatted,
+    /// which includes indenting nested GraphQL tokens, adding
+    /// new lines, and adding white space between property names and values.
+    /// </param>
+    /// <returns>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </returns>
+    public string ToString(bool indented) => SyntaxPrinter.Print(this, indented);
+}

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxKind.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxKind.cs
@@ -45,5 +45,8 @@ public enum SyntaxKind
     InputObjectTypeExtension,
     DirectiveDefinition,
     FloatValue,
-    PublicKeyword
+    PublicKeyword,
+    ListNullability,
+    RequiredDesignator,
+    OptionalDesignator
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/ISyntaxWriter.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/ISyntaxWriter.cs
@@ -1,18 +1,57 @@
 namespace HotChocolate.Language.Utilities;
 
+/// <summary>
+/// This interface represents a GraphQL syntax writer.
+/// </summary>
 public interface ISyntaxWriter
 {
+    /// <summary>
+    /// Increase writer indentation.
+    /// </summary>
     void Indent();
 
+    /// <summary>
+    /// Decrease writer indentation.
+    /// </summary>
     void Unindent();
 
+    /// <summary>
+    /// Write a single character.
+    /// </summary>
+    /// <param name="c">
+    /// The characted that shall be written.
+    /// </param>
     void Write(char c);
 
+    /// <summary>
+    /// Write a string.
+    /// </summary>
+    /// <param name="s">
+    /// The string that shall be written.
+    /// </param>
     void Write(string s);
 
+    /// <summary>
+    /// Write a line if the <paramref name="condition"/> is <c>true</c>.
+    /// </summary>
+    /// <param name="condition">
+    /// The condition that defines if a line shall be written.
+    /// </param>
     void WriteLine(bool condition = true);
 
+    /// <summary>
+    /// Write a space if the <paramref name="condition"/> is <c>true</c>.
+    /// </summary>
+    /// <param name="condition">
+    /// The condition that defines if a space shall be written.
+    /// </param>
     void WriteSpace(bool condition = true);
 
+    /// <summary>
+    /// Write the current indentation if the <paramref name="condition"/> is <c>true</c>.
+    /// </summary>
+    /// <param name="condition">
+    /// The condition that defines if the current indentation shall be written.
+    /// </param>
     void WriteIndent(bool condition = true);
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxPrinter.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxPrinter.cs
@@ -16,9 +16,9 @@ public static class SyntaxPrinter
         new(new SyntaxSerializerOptions { Indented = false });
 
     /// <summary>
-    /// Prints a GraphQL syntax tree`s string representation.
+    /// Prints a GraphQL syntax node`s string representation.
     /// </summary>
-    /// <param name="node">The node representing a single node or a syntax tree.</param>
+    /// <param name="node">The syntax node that shall be printed.</param>
     /// <param name="indented">Specified if the printed string shall have indentations.</param>
     /// <returns>
     /// Returns the printed GraphQL syntax tree.
@@ -46,6 +46,16 @@ public static class SyntaxPrinter
         }
     }
 
+    /// <summary>
+    /// Prints a GraphQL syntax node`s string representation into a stream.
+    /// </summary>
+    /// <param name="node">The syntax node that shall be printed.</param>
+    /// <param name="stream">The stream to which the printed node shall be written to.</param>
+    /// <param name="indented">Specified if the printed string shall have indentations.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// Returns the printed GraphQL syntax tree.
+    /// </returns>
     public static async ValueTask PrintToAsync(
         this ISyntaxNode node,
         Stream stream,
@@ -53,12 +63,12 @@ public static class SyntaxPrinter
         CancellationToken cancellationToken = default)
     {
 #if NETSTANDARD2_0
-            using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
+        using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
 #else
         await using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
 #endif
 
-        StringSyntaxWriter syntaxWriter = StringSyntaxWriter.Rent();
+        var syntaxWriter = StringSyntaxWriter.Rent();
 
         try
         {

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxPrinter.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxPrinter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -6,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace HotChocolate.Language.Utilities;
 
+/// <summary>
+/// This helper can serialize a GraphQL syntax tree into its string representation.
+/// </summary>
 public static class SyntaxPrinter
 {
     private static readonly SyntaxSerializer _serializer =
@@ -13,6 +15,14 @@ public static class SyntaxPrinter
     private static readonly SyntaxSerializer _serializerNoIndent =
         new(new SyntaxSerializerOptions { Indented = false });
 
+    /// <summary>
+    /// Prints a GraphQL syntax tree`s string representation.
+    /// </summary>
+    /// <param name="node">The node representing a single node or a syntax tree.</param>
+    /// <param name="indented">Specified if the printed string shall have indentations.</param>
+    /// <returns>
+    /// Returns the printed GraphQL syntax tree.
+    /// </returns>
     public static string Print(this ISyntaxNode node, bool indented = true)
     {
         StringSyntaxWriter writer = StringSyntaxWriter.Rent();

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.QuerySyntax.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.QuerySyntax.cs
@@ -151,7 +151,7 @@ public sealed partial class SyntaxSerializer
     {
         writer.WriteIndent();
 
-        if (node.Alias is { })
+        if (node.Alias is not null)
         {
             writer.WriteName(node.Alias);
             writer.Write(": ");
@@ -166,6 +166,11 @@ public sealed partial class SyntaxSerializer
             writer.Write(')');
         }
 
+        if (node.Required is not null)
+        {
+            VisitNullability(node.Required, writer);
+        }
+
         if (node.Directives.Count > 0)
         {
             writer.WriteSpace();
@@ -174,10 +179,40 @@ public sealed partial class SyntaxSerializer
                 w => w.WriteSpace());
         }
 
-        if (node.SelectionSet is { } selectionSet)
+        if (node.SelectionSet is not null)
         {
             writer.WriteSpace();
-            VisitSelectionSet(selectionSet, writer);
+            VisitSelectionSet(node.SelectionSet, writer);
+        }
+    }
+
+    private void VisitNullability(INullabilityNode node, ISyntaxWriter writer)
+    {
+        if (node.Kind == SyntaxKind.ListNullability)
+        {
+            writer.Write('[');
+        }
+
+        if (node.Element is not null)
+        {
+            VisitNullability(node.Element, writer);
+        }
+
+        if (node.Kind == SyntaxKind.OptionalDesignator)
+        {
+            writer.Write('?');
+            return;
+        }
+
+        if (node.Kind == SyntaxKind.RequiredDesignator)
+        {
+            writer.Write('!');
+            return;
+        }
+
+        if (node.Kind == SyntaxKind.ListNullability)
+        {
+            writer.Write(']');
         }
     }
 

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.cs
@@ -1,5 +1,8 @@
 namespace HotChocolate.Language.Utilities;
 
+/// <summary>
+/// This helper can serialize a GraphQL syntax tree into its string representation.
+/// </summary>
 public sealed partial class SyntaxSerializer
 {
     private readonly bool _indented;
@@ -66,6 +69,11 @@ public sealed partial class SyntaxSerializer
                 break;
             case SyntaxKind.ObjectField:
                 writer.WriteObjectField((ObjectFieldNode)node);
+                break;
+            case SyntaxKind.OptionalDesignator:
+            case SyntaxKind.RequiredDesignator:
+            case SyntaxKind.ListNullability:
+                VisitNullability((INullabilityNode)node, writer);
                 break;
             case SyntaxKind.SchemaDefinition:
                 VisitSchemaDefinition((SchemaDefinitionNode)node, writer);

--- a/src/HotChocolate/Language/src/Language.Utf8/GraphQLConstants.Initialization.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/GraphQLConstants.Initialization.cs
@@ -45,20 +45,21 @@ internal static partial class GraphQLConstants
 
     private static void InitializeIsPunctuatorCache()
     {
-        _isPunctuator['!'] = true;
-        _isPunctuator['$'] = true;
-        _isPunctuator['&'] = true;
-        _isPunctuator['('] = true;
-        _isPunctuator[')'] = true;
-        _isPunctuator[':'] = true;
-        _isPunctuator['='] = true;
-        _isPunctuator['@'] = true;
-        _isPunctuator['['] = true;
-        _isPunctuator[']'] = true;
-        _isPunctuator['{'] = true;
-        _isPunctuator['|'] = true;
-        _isPunctuator['}'] = true;
-        _isPunctuator['.'] = true;
+        _isPunctuator[Bang] = true;
+        _isPunctuator[Dollar] = true;
+        _isPunctuator[QuestionMark] = true;
+        _isPunctuator[Ampersand] = true;
+        _isPunctuator[LeftParenthesis] = true;
+        _isPunctuator[RightParenthesis] = true;
+        _isPunctuator[Colon] = true;
+        _isPunctuator[Equal] = true;
+        _isPunctuator[At] = true;
+        _isPunctuator[LeftBracket] = true;
+        _isPunctuator[RightBracket] = true;
+        _isPunctuator[LeftBrace] = true;
+        _isPunctuator[Pipe] = true;
+        _isPunctuator[RightBrace] = true;
+        _isPunctuator[Dot] = true;
     }
 
     private static void InitializeIsLetterOrUnderscoreCache()
@@ -141,6 +142,7 @@ internal static partial class GraphQLConstants
     private static void InitializePunctuator()
     {
         _punctuatorKind[Bang] = TokenKind.Bang;
+        _punctuatorKind[QuestionMark] = TokenKind.QuestionMark;
         _punctuatorKind[Dollar] = TokenKind.Dollar;
         _punctuatorKind[Ampersand] = TokenKind.Ampersand;
         _punctuatorKind[LeftParenthesis] = TokenKind.LeftParenthesis;

--- a/src/HotChocolate/Language/src/Language.Utf8/GraphQLConstants.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/GraphQLConstants.cs
@@ -73,6 +73,7 @@ internal static partial class GraphQLConstants
     public const byte ForwardSlash = (byte)'/';
 
     public const byte Bang = (byte)'!';
+    public const byte QuestionMark = (byte)'?';
     public const byte Dollar = (byte)'$';
     public const byte Ampersand = (byte)'&';
     public const byte LeftParenthesis = (byte)'(';
@@ -96,61 +97,41 @@ internal static partial class GraphQLConstants
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsLetterOrDigitOrUnderscore(this byte c)
-    {
-        return _isLetterOrDigitOrUnderscore[c];
-    }
+        => _isLetterOrDigitOrUnderscore[c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsLetterOrDigitOrUnderscore(this char c)
-    {
-        return _isLetterOrDigitOrUnderscore[(byte)c];
-    }
+        => _isLetterOrDigitOrUnderscore[(byte)c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsLetterOrUnderscore(this byte c)
-    {
-        return _isLetterOrUnderscore[c];
-    }
+        => _isLetterOrUnderscore[c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsLetterOrUnderscore(this char c)
-    {
-        return _isLetterOrUnderscore[(byte)c];
-    }
+        => _isLetterOrUnderscore[(byte)c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsDigit(this byte c)
-    {
-        return _isDigit[c];
-    }
+        => _isDigit[c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsDigitOrMinus(this byte c)
-    {
-        return _isDigitOrMinus[c];
-    }
+        => _isDigitOrMinus[c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsPunctuator(this byte c)
-    {
-        return _isPunctuator[c];
-    }
+        => _isPunctuator[c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsValidEscapeCharacter(this byte c)
-    {
-        return _isEscapeCharacter[c];
-    }
+        => _isEscapeCharacter[c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static byte EscapeCharacter(this byte c)
-    {
-        return _escapeCharacters[c];
-    }
+        => _escapeCharacters[c];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static TokenKind PunctuatorKind(this byte c)
-    {
-        return _punctuatorKind[c];
-    }
+        => _punctuatorKind[c];
 }

--- a/src/HotChocolate/Language/src/Language.Utf8/TokenKind.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/TokenKind.cs
@@ -16,34 +16,107 @@ public enum TokenKind : byte
     EndOfFile,
 
     /// <summary>
-    /// The bang token is used to specify
-    /// non null types and is represented by:
-    /// '!'.
+    /// !
     /// </summary>
     Bang,
 
     /// <summary>
-    /// The dollar token is used to specify variables
-    /// and variable declarations and is represented by:
-    /// '$'.
+    /// ?
+    /// </summary>
+    QuestionMark,
+
+    /// <summary>
+    /// $
     /// </summary>
     Dollar,
+
+    /// <summary>
+    /// &
+    /// </summary>
     Ampersand,
+
+    /// <summary>
+    /// (
+    /// </summary>
     LeftParenthesis,
+
+    /// <summary>
+    /// )
+    /// </summary>
     RightParenthesis,
+
+    /// <summary>
+    /// ...
+    /// </summary>
     Spread,
+
+    /// <summary>
+    /// :
+    /// </summary>
     Colon,
+
+    /// <summary>
+    /// =
+    /// </summary>
     Equal,
+
+    /// <summary>
+    /// @
+    /// </summary>
     At,
+
+    /// <summary>
+    /// [
+    /// </summary>
     LeftBracket,
+
+    /// <summary>
+    /// ]
+    /// </summary>
     RightBracket,
+
+    /// <summary>
+    /// {
+    /// </summary>
     LeftBrace,
+
+    /// <summary>
+    /// }
+    /// </summary>
     RightBrace,
+
+    /// <summary>
+    /// |
+    /// </summary>
     Pipe,
+
+    /// <summary>
+    /// A name token.
+    /// </summary>
     Name,
+
+    /// <summary>
+    /// A integer token.
+    /// </summary>
     Integer,
+
+    /// <summary>
+    /// A float token.
+    /// </summary>
     Float,
+
+    /// <summary>
+    /// A string token.
+    /// </summary>
     String,
+
+    /// <summary>
+    /// A block string token.
+    /// </summary>
     BlockString,
+
+    /// <summary>
+    /// A comment token.
+    /// </summary>
     Comment
 }

--- a/src/HotChocolate/Language/test/Language.Tests/AST/SelectionSetNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/SelectionSetNodeTests.cs
@@ -20,6 +20,7 @@ public class SelectionSetNodeTests
                     null,
                     new NameNode("bar"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
@@ -48,6 +49,7 @@ public class SelectionSetNodeTests
                 (
                     null,
                     new NameNode("bar"),
+                    null,
                     null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
@@ -80,6 +82,7 @@ public class SelectionSetNodeTests
                     null,
                     new NameNode("bar"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
@@ -98,6 +101,7 @@ public class SelectionSetNodeTests
             (
                 null,
                 new NameNode("baz"),
+                null,
                 null,
                 Array.Empty<DirectiveNode>(),
                 Array.Empty<ArgumentNode>(),
@@ -120,6 +124,7 @@ public class SelectionSetNodeTests
                     null,
                     new NameNode("bar"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
@@ -138,6 +143,7 @@ public class SelectionSetNodeTests
             (
                 null,
                 new NameNode("baz"),
+                null,
                 null,
                 Array.Empty<DirectiveNode>(),
                 Array.Empty<ArgumentNode>(),
@@ -160,6 +166,7 @@ public class SelectionSetNodeTests
                     null,
                     new NameNode("bar"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
@@ -179,6 +186,7 @@ public class SelectionSetNodeTests
                 null,
                 new NameNode("baz"),
                 null,
+                null,
                 Array.Empty<DirectiveNode>(),
                 Array.Empty<ArgumentNode>(),
                 null
@@ -187,6 +195,7 @@ public class SelectionSetNodeTests
             (
                 null,
                 new NameNode("qux"),
+                null,
                 null,
                 Array.Empty<DirectiveNode>(),
                 Array.Empty<ArgumentNode>(),
@@ -209,6 +218,7 @@ public class SelectionSetNodeTests
                     null,
                     new NameNode("bar"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
@@ -217,6 +227,7 @@ public class SelectionSetNodeTests
                 (
                     null,
                     new NameNode("baz"),
+                    null,
                     null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
@@ -250,6 +261,7 @@ public class SelectionSetNodeTests
                     null,
                     new NameNode("bar"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
@@ -258,6 +270,7 @@ public class SelectionSetNodeTests
                 (
                     null,
                     new NameNode("baz"),
+                    null,
                     null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
@@ -291,6 +304,7 @@ public class SelectionSetNodeTests
                     null,
                     new NameNode("bar"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
@@ -311,6 +325,7 @@ public class SelectionSetNodeTests
                     (
                         null,
                         new NameNode("baz"),
+                        null,
                         null,
                         Array.Empty<DirectiveNode>(),
                         Array.Empty<ArgumentNode>(),

--- a/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.AddSelection.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.AddSelection.snap
@@ -11,6 +11,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {
@@ -24,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.AddSelections.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.AddSelections.snap
@@ -11,6 +11,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {
@@ -24,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.AddSelections_Two.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.AddSelections_Two.snap
@@ -11,6 +11,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {
@@ -24,6 +25,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {
@@ -37,6 +39,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.CreateSelectionSet.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.CreateSelectionSet.snap
@@ -11,6 +11,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.RemoveSelection.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.RemoveSelection.snap
@@ -11,6 +11,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.RemoveSelections.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.RemoveSelections.snap
@@ -11,6 +11,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.WithLocation.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.WithLocation.snap
@@ -11,6 +11,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.WithSelections.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/AST/__snapshots__/SelectionSetNodeTests.WithSelections.snap
@@ -11,6 +11,7 @@
       "Kind": "Field",
       "Alias": null,
       "Arguments": [],
+      "Required": null,
       "SelectionSet": null,
       "Location": null,
       "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/Legacy/__snapshots__/LegacyParserWrapperTests.QueryWithComments.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Legacy/__snapshots__/LegacyParserWrapperTests.QueryWithComments.snap
@@ -17,6 +17,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": null,
@@ -25,6 +26,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": null,
                   "Name": {
@@ -38,6 +40,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": null,
@@ -46,6 +49,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": null,
                         "Name": {

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8KitchenSinkParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8KitchenSinkParserTests.cs
@@ -43,4 +43,22 @@ public class Utf8KitchenSinkParserTests
         document.ToString().MatchSnapshot(new SnapshotNameExtension("sdl"));
         document.MatchSnapshot();
     }
+
+    [Fact]
+    public void ParseFacebookKitchenSinkQueryNullability()
+    {
+        // arrange
+        var querySource =
+            FileResource.Open("kitchen-sink-nullability.graphql")
+                .NormalizeLineBreaks();
+        var parser = new Utf8GraphQLParser(
+            Encoding.UTF8.GetBytes(querySource));
+
+        // act
+        DocumentNode document = parser.Parse();
+
+        // assert
+        document.ToString().MatchSnapshot(new SnapshotNameExtension("sdl"));
+        document.MatchSnapshot();
+    }
 }

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8DirectiveParserTests.ParseQueryDirective.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8DirectiveParserTests.ParseQueryDirective.snap
@@ -104,6 +104,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 70,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_FieldNode_From_ByteArray.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_FieldNode_From_ByteArray.snap
@@ -33,6 +33,7 @@
       }
     }
   ],
+  "Required": null,
   "SelectionSet": null,
   "Location": {
     "Start": 0,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_FieldNode_From_Reader.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_FieldNode_From_Reader.snap
@@ -33,6 +33,7 @@
       }
     }
   ],
+  "Required": null,
   "SelectionSet": null,
   "Location": {
     "Start": 0,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_FieldNode_From_String.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_FieldNode_From_String.snap
@@ -33,6 +33,7 @@
       }
     }
   ],
+  "Required": null,
   "SelectionSet": null,
   "Location": {
     "Start": 0,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_SelectionSetNode_From_ByteArray.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_SelectionSetNode_From_ByteArray.snap
@@ -42,6 +42,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 2,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_SelectionSetNode_From_Reader.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_SelectionSetNode_From_Reader.snap
@@ -42,6 +42,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 2,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_SelectionSetNode_From_String.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8GraphQLParserSyntaxTests.Parse_SelectionSetNode_From_String.snap
@@ -42,6 +42,7 @@
           }
         }
       ],
+      "Required": null,
       "SelectionSet": null,
       "Location": {
         "Start": 2,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQuery.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQuery.snap
@@ -211,6 +211,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -224,6 +225,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 274,
@@ -305,6 +307,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -318,6 +321,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 327,
@@ -419,6 +423,7 @@
                                   }
                                 }
                               ],
+                              "Required": null,
                               "SelectionSet": {
                                 "Kind": "SelectionSet",
                                 "Location": {
@@ -432,6 +437,7 @@
                                     "Kind": "Field",
                                     "Alias": null,
                                     "Arguments": [],
+                                    "Required": null,
                                     "SelectionSet": null,
                                     "Location": {
                                       "Start": 408,
@@ -659,6 +665,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 490,
@@ -704,6 +711,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 515,
@@ -813,6 +821,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -826,6 +835,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -839,6 +849,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 598,
@@ -1047,6 +1058,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -1060,6 +1072,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -1073,6 +1086,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -1086,6 +1100,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 757,
@@ -1129,6 +1144,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -1142,6 +1158,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 800,
@@ -1428,6 +1445,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 854,
@@ -1580,6 +1598,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 957,
@@ -1603,6 +1622,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 1012,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQueryNullability.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQueryNullability.snap
@@ -1,0 +1,3281 @@
+﻿{
+  "Kind": "Document",
+  "Location": {
+    "Start": 0,
+    "End": 2119,
+    "Line": 1,
+    "Column": 1
+  },
+  "Definitions": [
+    {
+      "Kind": "OperationDefinition",
+      "Location": {
+        "Start": 0,
+        "End": 1499,
+        "Line": 1,
+        "Column": 1
+      },
+      "Name": {
+        "Kind": "Name",
+        "Location": {
+          "Start": 6,
+          "End": 16,
+          "Line": 1,
+          "Column": 7
+        },
+        "Value": "queryName"
+      },
+      "Operation": "Query",
+      "VariableDefinitions": [
+        {
+          "Kind": "VariableDefinition",
+          "Location": {
+            "Start": 16,
+            "End": 36,
+            "Line": 1,
+            "Column": 17
+          },
+          "Variable": {
+            "Kind": "Variable",
+            "Location": {
+              "Start": 16,
+              "End": 21,
+              "Line": 1,
+              "Column": 17
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 17,
+                "End": 21,
+                "Line": 1,
+                "Column": 18
+              },
+              "Value": "foo"
+            },
+            "Value": "foo"
+          },
+          "Type": {
+            "Kind": "NamedType",
+            "Location": {
+              "Start": 22,
+              "End": 36,
+              "Line": 1,
+              "Column": 23
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 22,
+                "End": 36,
+                "Line": 1,
+                "Column": 23
+              },
+              "Value": "ComplexType"
+            }
+          },
+          "DefaultValue": null,
+          "Directives": []
+        },
+        {
+          "Kind": "VariableDefinition",
+          "Location": {
+            "Start": 35,
+            "End": 56,
+            "Line": 1,
+            "Column": 36
+          },
+          "Variable": {
+            "Kind": "Variable",
+            "Location": {
+              "Start": 35,
+              "End": 41,
+              "Line": 1,
+              "Column": 36
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 36,
+                "End": 41,
+                "Line": 1,
+                "Column": 37
+              },
+              "Value": "site"
+            },
+            "Value": "site"
+          },
+          "Type": {
+            "Kind": "NamedType",
+            "Location": {
+              "Start": 42,
+              "End": 48,
+              "Line": 1,
+              "Column": 43
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 42,
+                "End": 48,
+                "Line": 1,
+                "Column": 43
+              },
+              "Value": "Site"
+            }
+          },
+          "DefaultValue": {
+            "Kind": "EnumValue",
+            "Location": {
+              "Start": 49,
+              "End": 56,
+              "Line": 1,
+              "Column": 50
+            },
+            "Value": "MOBILE"
+          },
+          "Directives": []
+        }
+      ],
+      "Directives": [
+        {
+          "Kind": "Directive",
+          "Location": {
+            "Start": 57,
+            "End": 67,
+            "Line": 1,
+            "Column": 58
+          },
+          "Name": {
+            "Kind": "Name",
+            "Location": {
+              "Start": 58,
+              "End": 67,
+              "Line": 1,
+              "Column": 59
+            },
+            "Value": "onQuery"
+          },
+          "Arguments": []
+        }
+      ],
+      "SelectionSet": {
+        "Kind": "SelectionSet",
+        "Location": {
+          "Start": 66,
+          "End": 1499,
+          "Line": 1,
+          "Column": 67
+        },
+        "Selections": [
+          {
+            "Kind": "Field",
+            "Alias": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 70,
+                "End": 83,
+                "Line": 2,
+                "Column": 3
+              },
+              "Value": "whoever123is"
+            },
+            "Arguments": [
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 89,
+                  "End": 104,
+                  "Line": 2,
+                  "Column": 22
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 89,
+                    "End": 92,
+                    "Line": 2,
+                    "Column": 22
+                  },
+                  "Value": "id"
+                },
+                "Value": {
+                  "Kind": "ListValue",
+                  "Location": {
+                    "Start": 93,
+                    "End": 104,
+                    "Line": 2,
+                    "Column": 26
+                  },
+                  "Items": [
+                    {
+                      "Kind": "IntValue",
+                      "Location": {
+                        "Start": 94,
+                        "End": 102,
+                        "Line": 2,
+                        "Column": 27
+                      },
+                      "Value": "123"
+                    },
+                    {
+                      "Kind": "IntValue",
+                      "Location": {
+                        "Start": 99,
+                        "End": 103,
+                        "Line": 2,
+                        "Column": 32
+                      },
+                      "Value": "456"
+                    }
+                  ]
+                }
+              }
+            ],
+            "Required": null,
+            "SelectionSet": {
+              "Kind": "SelectionSet",
+              "Location": {
+                "Start": 105,
+                "End": 1490,
+                "Line": 2,
+                "Column": 38
+              },
+              "Selections": [
+                {
+                  "Kind": "Field",
+                  "Alias": null,
+                  "Arguments": [],
+                  "Required": null,
+                  "SelectionSet": null,
+                  "Location": {
+                    "Start": 111,
+                    "End": 121,
+                    "Line": 3,
+                    "Column": 5
+                  },
+                  "Name": {
+                    "Kind": "Name",
+                    "Location": {
+                      "Start": 111,
+                      "End": 121,
+                      "Line": 3,
+                      "Column": 5
+                    },
+                    "Value": "id"
+                  },
+                  "Directives": []
+                },
+                {
+                  "Kind": "InlineFragment",
+                  "Location": {
+                    "Start": 118,
+                    "End": 1421,
+                    "Line": 4,
+                    "Column": 5
+                  },
+                  "TypeCondition": {
+                    "Kind": "NamedType",
+                    "Location": {
+                      "Start": 125,
+                      "End": 131,
+                      "Line": 4,
+                      "Column": 12
+                    },
+                    "Name": {
+                      "Kind": "Name",
+                      "Location": {
+                        "Start": 125,
+                        "End": 131,
+                        "Line": 4,
+                        "Column": 12
+                      },
+                      "Value": "User"
+                    }
+                  },
+                  "Directives": [
+                    {
+                      "Kind": "Directive",
+                      "Location": {
+                        "Start": 130,
+                        "End": 149,
+                        "Line": 4,
+                        "Column": 17
+                      },
+                      "Name": {
+                        "Kind": "Name",
+                        "Location": {
+                          "Start": 131,
+                          "End": 149,
+                          "Line": 4,
+                          "Column": 18
+                        },
+                        "Value": "onInlineFragment"
+                      },
+                      "Arguments": []
+                    }
+                  ],
+                  "SelectionSet": {
+                    "Kind": "SelectionSet",
+                    "Location": {
+                      "Start": 148,
+                      "End": 1421,
+                      "Line": 4,
+                      "Column": 35
+                    },
+                    "Selections": [
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": null,
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 163,
+                            "End": 326,
+                            "Line": 5,
+                            "Column": 14
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 173,
+                                "End": 189,
+                                "Line": 6,
+                                "Column": 9
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 173,
+                                  "End": 189,
+                                  "Line": 6,
+                                  "Column": 9
+                                },
+                                "Value": "id"
+                              },
+                              "Directives": []
+                            },
+                            {
+                              "Kind": "Field",
+                              "Alias": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 184,
+                                  "End": 190,
+                                  "Line": 7,
+                                  "Column": 9
+                                },
+                                "Value": "alias"
+                              },
+                              "Arguments": [
+                                {
+                                  "Kind": "Argument",
+                                  "Location": {
+                                    "Start": 198,
+                                    "End": 214,
+                                    "Line": 7,
+                                    "Column": 23
+                                  },
+                                  "Name": {
+                                    "Kind": "Name",
+                                    "Location": {
+                                      "Start": 198,
+                                      "End": 204,
+                                      "Line": 7,
+                                      "Column": 23
+                                    },
+                                    "Value": "first"
+                                  },
+                                  "Value": {
+                                    "Kind": "IntValue",
+                                    "Location": {
+                                      "Start": 205,
+                                      "End": 214,
+                                      "Line": 7,
+                                      "Column": 30
+                                    },
+                                    "Value": "10"
+                                  }
+                                },
+                                {
+                                  "Kind": "Argument",
+                                  "Location": {
+                                    "Start": 209,
+                                    "End": 221,
+                                    "Line": 7,
+                                    "Column": 34
+                                  },
+                                  "Name": {
+                                    "Kind": "Name",
+                                    "Location": {
+                                      "Start": 209,
+                                      "End": 215,
+                                      "Line": 7,
+                                      "Column": 34
+                                    },
+                                    "Value": "after"
+                                  },
+                                  "Value": {
+                                    "Kind": "Variable",
+                                    "Location": {
+                                      "Start": 216,
+                                      "End": 221,
+                                      "Line": 7,
+                                      "Column": 41
+                                    },
+                                    "Name": {
+                                      "Kind": "Name",
+                                      "Location": {
+                                        "Start": 217,
+                                        "End": 221,
+                                        "Line": 7,
+                                        "Column": 42
+                                      },
+                                      "Value": "foo"
+                                    },
+                                    "Value": "foo"
+                                  }
+                                }
+                              ],
+                              "Required": null,
+                              "SelectionSet": {
+                                "Kind": "SelectionSet",
+                                "Location": {
+                                  "Start": 241,
+                                  "End": 312,
+                                  "Line": 7,
+                                  "Column": 66
+                                },
+                                "Selections": [
+                                  {
+                                    "Kind": "Field",
+                                    "Alias": null,
+                                    "Arguments": [],
+                                    "Required": null,
+                                    "SelectionSet": null,
+                                    "Location": {
+                                      "Start": 253,
+                                      "End": 270,
+                                      "Line": 8,
+                                      "Column": 11
+                                    },
+                                    "Name": {
+                                      "Kind": "Name",
+                                      "Location": {
+                                        "Start": 253,
+                                        "End": 270,
+                                        "Line": 8,
+                                        "Column": 11
+                                      },
+                                      "Value": "id"
+                                    },
+                                    "Directives": []
+                                  },
+                                  {
+                                    "Kind": "FragmentSpread",
+                                    "Location": {
+                                      "Start": 267,
+                                      "End": 303,
+                                      "Line": 9,
+                                      "Column": 12
+                                    },
+                                    "Name": {
+                                      "Kind": "Name",
+                                      "Location": {
+                                        "Start": 270,
+                                        "End": 276,
+                                        "Line": 9,
+                                        "Column": 15
+                                      },
+                                      "Value": "frag"
+                                    },
+                                    "Directives": [
+                                      {
+                                        "Kind": "Directive",
+                                        "Location": {
+                                          "Start": 275,
+                                          "End": 303,
+                                          "Line": 9,
+                                          "Column": 20
+                                        },
+                                        "Name": {
+                                          "Kind": "Name",
+                                          "Location": {
+                                            "Start": 276,
+                                            "End": 303,
+                                            "Line": 9,
+                                            "Column": 21
+                                          },
+                                          "Value": "onFragmentSpread"
+                                        },
+                                        "Arguments": []
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              "Location": {
+                                "Start": 184,
+                                "End": 312,
+                                "Line": 7,
+                                "Column": 9
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 191,
+                                  "End": 198,
+                                  "Line": 7,
+                                  "Column": 16
+                                },
+                                "Value": "field1"
+                              },
+                              "Directives": [
+                                {
+                                  "Kind": "Directive",
+                                  "Location": {
+                                    "Start": 222,
+                                    "End": 242,
+                                    "Line": 7,
+                                    "Column": 47
+                                  },
+                                  "Name": {
+                                    "Kind": "Name",
+                                    "Location": {
+                                      "Start": 223,
+                                      "End": 231,
+                                      "Line": 7,
+                                      "Column": 48
+                                    },
+                                    "Value": "include"
+                                  },
+                                  "Arguments": [
+                                    {
+                                      "Kind": "Argument",
+                                      "Location": {
+                                        "Start": 231,
+                                        "End": 240,
+                                        "Line": 7,
+                                        "Column": 56
+                                      },
+                                      "Name": {
+                                        "Kind": "Name",
+                                        "Location": {
+                                          "Start": 231,
+                                          "End": 234,
+                                          "Line": 7,
+                                          "Column": 56
+                                        },
+                                        "Value": "if"
+                                      },
+                                      "Value": {
+                                        "Kind": "Variable",
+                                        "Location": {
+                                          "Start": 235,
+                                          "End": 240,
+                                          "Line": 7,
+                                          "Column": 60
+                                        },
+                                        "Name": {
+                                          "Kind": "Name",
+                                          "Location": {
+                                            "Start": 236,
+                                            "End": 240,
+                                            "Line": 7,
+                                            "Column": 61
+                                          },
+                                          "Value": "foo"
+                                        },
+                                        "Value": "foo"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 156,
+                          "End": 326,
+                          "Line": 5,
+                          "Column": 7
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 156,
+                            "End": 164,
+                            "Line": 5,
+                            "Column": 7
+                          },
+                          "Value": "field2"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 326,
+                            "End": 349,
+                            "Line": 12,
+                            "Column": 14
+                          },
+                          "Element": null
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 320,
+                          "End": 349,
+                          "Line": 12,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 320,
+                            "End": 327,
+                            "Line": 12,
+                            "Column": 8
+                          },
+                          "Value": "field3"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 335,
+                            "End": 350,
+                            "Line": 13,
+                            "Column": 8
+                          },
+                          "Value": "requiredField4"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 357,
+                            "End": 372,
+                            "Line": 13,
+                            "Column": 30
+                          },
+                          "Element": null
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 335,
+                          "End": 372,
+                          "Line": 13,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 351,
+                            "End": 358,
+                            "Line": 13,
+                            "Column": 24
+                          },
+                          "Value": "field4"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 372,
+                            "End": 395,
+                            "Line": 14,
+                            "Column": 14
+                          },
+                          "Element": null
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 366,
+                          "End": 395,
+                          "Line": 14,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 366,
+                            "End": 373,
+                            "Line": 14,
+                            "Column": 8
+                          },
+                          "Value": "field5"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 381,
+                            "End": 396,
+                            "Line": 15,
+                            "Column": 8
+                          },
+                          "Value": "optionalField6"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 403,
+                            "End": 438,
+                            "Line": 15,
+                            "Column": 30
+                          },
+                          "Element": null
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 381,
+                          "End": 438,
+                          "Line": 15,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 397,
+                            "End": 404,
+                            "Line": 15,
+                            "Column": 24
+                          },
+                          "Value": "field6"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 412,
+                            "End": 439,
+                            "Line": 16,
+                            "Column": 8
+                          },
+                          "Value": "unsetListItemsRequiredList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 451,
+                            "End": 486,
+                            "Line": 16,
+                            "Column": 47
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 449,
+                              "End": 452,
+                              "Line": 16,
+                              "Column": 45
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 412,
+                          "End": 486,
+                          "Line": 16,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 440,
+                            "End": 450,
+                            "Line": 16,
+                            "Column": 36
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 460,
+                            "End": 487,
+                            "Line": 17,
+                            "Column": 8
+                          },
+                          "Value": "requiredListItemsUnsetList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "ListNullability",
+                          "Location": {
+                            "Start": 497,
+                            "End": 537,
+                            "Line": 17,
+                            "Column": 45
+                          },
+                          "Element": {
+                            "Kind": "RequiredDesignator",
+                            "Location": {
+                              "Start": 498,
+                              "End": 500,
+                              "Line": 17,
+                              "Column": 46
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 460,
+                          "End": 537,
+                          "Line": 17,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 488,
+                            "End": 498,
+                            "Line": 17,
+                            "Column": 36
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 508,
+                            "End": 538,
+                            "Line": 18,
+                            "Column": 8
+                          },
+                          "Value": "requiredListItemsRequiredList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 551,
+                            "End": 586,
+                            "Line": 18,
+                            "Column": 51
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 548,
+                              "End": 552,
+                              "Line": 18,
+                              "Column": 48
+                            },
+                            "Element": {
+                              "Kind": "RequiredDesignator",
+                              "Location": {
+                                "Start": 549,
+                                "End": 551,
+                                "Line": 18,
+                                "Column": 49
+                              },
+                              "Element": null
+                            }
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 508,
+                          "End": 586,
+                          "Line": 18,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 539,
+                            "End": 549,
+                            "Line": 18,
+                            "Column": 39
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 560,
+                            "End": 587,
+                            "Line": 19,
+                            "Column": 8
+                          },
+                          "Value": "unsetListItemsOptionalList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 599,
+                            "End": 634,
+                            "Line": 19,
+                            "Column": 47
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 597,
+                              "End": 600,
+                              "Line": 19,
+                              "Column": 45
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 560,
+                          "End": 634,
+                          "Line": 19,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 588,
+                            "End": 598,
+                            "Line": 19,
+                            "Column": 36
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 608,
+                            "End": 635,
+                            "Line": 20,
+                            "Column": 8
+                          },
+                          "Value": "optionalListItemsUnsetList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "ListNullability",
+                          "Location": {
+                            "Start": 645,
+                            "End": 685,
+                            "Line": 20,
+                            "Column": 45
+                          },
+                          "Element": {
+                            "Kind": "RequiredDesignator",
+                            "Location": {
+                              "Start": 646,
+                              "End": 648,
+                              "Line": 20,
+                              "Column": 46
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 608,
+                          "End": 685,
+                          "Line": 20,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 636,
+                            "End": 646,
+                            "Line": 20,
+                            "Column": 36
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 656,
+                            "End": 686,
+                            "Line": 21,
+                            "Column": 8
+                          },
+                          "Value": "optionalListItemsOptionalList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 699,
+                            "End": 728,
+                            "Line": 21,
+                            "Column": 51
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 696,
+                              "End": 700,
+                              "Line": 21,
+                              "Column": 48
+                            },
+                            "Element": {
+                              "Kind": "RequiredDesignator",
+                              "Location": {
+                                "Start": 697,
+                                "End": 699,
+                                "Line": 21,
+                                "Column": 49
+                              },
+                              "Element": null
+                            }
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 656,
+                          "End": 728,
+                          "Line": 21,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 687,
+                            "End": 697,
+                            "Line": 21,
+                            "Column": 39
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 708,
+                            "End": 729,
+                            "Line": 22,
+                            "Column": 8
+                          },
+                          "Value": "multidimensionalList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 748,
+                            "End": 763,
+                            "Line": 22,
+                            "Column": 48
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 739,
+                              "End": 749,
+                              "Line": 22,
+                              "Column": 39
+                            },
+                            "Element": {
+                              "Kind": "RequiredDesignator",
+                              "Location": {
+                                "Start": 746,
+                                "End": 748,
+                                "Line": 22,
+                                "Column": 46
+                              },
+                              "Element": {
+                                "Kind": "ListNullability",
+                                "Location": {
+                                  "Start": 740,
+                                  "End": 747,
+                                  "Line": 22,
+                                  "Column": 40
+                                },
+                                "Element": {
+                                  "Kind": "RequiredDesignator",
+                                  "Location": {
+                                    "Start": 744,
+                                    "End": 746,
+                                    "Line": 22,
+                                    "Column": 44
+                                  },
+                                  "Element": {
+                                    "Kind": "ListNullability",
+                                    "Location": {
+                                      "Start": 741,
+                                      "End": 745,
+                                      "Line": 22,
+                                      "Column": 41
+                                    },
+                                    "Element": {
+                                      "Kind": "RequiredDesignator",
+                                      "Location": {
+                                        "Start": 742,
+                                        "End": 744,
+                                        "Line": 22,
+                                        "Column": 42
+                                      },
+                                      "Element": null
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 708,
+                          "End": 763,
+                          "Line": 22,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 730,
+                            "End": 740,
+                            "Line": 22,
+                            "Column": 30
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 763,
+                            "End": 766,
+                            "Line": 23,
+                            "Column": 14
+                          },
+                          "Element": null
+                        },
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 765,
+                            "End": 813,
+                            "Line": 23,
+                            "Column": 16
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 776,
+                                "End": 791,
+                                "Line": 24,
+                                "Column": 10
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 776,
+                                  "End": 791,
+                                  "Line": 24,
+                                  "Column": 10
+                                },
+                                "Value": "field8"
+                              },
+                              "Directives": []
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 757,
+                          "End": 813,
+                          "Line": 23,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 757,
+                            "End": 764,
+                            "Line": 23,
+                            "Column": 8
+                          },
+                          "Value": "field7"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 799,
+                            "End": 814,
+                            "Line": 26,
+                            "Column": 8
+                          },
+                          "Value": "requiredField4"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 821,
+                            "End": 824,
+                            "Line": 26,
+                            "Column": 30
+                          },
+                          "Element": null
+                        },
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 823,
+                            "End": 863,
+                            "Line": 26,
+                            "Column": 32
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 834,
+                                "End": 849,
+                                "Line": 27,
+                                "Column": 10
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 834,
+                                  "End": 849,
+                                  "Line": 27,
+                                  "Column": 10
+                                },
+                                "Value": "field8"
+                              },
+                              "Directives": []
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 799,
+                          "End": 863,
+                          "Line": 26,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 815,
+                            "End": 822,
+                            "Line": 26,
+                            "Column": 24
+                          },
+                          "Value": "field7"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 863,
+                            "End": 866,
+                            "Line": 29,
+                            "Column": 14
+                          },
+                          "Element": null
+                        },
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 865,
+                            "End": 914,
+                            "Line": 29,
+                            "Column": 16
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 876,
+                                "End": 892,
+                                "Line": 30,
+                                "Column": 10
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 876,
+                                  "End": 892,
+                                  "Line": 30,
+                                  "Column": 10
+                                },
+                                "Value": "field10"
+                              },
+                              "Directives": []
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 857,
+                          "End": 914,
+                          "Line": 29,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 857,
+                            "End": 864,
+                            "Line": 29,
+                            "Column": 8
+                          },
+                          "Value": "field9"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 900,
+                            "End": 915,
+                            "Line": 32,
+                            "Column": 8
+                          },
+                          "Value": "optionalField9"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 922,
+                            "End": 925,
+                            "Line": 32,
+                            "Column": 30
+                          },
+                          "Element": null
+                        },
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 924,
+                            "End": 966,
+                            "Line": 32,
+                            "Column": 32
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 935,
+                                "End": 951,
+                                "Line": 33,
+                                "Column": 10
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 935,
+                                  "End": 951,
+                                  "Line": 33,
+                                  "Column": 10
+                                },
+                                "Value": "field10"
+                              },
+                              "Directives": []
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 900,
+                          "End": 966,
+                          "Line": 32,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 916,
+                            "End": 923,
+                            "Line": 32,
+                            "Column": 24
+                          },
+                          "Value": "field9"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 968,
+                            "End": 971,
+                            "Line": 35,
+                            "Column": 17
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 966,
+                              "End": 969,
+                              "Line": 35,
+                              "Column": 15
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 970,
+                            "End": 1020,
+                            "Line": 35,
+                            "Column": 19
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 981,
+                                "End": 997,
+                                "Line": 36,
+                                "Column": 10
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 981,
+                                  "End": 997,
+                                  "Line": 36,
+                                  "Column": 10
+                                },
+                                "Value": "field12"
+                              },
+                              "Directives": []
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 959,
+                          "End": 1020,
+                          "Line": 35,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 959,
+                            "End": 967,
+                            "Line": 35,
+                            "Column": 8
+                          },
+                          "Value": "field11"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1005,
+                            "End": 1021,
+                            "Line": 38,
+                            "Column": 8
+                          },
+                          "Value": "requiredField11"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 1031,
+                            "End": 1034,
+                            "Line": 38,
+                            "Column": 34
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 1029,
+                              "End": 1032,
+                              "Line": 38,
+                              "Column": 32
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 1033,
+                            "End": 1094,
+                            "Line": 38,
+                            "Column": 36
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 1044,
+                                "End": 1060,
+                                "Line": 39,
+                                "Column": 10
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 1044,
+                                  "End": 1060,
+                                  "Line": 39,
+                                  "Column": 10
+                                },
+                                "Value": "field12"
+                              },
+                              "Directives": []
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 1005,
+                          "End": 1094,
+                          "Line": 38,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1022,
+                            "End": 1030,
+                            "Line": 38,
+                            "Column": 25
+                          },
+                          "Value": "field11"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1068,
+                            "End": 1095,
+                            "Line": 41,
+                            "Column": 8
+                          },
+                          "Value": "unsetListItemsRequiredList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 1107,
+                            "End": 1142,
+                            "Line": 41,
+                            "Column": 47
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 1105,
+                              "End": 1108,
+                              "Line": 41,
+                              "Column": 45
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1068,
+                          "End": 1142,
+                          "Line": 41,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1096,
+                            "End": 1106,
+                            "Line": 41,
+                            "Column": 36
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1116,
+                            "End": 1143,
+                            "Line": 42,
+                            "Column": 8
+                          },
+                          "Value": "requiredListItemsUnsetList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "ListNullability",
+                          "Location": {
+                            "Start": 1153,
+                            "End": 1193,
+                            "Line": 42,
+                            "Column": 45
+                          },
+                          "Element": {
+                            "Kind": "RequiredDesignator",
+                            "Location": {
+                              "Start": 1154,
+                              "End": 1156,
+                              "Line": 42,
+                              "Column": 46
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1116,
+                          "End": 1193,
+                          "Line": 42,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1144,
+                            "End": 1154,
+                            "Line": 42,
+                            "Column": 36
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1164,
+                            "End": 1194,
+                            "Line": 43,
+                            "Column": 8
+                          },
+                          "Value": "requiredListItemsRequiredList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 1207,
+                            "End": 1242,
+                            "Line": 43,
+                            "Column": 51
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 1204,
+                              "End": 1208,
+                              "Line": 43,
+                              "Column": 48
+                            },
+                            "Element": {
+                              "Kind": "RequiredDesignator",
+                              "Location": {
+                                "Start": 1205,
+                                "End": 1207,
+                                "Line": 43,
+                                "Column": 49
+                              },
+                              "Element": null
+                            }
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1164,
+                          "End": 1242,
+                          "Line": 43,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1195,
+                            "End": 1205,
+                            "Line": 43,
+                            "Column": 39
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1216,
+                            "End": 1243,
+                            "Line": 44,
+                            "Column": 8
+                          },
+                          "Value": "unsetListItemsOptionalList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 1255,
+                            "End": 1290,
+                            "Line": 44,
+                            "Column": 47
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 1253,
+                              "End": 1256,
+                              "Line": 44,
+                              "Column": 45
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1216,
+                          "End": 1290,
+                          "Line": 44,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1244,
+                            "End": 1254,
+                            "Line": 44,
+                            "Column": 36
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1264,
+                            "End": 1291,
+                            "Line": 45,
+                            "Column": 8
+                          },
+                          "Value": "optionalListItemsUnsetList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "ListNullability",
+                          "Location": {
+                            "Start": 1301,
+                            "End": 1341,
+                            "Line": 45,
+                            "Column": 45
+                          },
+                          "Element": {
+                            "Kind": "RequiredDesignator",
+                            "Location": {
+                              "Start": 1302,
+                              "End": 1304,
+                              "Line": 45,
+                              "Column": 46
+                            },
+                            "Element": null
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1264,
+                          "End": 1341,
+                          "Line": 45,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1292,
+                            "End": 1302,
+                            "Line": 45,
+                            "Column": 36
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1312,
+                            "End": 1342,
+                            "Line": 46,
+                            "Column": 8
+                          },
+                          "Value": "optionalListItemsOptionalList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 1355,
+                            "End": 1384,
+                            "Line": 46,
+                            "Column": 51
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 1352,
+                              "End": 1356,
+                              "Line": 46,
+                              "Column": 48
+                            },
+                            "Element": {
+                              "Kind": "RequiredDesignator",
+                              "Location": {
+                                "Start": 1353,
+                                "End": 1355,
+                                "Line": 46,
+                                "Column": 49
+                              },
+                              "Element": null
+                            }
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1312,
+                          "End": 1384,
+                          "Line": 46,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1343,
+                            "End": 1353,
+                            "Line": 46,
+                            "Column": 39
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1364,
+                            "End": 1385,
+                            "Line": 47,
+                            "Column": 8
+                          },
+                          "Value": "multidimensionalList"
+                        },
+                        "Arguments": [],
+                        "Required": {
+                          "Kind": "RequiredDesignator",
+                          "Location": {
+                            "Start": 1404,
+                            "End": 1412,
+                            "Line": 47,
+                            "Column": 48
+                          },
+                          "Element": {
+                            "Kind": "ListNullability",
+                            "Location": {
+                              "Start": 1395,
+                              "End": 1405,
+                              "Line": 47,
+                              "Column": 39
+                            },
+                            "Element": {
+                              "Kind": "RequiredDesignator",
+                              "Location": {
+                                "Start": 1402,
+                                "End": 1404,
+                                "Line": 47,
+                                "Column": 46
+                              },
+                              "Element": {
+                                "Kind": "ListNullability",
+                                "Location": {
+                                  "Start": 1396,
+                                  "End": 1403,
+                                  "Line": 47,
+                                  "Column": 40
+                                },
+                                "Element": {
+                                  "Kind": "RequiredDesignator",
+                                  "Location": {
+                                    "Start": 1400,
+                                    "End": 1402,
+                                    "Line": 47,
+                                    "Column": 44
+                                  },
+                                  "Element": {
+                                    "Kind": "ListNullability",
+                                    "Location": {
+                                      "Start": 1397,
+                                      "End": 1401,
+                                      "Line": 47,
+                                      "Column": 41
+                                    },
+                                    "Element": {
+                                      "Kind": "RequiredDesignator",
+                                      "Location": {
+                                        "Start": 1398,
+                                        "End": 1400,
+                                        "Line": 47,
+                                        "Column": 42
+                                      },
+                                      "Element": null
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1364,
+                          "End": 1412,
+                          "Line": 47,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1386,
+                            "End": 1396,
+                            "Line": 47,
+                            "Column": 30
+                          },
+                          "Value": "listField"
+                        },
+                        "Directives": []
+                      }
+                    ]
+                  }
+                },
+                {
+                  "Kind": "InlineFragment",
+                  "Location": {
+                    "Start": 1418,
+                    "End": 1467,
+                    "Line": 49,
+                    "Column": 6
+                  },
+                  "TypeCondition": null,
+                  "Directives": [
+                    {
+                      "Kind": "Directive",
+                      "Location": {
+                        "Start": 1422,
+                        "End": 1443,
+                        "Line": 49,
+                        "Column": 10
+                      },
+                      "Name": {
+                        "Kind": "Name",
+                        "Location": {
+                          "Start": 1423,
+                          "End": 1428,
+                          "Line": 49,
+                          "Column": 11
+                        },
+                        "Value": "skip"
+                      },
+                      "Arguments": [
+                        {
+                          "Kind": "Argument",
+                          "Location": {
+                            "Start": 1428,
+                            "End": 1441,
+                            "Line": 49,
+                            "Column": 16
+                          },
+                          "Name": {
+                            "Kind": "Name",
+                            "Location": {
+                              "Start": 1428,
+                              "End": 1435,
+                              "Line": 49,
+                              "Column": 16
+                            },
+                            "Value": "unless"
+                          },
+                          "Value": {
+                            "Kind": "Variable",
+                            "Location": {
+                              "Start": 1436,
+                              "End": 1441,
+                              "Line": 49,
+                              "Column": 24
+                            },
+                            "Name": {
+                              "Kind": "Name",
+                              "Location": {
+                                "Start": 1437,
+                                "End": 1441,
+                                "Line": 49,
+                                "Column": 25
+                              },
+                              "Value": "foo"
+                            },
+                            "Value": "foo"
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "SelectionSet": {
+                    "Kind": "SelectionSet",
+                    "Location": {
+                      "Start": 1442,
+                      "End": 1467,
+                      "Line": 49,
+                      "Column": 30
+                    },
+                    "Selections": [
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": null,
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1451,
+                          "End": 1459,
+                          "Line": 50,
+                          "Column": 8
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1451,
+                            "End": 1459,
+                            "Line": 50,
+                            "Column": 8
+                          },
+                          "Value": "id"
+                        },
+                        "Directives": []
+                      }
+                    ]
+                  }
+                },
+                {
+                  "Kind": "InlineFragment",
+                  "Location": {
+                    "Start": 1464,
+                    "End": 1488,
+                    "Line": 52,
+                    "Column": 5
+                  },
+                  "TypeCondition": null,
+                  "Directives": [],
+                  "SelectionSet": {
+                    "Kind": "SelectionSet",
+                    "Location": {
+                      "Start": 1468,
+                      "End": 1488,
+                      "Line": 52,
+                      "Column": 9
+                    },
+                    "Selections": [
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": null,
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1476,
+                          "End": 1484,
+                          "Line": 53,
+                          "Column": 7
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1476,
+                            "End": 1484,
+                            "Line": 53,
+                            "Column": 7
+                          },
+                          "Value": "id"
+                        },
+                        "Directives": []
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "Location": {
+              "Start": 70,
+              "End": 1490,
+              "Line": 2,
+              "Column": 3
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 84,
+                "End": 89,
+                "Line": 2,
+                "Column": 17
+              },
+              "Value": "node"
+            },
+            "Directives": []
+          }
+        ]
+      }
+    },
+    {
+      "Kind": "OperationDefinition",
+      "Location": {
+        "Start": 1491,
+        "End": 1608,
+        "Line": 57,
+        "Column": 1
+      },
+      "Name": {
+        "Kind": "Name",
+        "Location": {
+          "Start": 1500,
+          "End": 1511,
+          "Line": 57,
+          "Column": 10
+        },
+        "Value": "likeStory"
+      },
+      "Operation": "Mutation",
+      "VariableDefinitions": [],
+      "Directives": [
+        {
+          "Kind": "Directive",
+          "Location": {
+            "Start": 1510,
+            "End": 1523,
+            "Line": 57,
+            "Column": 20
+          },
+          "Name": {
+            "Kind": "Name",
+            "Location": {
+              "Start": 1511,
+              "End": 1523,
+              "Line": 57,
+              "Column": 21
+            },
+            "Value": "onMutation"
+          },
+          "Arguments": []
+        }
+      ],
+      "SelectionSet": {
+        "Kind": "SelectionSet",
+        "Location": {
+          "Start": 1522,
+          "End": 1608,
+          "Line": 57,
+          "Column": 32
+        },
+        "Selections": [
+          {
+            "Kind": "Field",
+            "Alias": null,
+            "Arguments": [
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 1531,
+                  "End": 1542,
+                  "Line": 58,
+                  "Column": 8
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 1531,
+                    "End": 1537,
+                    "Line": 58,
+                    "Column": 8
+                  },
+                  "Value": "story"
+                },
+                "Value": {
+                  "Kind": "IntValue",
+                  "Location": {
+                    "Start": 1538,
+                    "End": 1542,
+                    "Line": 58,
+                    "Column": 15
+                  },
+                  "Value": "123"
+                }
+              }
+            ],
+            "Required": null,
+            "SelectionSet": {
+              "Kind": "SelectionSet",
+              "Location": {
+                "Start": 1552,
+                "End": 1595,
+                "Line": 58,
+                "Column": 29
+              },
+              "Selections": [
+                {
+                  "Kind": "Field",
+                  "Alias": null,
+                  "Arguments": [],
+                  "Required": null,
+                  "SelectionSet": {
+                    "Kind": "SelectionSet",
+                    "Location": {
+                      "Start": 1564,
+                      "End": 1593,
+                      "Line": 59,
+                      "Column": 11
+                    },
+                    "Selections": [
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": null,
+                        "SelectionSet": null,
+                        "Location": {
+                          "Start": 1572,
+                          "End": 1589,
+                          "Line": 60,
+                          "Column": 7
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1572,
+                            "End": 1576,
+                            "Line": 60,
+                            "Column": 7
+                          },
+                          "Value": "id"
+                        },
+                        "Directives": [
+                          {
+                            "Kind": "Directive",
+                            "Location": {
+                              "Start": 1575,
+                              "End": 1589,
+                              "Line": 60,
+                              "Column": 10
+                            },
+                            "Name": {
+                              "Kind": "Name",
+                              "Location": {
+                                "Start": 1576,
+                                "End": 1589,
+                                "Line": 60,
+                                "Column": 11
+                              },
+                              "Value": "onField"
+                            },
+                            "Arguments": []
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "Location": {
+                    "Start": 1558,
+                    "End": 1593,
+                    "Line": 59,
+                    "Column": 5
+                  },
+                  "Name": {
+                    "Kind": "Name",
+                    "Location": {
+                      "Start": 1558,
+                      "End": 1565,
+                      "Line": 59,
+                      "Column": 5
+                    },
+                    "Value": "story"
+                  },
+                  "Directives": []
+                }
+              ]
+            },
+            "Location": {
+              "Start": 1526,
+              "End": 1595,
+              "Line": 58,
+              "Column": 3
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 1526,
+                "End": 1531,
+                "Line": 58,
+                "Column": 3
+              },
+              "Value": "like"
+            },
+            "Directives": [
+              {
+                "Kind": "Directive",
+                "Location": {
+                  "Start": 1543,
+                  "End": 1553,
+                  "Line": 58,
+                  "Column": 20
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 1544,
+                    "End": 1553,
+                    "Line": 58,
+                    "Column": 21
+                  },
+                  "Value": "onField"
+                },
+                "Arguments": []
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Kind": "OperationDefinition",
+      "Location": {
+        "Start": 1596,
+        "End": 1859,
+        "Line": 64,
+        "Column": 1
+      },
+      "Name": {
+        "Kind": "Name",
+        "Location": {
+          "Start": 1609,
+          "End": 1631,
+          "Line": 64,
+          "Column": 14
+        },
+        "Value": "StoryLikeSubscription"
+      },
+      "Operation": "Subscription",
+      "VariableDefinitions": [
+        {
+          "Kind": "VariableDefinition",
+          "Location": {
+            "Start": 1634,
+            "End": 1689,
+            "Line": 65,
+            "Column": 3
+          },
+          "Variable": {
+            "Kind": "Variable",
+            "Location": {
+              "Start": 1634,
+              "End": 1641,
+              "Line": 65,
+              "Column": 3
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 1635,
+                "End": 1641,
+                "Line": 65,
+                "Column": 4
+              },
+              "Value": "input"
+            },
+            "Value": "input"
+          },
+          "Type": {
+            "Kind": "NamedType",
+            "Location": {
+              "Start": 1642,
+              "End": 1667,
+              "Line": 65,
+              "Column": 11
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 1642,
+                "End": 1667,
+                "Line": 65,
+                "Column": 11
+              },
+              "Value": "StoryLikeSubscribeInput"
+            }
+          },
+          "DefaultValue": null,
+          "Directives": [
+            {
+              "Kind": "Directive",
+              "Location": {
+                "Start": 1666,
+                "End": 1689,
+                "Line": 65,
+                "Column": 35
+              },
+              "Name": {
+                "Kind": "Name",
+                "Location": {
+                  "Start": 1667,
+                  "End": 1689,
+                  "Line": 65,
+                  "Column": 36
+                },
+                "Value": "onVariableDefinition"
+              },
+              "Arguments": []
+            }
+          ]
+        }
+      ],
+      "Directives": [
+        {
+          "Kind": "Directive",
+          "Location": {
+            "Start": 1692,
+            "End": 1709,
+            "Line": 67,
+            "Column": 3
+          },
+          "Name": {
+            "Kind": "Name",
+            "Location": {
+              "Start": 1693,
+              "End": 1709,
+              "Line": 67,
+              "Column": 4
+            },
+            "Value": "onSubscription"
+          },
+          "Arguments": []
+        }
+      ],
+      "SelectionSet": {
+        "Kind": "SelectionSet",
+        "Location": {
+          "Start": 1708,
+          "End": 1859,
+          "Line": 67,
+          "Column": 19
+        },
+        "Selections": [
+          {
+            "Kind": "Field",
+            "Alias": null,
+            "Arguments": [
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 1731,
+                  "End": 1745,
+                  "Line": 68,
+                  "Column": 22
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 1731,
+                    "End": 1737,
+                    "Line": 68,
+                    "Column": 22
+                  },
+                  "Value": "input"
+                },
+                "Value": {
+                  "Kind": "Variable",
+                  "Location": {
+                    "Start": 1738,
+                    "End": 1745,
+                    "Line": 68,
+                    "Column": 29
+                  },
+                  "Name": {
+                    "Kind": "Name",
+                    "Location": {
+                      "Start": 1739,
+                      "End": 1745,
+                      "Line": 68,
+                      "Column": 30
+                    },
+                    "Value": "input"
+                  },
+                  "Value": "input"
+                }
+              }
+            ],
+            "Required": null,
+            "SelectionSet": {
+              "Kind": "SelectionSet",
+              "Location": {
+                "Start": 1746,
+                "End": 1850,
+                "Line": 68,
+                "Column": 37
+              },
+              "Selections": [
+                {
+                  "Kind": "Field",
+                  "Alias": null,
+                  "Arguments": [],
+                  "Required": null,
+                  "SelectionSet": {
+                    "Kind": "SelectionSet",
+                    "Location": {
+                      "Start": 1758,
+                      "End": 1848,
+                      "Line": 69,
+                      "Column": 11
+                    },
+                    "Selections": [
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": null,
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 1773,
+                            "End": 1815,
+                            "Line": 70,
+                            "Column": 14
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 1783,
+                                "End": 1796,
+                                "Line": 71,
+                                "Column": 9
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 1783,
+                                  "End": 1796,
+                                  "Line": 71,
+                                  "Column": 9
+                                },
+                                "Value": "count"
+                              },
+                              "Directives": []
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 1766,
+                          "End": 1815,
+                          "Line": 70,
+                          "Column": 7
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1766,
+                            "End": 1774,
+                            "Line": 70,
+                            "Column": 7
+                          },
+                          "Value": "likers"
+                        },
+                        "Directives": []
+                      },
+                      {
+                        "Kind": "Field",
+                        "Alias": null,
+                        "Arguments": [],
+                        "Required": null,
+                        "SelectionSet": {
+                          "Kind": "SelectionSet",
+                          "Location": {
+                            "Start": 1816,
+                            "End": 1844,
+                            "Line": 73,
+                            "Column": 20
+                          },
+                          "Selections": [
+                            {
+                              "Kind": "Field",
+                              "Alias": null,
+                              "Arguments": [],
+                              "Required": null,
+                              "SelectionSet": null,
+                              "Location": {
+                                "Start": 1826,
+                                "End": 1838,
+                                "Line": 74,
+                                "Column": 9
+                              },
+                              "Name": {
+                                "Kind": "Name",
+                                "Location": {
+                                  "Start": 1826,
+                                  "End": 1838,
+                                  "Line": 74,
+                                  "Column": 9
+                                },
+                                "Value": "text"
+                              },
+                              "Directives": []
+                            }
+                          ]
+                        },
+                        "Location": {
+                          "Start": 1803,
+                          "End": 1844,
+                          "Line": 73,
+                          "Column": 7
+                        },
+                        "Name": {
+                          "Kind": "Name",
+                          "Location": {
+                            "Start": 1803,
+                            "End": 1817,
+                            "Line": 73,
+                            "Column": 7
+                          },
+                          "Value": "likeSentence"
+                        },
+                        "Directives": []
+                      }
+                    ]
+                  },
+                  "Location": {
+                    "Start": 1752,
+                    "End": 1848,
+                    "Line": 69,
+                    "Column": 5
+                  },
+                  "Name": {
+                    "Kind": "Name",
+                    "Location": {
+                      "Start": 1752,
+                      "End": 1759,
+                      "Line": 69,
+                      "Column": 5
+                    },
+                    "Value": "story"
+                  },
+                  "Directives": []
+                }
+              ]
+            },
+            "Location": {
+              "Start": 1712,
+              "End": 1850,
+              "Line": 68,
+              "Column": 3
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 1712,
+                "End": 1731,
+                "Line": 68,
+                "Column": 3
+              },
+              "Value": "storyLikeSubscribe"
+            },
+            "Directives": []
+          }
+        ]
+      }
+    },
+    {
+      "Kind": "FragmentDefinition",
+      "VariableDefinitions": [],
+      "TypeCondition": {
+        "Kind": "NamedType",
+        "Location": {
+          "Start": 1868,
+          "End": 1876,
+          "Line": 79,
+          "Column": 18
+        },
+        "Name": {
+          "Kind": "Name",
+          "Location": {
+            "Start": 1868,
+            "End": 1876,
+            "Line": 79,
+            "Column": 18
+          },
+          "Value": "Friend"
+        }
+      },
+      "SelectionSet": {
+        "Kind": "SelectionSet",
+        "Location": {
+          "Start": 1897,
+          "End": 2033,
+          "Line": 79,
+          "Column": 47
+        },
+        "Selections": [
+          {
+            "Kind": "Field",
+            "Alias": null,
+            "Arguments": [
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 1910,
+                  "End": 1929,
+                  "Line": 81,
+                  "Column": 5
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 1910,
+                    "End": 1915,
+                    "Line": 81,
+                    "Column": 5
+                  },
+                  "Value": "size"
+                },
+                "Value": {
+                  "Kind": "Variable",
+                  "Location": {
+                    "Start": 1916,
+                    "End": 1929,
+                    "Line": 81,
+                    "Column": 11
+                  },
+                  "Name": {
+                    "Kind": "Name",
+                    "Location": {
+                      "Start": 1917,
+                      "End": 1929,
+                      "Line": 81,
+                      "Column": 12
+                    },
+                    "Value": "size"
+                  },
+                  "Value": "size"
+                }
+              },
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 1926,
+                  "End": 1941,
+                  "Line": 82,
+                  "Column": 5
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 1926,
+                    "End": 1930,
+                    "Line": 82,
+                    "Column": 5
+                  },
+                  "Value": "bar"
+                },
+                "Value": {
+                  "Kind": "Variable",
+                  "Location": {
+                    "Start": 1931,
+                    "End": 1941,
+                    "Line": 82,
+                    "Column": 10
+                  },
+                  "Name": {
+                    "Kind": "Name",
+                    "Location": {
+                      "Start": 1932,
+                      "End": 1941,
+                      "Line": 82,
+                      "Column": 11
+                    },
+                    "Value": "b"
+                  },
+                  "Value": "b"
+                }
+              },
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 1938,
+                  "End": 2029,
+                  "Line": 83,
+                  "Column": 5
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 1938,
+                    "End": 1942,
+                    "Line": 83,
+                    "Column": 5
+                  },
+                  "Value": "obj"
+                },
+                "Value": {
+                  "Kind": "ObjectValue",
+                  "Location": {
+                    "Start": 1943,
+                    "End": 2029,
+                    "Line": 83,
+                    "Column": 10
+                  },
+                  "Fields": [
+                    {
+                      "Kind": "ObjectField",
+                      "Location": {
+                        "Start": 1951,
+                        "End": 1975,
+                        "Line": 84,
+                        "Column": 7
+                      },
+                      "Name": {
+                        "Kind": "Name",
+                        "Location": {
+                          "Start": 1951,
+                          "End": 1955,
+                          "Line": 84,
+                          "Column": 7
+                        },
+                        "Value": "key"
+                      },
+                      "Value": {
+                        "Kind": "StringValue",
+                        "Location": {
+                          "Start": 1956,
+                          "End": 1975,
+                          "Line": 84,
+                          "Column": 12
+                        },
+                        "Value": "value",
+                        "Block": false
+                      }
+                    },
+                    {
+                      "Kind": "ObjectField",
+                      "Location": {
+                        "Start": 1970,
+                        "End": 2025,
+                        "Line": 85,
+                        "Column": 7
+                      },
+                      "Name": {
+                        "Kind": "Name",
+                        "Location": {
+                          "Start": 1970,
+                          "End": 1976,
+                          "Line": 85,
+                          "Column": 7
+                        },
+                        "Value": "block"
+                      },
+                      "Value": {
+                        "Kind": "StringValue",
+                        "Location": {
+                          "Start": 1977,
+                          "End": 2025,
+                          "Line": 85,
+                          "Column": 14
+                        },
+                        "Value": "block string uses \"\"\"",
+                        "Block": true
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "Required": null,
+            "SelectionSet": null,
+            "Location": {
+              "Start": 1901,
+              "End": 2031,
+              "Line": 80,
+              "Column": 3
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 1901,
+                "End": 1905,
+                "Line": 80,
+                "Column": 3
+              },
+              "Value": "foo"
+            },
+            "Directives": []
+          }
+        ]
+      },
+      "Location": {
+        "Start": 1851,
+        "End": 2033,
+        "Line": 79,
+        "Column": 1
+      },
+      "Name": {
+        "Kind": "Name",
+        "Location": {
+          "Start": 1860,
+          "End": 1867,
+          "Line": 79,
+          "Column": 10
+        },
+        "Value": "frag"
+      },
+      "Directives": [
+        {
+          "Kind": "Directive",
+          "Location": {
+            "Start": 1875,
+            "End": 1898,
+            "Line": 79,
+            "Column": 25
+          },
+          "Name": {
+            "Kind": "Name",
+            "Location": {
+              "Start": 1876,
+              "End": 1898,
+              "Line": 79,
+              "Column": 26
+            },
+            "Value": "onFragmentDefinition"
+          },
+          "Arguments": []
+        }
+      ]
+    },
+    {
+      "Kind": "OperationDefinition",
+      "Location": {
+        "Start": 2032,
+        "End": 2102,
+        "Line": 91,
+        "Column": 1
+      },
+      "Name": null,
+      "Operation": "Query",
+      "VariableDefinitions": [],
+      "Directives": [],
+      "SelectionSet": {
+        "Kind": "SelectionSet",
+        "Location": {
+          "Start": 2032,
+          "End": 2102,
+          "Line": 91,
+          "Column": 1
+        },
+        "Selections": [
+          {
+            "Kind": "Field",
+            "Alias": null,
+            "Arguments": [
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 2044,
+                  "End": 2063,
+                  "Line": 92,
+                  "Column": 11
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 2044,
+                    "End": 2051,
+                    "Line": 92,
+                    "Column": 11
+                  },
+                  "Value": "truthy"
+                },
+                "Value": {
+                  "Kind": "BooleanValue",
+                  "Location": {
+                    "Start": 2052,
+                    "End": 2063,
+                    "Line": 92,
+                    "Column": 19
+                  },
+                  "Value": true
+                }
+              },
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 2058,
+                  "End": 2079,
+                  "Line": 92,
+                  "Column": 25
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 2058,
+                    "End": 2064,
+                    "Line": 92,
+                    "Column": 25
+                  },
+                  "Value": "falsy"
+                },
+                "Value": {
+                  "Kind": "BooleanValue",
+                  "Location": {
+                    "Start": 2065,
+                    "End": 2079,
+                    "Line": 92,
+                    "Column": 32
+                  },
+                  "Value": false
+                }
+              },
+              {
+                "Kind": "Argument",
+                "Location": {
+                  "Start": 2072,
+                  "End": 2086,
+                  "Line": 92,
+                  "Column": 39
+                },
+                "Name": {
+                  "Kind": "Name",
+                  "Location": {
+                    "Start": 2072,
+                    "End": 2080,
+                    "Line": 92,
+                    "Column": 39
+                  },
+                  "Value": "nullish"
+                },
+                "Value": {
+                  "Kind": "NullValue",
+                  "Location": {
+                    "Start": 2081,
+                    "End": 2086,
+                    "Line": 92,
+                    "Column": 48
+                  },
+                  "Value": null
+                }
+              }
+            ],
+            "Required": null,
+            "SelectionSet": null,
+            "Location": {
+              "Start": 2036,
+              "End": 2094,
+              "Line": 92,
+              "Column": 3
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 2036,
+                "End": 2044,
+                "Line": 92,
+                "Column": 3
+              },
+              "Value": "unnamed"
+            },
+            "Directives": []
+          },
+          {
+            "Kind": "Field",
+            "Alias": null,
+            "Arguments": [],
+            "Required": null,
+            "SelectionSet": null,
+            "Location": {
+              "Start": 2089,
+              "End": 2096,
+              "Line": 93,
+              "Column": 3
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 2089,
+                "End": 2096,
+                "Line": 93,
+                "Column": 3
+              },
+              "Value": "query"
+            },
+            "Directives": []
+          }
+        ]
+      }
+    },
+    {
+      "Kind": "OperationDefinition",
+      "Location": {
+        "Start": 2097,
+        "End": 2119,
+        "Line": 95,
+        "Column": 1
+      },
+      "Name": null,
+      "Operation": "Query",
+      "VariableDefinitions": [],
+      "Directives": [],
+      "SelectionSet": {
+        "Kind": "SelectionSet",
+        "Location": {
+          "Start": 2103,
+          "End": 2119,
+          "Line": 95,
+          "Column": 7
+        },
+        "Selections": [
+          {
+            "Kind": "Field",
+            "Alias": null,
+            "Arguments": [],
+            "Required": null,
+            "SelectionSet": null,
+            "Location": {
+              "Start": 2107,
+              "End": 2119,
+              "Line": 96,
+              "Column": 3
+            },
+            "Name": {
+              "Kind": "Name",
+              "Location": {
+                "Start": 2107,
+                "End": 2119,
+                "Line": 96,
+                "Column": 3
+              },
+              "Value": "__typename"
+            },
+            "Directives": []
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQueryNullability.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQueryNullability.snap
@@ -700,7 +700,7 @@
                         "Alias": null,
                         "Arguments": [],
                         "Required": {
-                          "Kind": "RequiredDesignator",
+                          "Kind": "OptionalDesignator",
                           "Location": {
                             "Start": 372,
                             "End": 395,
@@ -742,7 +742,7 @@
                         },
                         "Arguments": [],
                         "Required": {
-                          "Kind": "RequiredDesignator",
+                          "Kind": "OptionalDesignator",
                           "Location": {
                             "Start": 403,
                             "End": 438,
@@ -946,7 +946,7 @@
                         },
                         "Arguments": [],
                         "Required": {
-                          "Kind": "RequiredDesignator",
+                          "Kind": "OptionalDesignator",
                           "Location": {
                             "Start": 599,
                             "End": 634,
@@ -1005,7 +1005,7 @@
                             "Column": 45
                           },
                           "Element": {
-                            "Kind": "RequiredDesignator",
+                            "Kind": "OptionalDesignator",
                             "Location": {
                               "Start": 646,
                               "End": 648,
@@ -1048,7 +1048,7 @@
                         },
                         "Arguments": [],
                         "Required": {
-                          "Kind": "RequiredDesignator",
+                          "Kind": "OptionalDesignator",
                           "Location": {
                             "Start": 699,
                             "End": 728,
@@ -1064,7 +1064,7 @@
                               "Column": 48
                             },
                             "Element": {
-                              "Kind": "RequiredDesignator",
+                              "Kind": "OptionalDesignator",
                               "Location": {
                                 "Start": 697,
                                 "End": 699,
@@ -1338,7 +1338,7 @@
                         "Alias": null,
                         "Arguments": [],
                         "Required": {
-                          "Kind": "RequiredDesignator",
+                          "Kind": "OptionalDesignator",
                           "Location": {
                             "Start": 863,
                             "End": 866,
@@ -1414,7 +1414,7 @@
                         },
                         "Arguments": [],
                         "Required": {
-                          "Kind": "RequiredDesignator",
+                          "Kind": "OptionalDesignator",
                           "Location": {
                             "Start": 922,
                             "End": 925,
@@ -1813,7 +1813,7 @@
                         },
                         "Arguments": [],
                         "Required": {
-                          "Kind": "RequiredDesignator",
+                          "Kind": "OptionalDesignator",
                           "Location": {
                             "Start": 1255,
                             "End": 1290,
@@ -1872,7 +1872,7 @@
                             "Column": 45
                           },
                           "Element": {
-                            "Kind": "RequiredDesignator",
+                            "Kind": "OptionalDesignator",
                             "Location": {
                               "Start": 1302,
                               "End": 1304,
@@ -1915,7 +1915,7 @@
                         },
                         "Arguments": [],
                         "Required": {
-                          "Kind": "RequiredDesignator",
+                          "Kind": "OptionalDesignator",
                           "Location": {
                             "Start": 1355,
                             "End": 1384,
@@ -1931,7 +1931,7 @@
                               "Column": 48
                             },
                             "Element": {
-                              "Kind": "RequiredDesignator",
+                              "Kind": "OptionalDesignator",
                               "Location": {
                                 "Start": 1353,
                                 "End": 1355,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQueryNullability_sdl.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQueryNullability_sdl.snap
@@ -1,0 +1,92 @@
+﻿query queryName($foo: ComplexType, $site: Site = MOBILE) @onQuery {
+  whoever123is: node(id: [ 123, 456 ]) {
+    id
+    ... on User @onInlineFragment {
+      field2 {
+        id
+        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+          id
+          ... frag@onFragmentSpread
+        }
+      }
+      field3!
+      requiredField4: field4!
+      field5!
+      optionalField6: field6!
+      unsetListItemsRequiredList: listField[]!
+      requiredListItemsUnsetList: listField[!]
+      requiredListItemsRequiredList: listField[!]!
+      unsetListItemsOptionalList: listField[]!
+      optionalListItemsUnsetList: listField[!]
+      optionalListItemsOptionalList: listField[!]!
+      multidimensionalList: listField[[[!]!]!]!
+      field7! {
+        field8
+      }
+      requiredField4: field7! {
+        field8
+      }
+      field9! {
+        field10
+      }
+      optionalField9: field9! {
+        field10
+      }
+      field11[]! {
+        field12
+      }
+      requiredField11: field11[]! {
+        field12
+      }
+      unsetListItemsRequiredList: listField[]!
+      requiredListItemsUnsetList: listField[!]
+      requiredListItemsRequiredList: listField[!]!
+      unsetListItemsOptionalList: listField[]!
+      optionalListItemsUnsetList: listField[!]
+      optionalListItemsOptionalList: listField[!]!
+      multidimensionalList: listField[[[!]!]!]!
+    }
+    ... @skip(unless: $foo) {
+      id
+    }
+    ... {
+      id
+    }
+  }
+}
+
+mutation likeStory @onMutation {
+  like(story: 123) @onField {
+    story {
+      id @onField
+    }
+  }
+}
+
+subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) @onSubscription {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+fragment frag on Friend@onFragmentDefinition {
+  foo(size: $size, bar: $b, obj: { key: "value", block: """
+  block string uses \"""
+  """ })
+}
+
+{
+  unnamed(truthy: true, falsy: false, nullish: null)
+  query
+}
+
+{
+  __typename
+}

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQueryNullability_sdl.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8KitchenSinkParserTests.ParseFacebookKitchenSinkQueryNullability_sdl.snap
@@ -11,14 +11,14 @@
       }
       field3!
       requiredField4: field4!
-      field5!
-      optionalField6: field6!
+      field5?
+      optionalField6: field6?
       unsetListItemsRequiredList: listField[]!
       requiredListItemsUnsetList: listField[!]
       requiredListItemsRequiredList: listField[!]!
-      unsetListItemsOptionalList: listField[]!
-      optionalListItemsUnsetList: listField[!]
-      optionalListItemsOptionalList: listField[!]!
+      unsetListItemsOptionalList: listField[]?
+      optionalListItemsUnsetList: listField[?]
+      optionalListItemsOptionalList: listField[?]?
       multidimensionalList: listField[[[!]!]!]!
       field7! {
         field8
@@ -26,10 +26,10 @@
       requiredField4: field7! {
         field8
       }
-      field9! {
+      field9? {
         field10
       }
-      optionalField9: field9! {
+      optionalField9: field9? {
         field10
       }
       field11[]! {
@@ -41,9 +41,9 @@
       unsetListItemsRequiredList: listField[]!
       requiredListItemsUnsetList: listField[!]
       requiredListItemsRequiredList: listField[!]!
-      unsetListItemsOptionalList: listField[]!
-      optionalListItemsUnsetList: listField[!]
-      optionalListItemsOptionalList: listField[!]!
+      unsetListItemsOptionalList: listField[]?
+      optionalListItemsUnsetList: listField[?]
+      optionalListItemsOptionalList: listField[?]?
       multidimensionalList: listField[[[!]!]!]!
     }
     ... @skip(unless: $foo) {

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.IntrospectionQuery.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.IntrospectionQuery.snap
@@ -41,6 +41,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -54,6 +55,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -67,6 +69,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 62,
@@ -110,6 +113,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -123,6 +127,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 98,
@@ -166,6 +171,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -179,6 +185,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 138,
@@ -222,6 +229,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -275,6 +283,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -288,6 +297,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 208,
@@ -311,6 +321,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 219,
@@ -334,6 +345,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -387,6 +399,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 280,
@@ -410,6 +423,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 298,
@@ -433,6 +447,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 315,
@@ -530,6 +545,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 368,
@@ -553,6 +569,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 375,
@@ -576,6 +593,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 382,
@@ -629,6 +647,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -642,6 +661,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 434,
@@ -665,6 +685,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 443,
@@ -688,6 +709,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -741,6 +763,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -794,6 +817,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 530,
@@ -817,6 +841,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 547,
@@ -860,6 +885,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -913,6 +939,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -996,6 +1023,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -1009,6 +1037,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 685,
@@ -1032,6 +1061,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 694,
@@ -1055,6 +1085,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 710,
@@ -1078,6 +1109,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 727,
@@ -1121,6 +1153,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -1225,6 +1258,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 829,
@@ -1248,6 +1282,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 836,
@@ -1271,6 +1306,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -1324,6 +1360,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 878,
@@ -1398,6 +1435,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 925,
@@ -1421,6 +1459,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 932,
@@ -1444,6 +1483,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -1457,6 +1497,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 952,
@@ -1480,6 +1521,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 961,
@@ -1503,6 +1545,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -1516,6 +1559,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 985,
@@ -1539,6 +1583,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 996,
@@ -1562,6 +1607,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -1575,6 +1621,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 1024,
@@ -1598,6 +1645,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 1037,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.KitchenSinkQueryQuery.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.KitchenSinkQueryQuery.snap
@@ -211,6 +211,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -224,6 +225,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 274,
@@ -305,6 +307,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -318,6 +321,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 327,
@@ -419,6 +423,7 @@
                                   }
                                 }
                               ],
+                              "Required": null,
                               "SelectionSet": {
                                 "Kind": "SelectionSet",
                                 "Location": {
@@ -432,6 +437,7 @@
                                     "Kind": "Field",
                                     "Alias": null,
                                     "Arguments": [],
+                                    "Required": null,
                                     "SelectionSet": null,
                                     "Location": {
                                       "Start": 408,
@@ -659,6 +665,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 490,
@@ -704,6 +711,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 515,
@@ -813,6 +821,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -826,6 +835,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -839,6 +849,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 598,
@@ -1047,6 +1058,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -1060,6 +1072,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -1073,6 +1086,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -1086,6 +1100,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 757,
@@ -1129,6 +1144,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": {
                           "Kind": "SelectionSet",
                           "Location": {
@@ -1142,6 +1158,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 800,
@@ -1428,6 +1445,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 854,
@@ -1580,6 +1598,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 957,
@@ -1603,6 +1622,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": null,
             "Location": {
               "Start": 1012,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.QueryWithComments.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.QueryWithComments.snap
@@ -32,6 +32,7 @@
             "Kind": "Field",
             "Alias": null,
             "Arguments": [],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -45,6 +46,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 45,
@@ -186,6 +188,7 @@
                       }
                     }
                   ],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -199,6 +202,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 191,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.QueryWithStringArg.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.QueryWithStringArg.snap
@@ -63,6 +63,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -76,6 +77,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 43,
@@ -99,6 +101,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -112,6 +115,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 71,
@@ -155,6 +159,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": {
                     "Kind": "SelectionSet",
                     "Location": {
@@ -168,6 +173,7 @@
                         "Kind": "Field",
                         "Alias": null,
                         "Arguments": [],
+                        "Required": null,
                         "SelectionSet": null,
                         "Location": {
                           "Start": 104,
@@ -228,6 +234,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 152,
@@ -291,6 +298,7 @@
                               "Kind": "Field",
                               "Alias": null,
                               "Arguments": [],
+                              "Required": null,
                               "SelectionSet": null,
                               "Location": {
                                 "Start": 209,

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.RussianLiterals.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/Utf8QueryParserTests.RussianLiterals.snap
@@ -63,6 +63,7 @@
                 }
               }
             ],
+            "Required": null,
             "SelectionSet": {
               "Kind": "SelectionSet",
               "Location": {
@@ -76,6 +77,7 @@
                   "Kind": "Field",
                   "Alias": null,
                   "Arguments": [],
+                  "Required": null,
                   "SelectionSet": null,
                   "Location": {
                     "Start": 49,

--- a/src/HotChocolate/Language/test/Language.Tests/__resources__/kitchen-sink-nullability.graphql
+++ b/src/HotChocolate/Language/test/Language.Tests/__resources__/kitchen-sink-nullability.graphql
@@ -1,0 +1,97 @@
+query queryName($foo: ComplexType, $site: Site = MOBILE) @onQuery {
+  whoever123is: node(id: [123, 456]) {
+    id
+    ... on User @onInlineFragment {
+      field2 {
+        id
+        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+          id
+           ...frag @onFragmentSpread
+         }
+       }
+       field3!
+       requiredField4: field4!
+       field5?
+       optionalField6: field6?
+       unsetListItemsRequiredList: listField[]!
+       requiredListItemsUnsetList: listField[!]
+       requiredListItemsRequiredList: listField[!]!
+       unsetListItemsOptionalList: listField[]?
+       optionalListItemsUnsetList: listField[?]
+       optionalListItemsOptionalList: listField[?]?
+       multidimensionalList: listField[[[!]!]!]!
+       field7! {
+         field8
+       }
+       requiredField4: field7! {
+         field8
+       }
+       field9? {
+         field10
+       }
+       optionalField9: field9? {
+         field10
+       }
+       field11[]! {
+         field12
+       }
+       requiredField11: field11[]! {
+         field12
+       }
+       unsetListItemsRequiredList: listField[]!
+       requiredListItemsUnsetList: listField[!]
+       requiredListItemsRequiredList: listField[!]!
+       unsetListItemsOptionalList: listField[]?
+       optionalListItemsUnsetList: listField[?]
+       optionalListItemsOptionalList: listField[?]?
+       multidimensionalList: listField[[[!]!]!]!
+     }
+     ... @skip(unless: $foo) {
+       id
+    }
+    ... {
+      id
+    }
+  }
+}
+mutation likeStory @onMutation {
+  like(story: 123) @onField {
+    story {
+      id @onField
+    }
+  }
+}
+subscription StoryLikeSubscription(
+  $input: StoryLikeSubscribeInput @onVariableDefinition
+)
+  @onSubscription {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+fragment frag on Friend @onFragmentDefinition {
+  foo(
+    size: $size
+    bar: $b
+    obj: {
+      key: "value"
+      block: """
+      block string uses \"""
+      """
+    }
+  )
+}
+{
+  unnamed(truthy: true, falsy: false, nullish: null)
+  query
+}
+query {
+  __typename
+}

--- a/src/HotChocolate/Language/test/Language.Tests/__snapshots__/SyntaxNodeVisitorTests.Visit_Kitchen_Sink_Query.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/__snapshots__/SyntaxNodeVisitorTests.Visit_Kitchen_Sink_Query.snap
@@ -212,6 +212,7 @@
                   }
                 }
               ],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -225,6 +226,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": null,
                     "Location": {
                       "Start": 274,
@@ -306,6 +308,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": {
                             "Kind": "SelectionSet",
                             "Location": {
@@ -319,6 +322,7 @@
                                 "Kind": "Field",
                                 "Alias": null,
                                 "Arguments": [],
+                                "Required": null,
                                 "SelectionSet": null,
                                 "Location": {
                                   "Start": 327,
@@ -420,6 +424,7 @@
                                     }
                                   }
                                 ],
+                                "Required": null,
                                 "SelectionSet": {
                                   "Kind": "SelectionSet",
                                   "Location": {
@@ -433,6 +438,7 @@
                                       "Kind": "Field",
                                       "Alias": null,
                                       "Arguments": [],
+                                      "Required": null,
                                       "SelectionSet": null,
                                       "Location": {
                                         "Start": 408,
@@ -660,6 +666,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": null,
                           "Location": {
                             "Start": 490,
@@ -705,6 +712,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": null,
                           "Location": {
                             "Start": 515,
@@ -814,6 +822,7 @@
                   }
                 }
               ],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -827,6 +836,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": {
                       "Kind": "SelectionSet",
                       "Location": {
@@ -840,6 +850,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": null,
                           "Location": {
                             "Start": 598,
@@ -1048,6 +1059,7 @@
                   }
                 }
               ],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -1061,6 +1073,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": {
                       "Kind": "SelectionSet",
                       "Location": {
@@ -1074,6 +1087,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": {
                             "Kind": "SelectionSet",
                             "Location": {
@@ -1087,6 +1101,7 @@
                                 "Kind": "Field",
                                 "Alias": null,
                                 "Arguments": [],
+                                "Required": null,
                                 "SelectionSet": null,
                                 "Location": {
                                   "Start": 757,
@@ -1130,6 +1145,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": {
                             "Kind": "SelectionSet",
                             "Location": {
@@ -1143,6 +1159,7 @@
                                 "Kind": "Field",
                                 "Alias": null,
                                 "Arguments": [],
+                                "Required": null,
                                 "SelectionSet": null,
                                 "Location": {
                                   "Start": 800,
@@ -1429,6 +1446,7 @@
                   }
                 }
               ],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 854,
@@ -1581,6 +1599,7 @@
                   }
                 }
               ],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 957,
@@ -1604,6 +1623,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 1012,
@@ -1832,6 +1852,7 @@
               }
             }
           ],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -1845,6 +1866,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 274,
@@ -1926,6 +1948,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": {
                         "Kind": "SelectionSet",
                         "Location": {
@@ -1939,6 +1962,7 @@
                             "Kind": "Field",
                             "Alias": null,
                             "Arguments": [],
+                            "Required": null,
                             "SelectionSet": null,
                             "Location": {
                               "Start": 327,
@@ -2040,6 +2064,7 @@
                                 }
                               }
                             ],
+                            "Required": null,
                             "SelectionSet": {
                               "Kind": "SelectionSet",
                               "Location": {
@@ -2053,6 +2078,7 @@
                                   "Kind": "Field",
                                   "Alias": null,
                                   "Arguments": [],
+                                  "Required": null,
                                   "SelectionSet": null,
                                   "Location": {
                                     "Start": 408,
@@ -2280,6 +2306,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": null,
                       "Location": {
                         "Start": 490,
@@ -2325,6 +2352,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": null,
                       "Location": {
                         "Start": 515,
@@ -2443,6 +2471,7 @@
             }
           }
         ],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -2456,6 +2485,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 274,
@@ -2537,6 +2567,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": {
                       "Kind": "SelectionSet",
                       "Location": {
@@ -2550,6 +2581,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": null,
                           "Location": {
                             "Start": 327,
@@ -2651,6 +2683,7 @@
                               }
                             }
                           ],
+                          "Required": null,
                           "SelectionSet": {
                             "Kind": "SelectionSet",
                             "Location": {
@@ -2664,6 +2697,7 @@
                                 "Kind": "Field",
                                 "Alias": null,
                                 "Arguments": [],
+                                "Required": null,
                                 "SelectionSet": null,
                                 "Location": {
                                   "Start": 408,
@@ -2891,6 +2925,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": null,
                     "Location": {
                       "Start": 490,
@@ -2936,6 +2971,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": null,
                     "Location": {
                       "Start": 515,
@@ -3044,6 +3080,7 @@
         }
       }
     ],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -3057,6 +3094,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 274,
@@ -3138,6 +3176,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": {
                   "Kind": "SelectionSet",
                   "Location": {
@@ -3151,6 +3190,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": null,
                       "Location": {
                         "Start": 327,
@@ -3252,6 +3292,7 @@
                           }
                         }
                       ],
+                      "Required": null,
                       "SelectionSet": {
                         "Kind": "SelectionSet",
                         "Location": {
@@ -3265,6 +3306,7 @@
                             "Kind": "Field",
                             "Alias": null,
                             "Arguments": [],
+                            "Required": null,
                             "SelectionSet": null,
                             "Location": {
                               "Start": 408,
@@ -3492,6 +3534,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 490,
@@ -3537,6 +3580,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 515,
@@ -3592,6 +3636,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 274,
@@ -3673,6 +3718,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -3686,6 +3732,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": null,
                     "Location": {
                       "Start": 327,
@@ -3787,6 +3834,7 @@
                         }
                       }
                     ],
+                    "Required": null,
                     "SelectionSet": {
                       "Kind": "SelectionSet",
                       "Location": {
@@ -3800,6 +3848,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": null,
                           "Location": {
                             "Start": 408,
@@ -4027,6 +4076,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 490,
@@ -4072,6 +4122,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 515,
@@ -4100,6 +4151,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 274,
@@ -4191,6 +4243,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -4204,6 +4257,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 327,
@@ -4305,6 +4359,7 @@
                     }
                   }
                 ],
+                "Required": null,
                 "SelectionSet": {
                   "Kind": "SelectionSet",
                   "Location": {
@@ -4318,6 +4373,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": null,
                       "Location": {
                         "Start": 408,
@@ -4474,6 +4530,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -4487,6 +4544,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 327,
@@ -4588,6 +4646,7 @@
                   }
                 }
               ],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -4601,6 +4660,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": null,
                     "Location": {
                       "Start": 408,
@@ -4747,6 +4807,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -4760,6 +4821,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 327,
@@ -4861,6 +4923,7 @@
               }
             }
           ],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -4874,6 +4937,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 408,
@@ -5027,6 +5091,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 327,
@@ -5128,6 +5193,7 @@
             }
           }
         ],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -5141,6 +5207,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 408,
@@ -5267,6 +5334,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 327,
@@ -5378,6 +5446,7 @@
         }
       }
     ],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -5391,6 +5460,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 408,
@@ -5524,6 +5594,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 408,
@@ -5569,6 +5640,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 408,
@@ -6078,6 +6150,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 490,
@@ -6113,6 +6186,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 490,
@@ -6138,6 +6212,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 490,
@@ -6339,6 +6414,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 515,
@@ -6374,6 +6450,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 515,
@@ -6399,6 +6476,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 515,
@@ -6870,6 +6948,7 @@
               }
             }
           ],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -6883,6 +6962,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": {
                   "Kind": "SelectionSet",
                   "Location": {
@@ -6896,6 +6976,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": null,
                       "Location": {
                         "Start": 598,
@@ -7022,6 +7103,7 @@
             }
           }
         ],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -7035,6 +7117,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -7048,6 +7131,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": null,
                     "Location": {
                       "Start": 598,
@@ -7164,6 +7248,7 @@
         }
       }
     ],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -7177,6 +7262,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -7190,6 +7276,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 598,
@@ -7283,6 +7370,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -7296,6 +7384,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 598,
@@ -7341,6 +7430,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -7354,6 +7444,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 598,
@@ -7406,6 +7497,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 598,
@@ -7431,6 +7523,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 598,
@@ -7694,6 +7787,7 @@
               }
             }
           ],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -7707,6 +7801,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": {
                   "Kind": "SelectionSet",
                   "Location": {
@@ -7720,6 +7815,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": {
                         "Kind": "SelectionSet",
                         "Location": {
@@ -7733,6 +7829,7 @@
                             "Kind": "Field",
                             "Alias": null,
                             "Arguments": [],
+                            "Required": null,
                             "SelectionSet": null,
                             "Location": {
                               "Start": 757,
@@ -7776,6 +7873,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": {
                         "Kind": "SelectionSet",
                         "Location": {
@@ -7789,6 +7887,7 @@
                             "Kind": "Field",
                             "Alias": null,
                             "Arguments": [],
+                            "Required": null,
                             "SelectionSet": null,
                             "Location": {
                               "Start": 800,
@@ -7924,6 +8023,7 @@
             }
           }
         ],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -7937,6 +8037,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -7950,6 +8051,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": {
                       "Kind": "SelectionSet",
                       "Location": {
@@ -7963,6 +8065,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": null,
                           "Location": {
                             "Start": 757,
@@ -8006,6 +8109,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": {
                       "Kind": "SelectionSet",
                       "Location": {
@@ -8019,6 +8123,7 @@
                           "Kind": "Field",
                           "Alias": null,
                           "Arguments": [],
+                          "Required": null,
                           "SelectionSet": null,
                           "Location": {
                             "Start": 800,
@@ -8144,6 +8249,7 @@
         }
       }
     ],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -8157,6 +8263,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -8170,6 +8277,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": {
                   "Kind": "SelectionSet",
                   "Location": {
@@ -8183,6 +8291,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": null,
                       "Location": {
                         "Start": 757,
@@ -8226,6 +8335,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": {
                   "Kind": "SelectionSet",
                   "Location": {
@@ -8239,6 +8349,7 @@
                       "Kind": "Field",
                       "Alias": null,
                       "Arguments": [],
+                      "Required": null,
                       "SelectionSet": null,
                       "Location": {
                         "Start": 800,
@@ -8331,6 +8442,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -8344,6 +8456,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -8357,6 +8470,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": null,
                     "Location": {
                       "Start": 757,
@@ -8400,6 +8514,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": {
                 "Kind": "SelectionSet",
                 "Location": {
@@ -8413,6 +8528,7 @@
                     "Kind": "Field",
                     "Alias": null,
                     "Arguments": [],
+                    "Required": null,
                     "SelectionSet": null,
                     "Location": {
                       "Start": 800,
@@ -8478,6 +8594,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -8491,6 +8608,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -8504,6 +8622,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 757,
@@ -8547,6 +8666,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": {
             "Kind": "SelectionSet",
             "Location": {
@@ -8560,6 +8680,7 @@
                 "Kind": "Field",
                 "Alias": null,
                 "Arguments": [],
+                "Required": null,
                 "SelectionSet": null,
                 "Location": {
                   "Start": 800,
@@ -8632,6 +8753,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -8645,6 +8767,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 757,
@@ -8688,6 +8811,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": {
           "Kind": "SelectionSet",
           "Location": {
@@ -8701,6 +8825,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 800,
@@ -8746,6 +8871,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -8759,6 +8885,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 757,
@@ -8811,6 +8938,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 757,
@@ -8836,6 +8964,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 757,
@@ -8879,6 +9008,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": {
       "Kind": "SelectionSet",
       "Location": {
@@ -8892,6 +9022,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 800,
@@ -8944,6 +9075,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 800,
@@ -8969,6 +9101,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 800,
@@ -9430,6 +9563,7 @@
               }
             }
           ],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 854,
@@ -9651,6 +9785,7 @@
             }
           }
         ],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 854,
@@ -9845,6 +9980,7 @@
         }
       }
     ],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 854,
@@ -10457,6 +10593,7 @@
               }
             }
           ],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 957,
@@ -10480,6 +10617,7 @@
           "Kind": "Field",
           "Alias": null,
           "Arguments": [],
+          "Required": null,
           "SelectionSet": null,
           "Location": {
             "Start": 1012,
@@ -10603,6 +10741,7 @@
             }
           }
         ],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 957,
@@ -10626,6 +10765,7 @@
         "Kind": "Field",
         "Alias": null,
         "Arguments": [],
+        "Required": null,
         "SelectionSet": null,
         "Location": {
           "Start": 1012,
@@ -10739,6 +10879,7 @@
         }
       }
     ],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 957,
@@ -10909,6 +11050,7 @@
     "Kind": "Field",
     "Alias": null,
     "Arguments": [],
+    "Required": null,
     "SelectionSet": null,
     "Location": {
       "Start": 1012,

--- a/src/HotChocolate/Neo4J/src/Data/Projections/Handlers/Neo4JProjectionFieldHandler.cs
+++ b/src/HotChocolate/Neo4J/src/Data/Projections/Handlers/Neo4JProjectionFieldHandler.cs
@@ -26,7 +26,7 @@ namespace HotChocolate.Data.Neo4J.Projections
 
             selection.Field.ContextData.TryGetValue(
                 nameof(Neo4JRelationshipAttribute),
-                out object? relationship);
+                out var relationship);
 
             if (relationship is Neo4JRelationshipAttribute rel)
             {

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonLineStringTypeTests.LineString_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonLineStringTypeTests.LineString_Execution_With_Fragments.snap
@@ -63,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 29,
@@ -86,6 +87,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 34,
@@ -109,6 +111,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 46,
@@ -132,6 +135,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 51,

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiLineStringTypeTests.MultiLineString_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiLineStringTypeTests.MultiLineString_Execution_With_Fragments.snap
@@ -63,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 34,
@@ -86,6 +87,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 39,
@@ -109,6 +111,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 51,
@@ -132,6 +135,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 56,

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiPointTypeTests.MultiPoint_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiPointTypeTests.MultiPoint_Execution_With_Fragments.snap
@@ -63,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 29,
@@ -86,6 +87,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 34,
@@ -109,6 +111,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 46,
@@ -132,6 +135,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 51,

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiPolygonTypeTests.MultiPolygon_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiPolygonTypeTests.MultiPolygon_Execution_With_Fragments.snap
@@ -63,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 31,
@@ -86,6 +87,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 36,
@@ -109,6 +111,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 48,
@@ -132,6 +135,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 53,

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPointTypeTests.Point_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPointTypeTests.Point_Execution_With_Fragments.snap
@@ -63,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 24,
@@ -86,6 +87,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 29,
@@ -109,6 +111,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 41,
@@ -132,6 +135,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 46,

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPolygonTypeTests.Polygon_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPolygonTypeTests.Polygon_Execution_With_Fragments.snap
@@ -63,6 +63,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 26,
@@ -86,6 +87,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 31,
@@ -109,6 +111,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 43,
@@ -132,6 +135,7 @@
               "Kind": "Field",
               "Alias": null,
               "Arguments": [],
+              "Required": null,
               "SelectionSet": null,
               "Location": {
                 "Start": 48,

--- a/src/HotChocolate/Stitching/src/Stitching/Delegation/DictionaryResultMiddleware.cs
+++ b/src/HotChocolate/Stitching/src/Stitching/Delegation/DictionaryResultMiddleware.cs
@@ -31,7 +31,7 @@ namespace HotChocolate.Stitching.Delegation
                 !context.Selection.Field.Directives.Contains(DirectiveNames.Computed) &&
                 context.Parent<object>() is IReadOnlyDictionary<string, object> dict)
             {
-                string responseName = context.Selection.SyntaxNode.Alias == null
+                var responseName = context.Selection.SyntaxNode.Alias == null
                     ? context.Selection.SyntaxNode.Name.Value
                     : context.Selection.SyntaxNode.Alias.Value;
 

--- a/src/HotChocolate/Stitching/src/Stitching/Delegation/ExtractFieldQuerySyntaxRewriter.cs
+++ b/src/HotChocolate/Stitching/src/Stitching/Delegation/ExtractFieldQuerySyntaxRewriter.cs
@@ -66,8 +66,8 @@ namespace HotChocolate.Stitching.Delegation
             {
                 FieldNode field = RewriteField(syntaxNode, context);
 
-                if (selection.Field.Type.NamedType().IsLeafType() || 
-                    (field.SelectionSet is not null && 
+                if (selection.Field.Type.NamedType().IsLeafType() ||
+                    (field.SelectionSet is not null &&
                     field.SelectionSet.Selections.Count > 0))
                 {
                     syntaxNodes.Add(field);
@@ -374,6 +374,7 @@ namespace HotChocolate.Stitching.Delegation
                 null,
                 new NameNode(fieldName),
                 null,
+                null,
                 Array.Empty<DirectiveNode>(),
                 Array.Empty<ArgumentNode>(),
                 null
@@ -454,7 +455,7 @@ namespace HotChocolate.Stitching.Delegation
                 currentContext.TypeContext = type;
 
                 if (type.TryGetSourceDirective(
-                    context.Schema, 
+                    context.Schema,
                     out SourceDirective? sourceDirective))
                 {
                     current = current.WithTypeCondition(

--- a/src/HotChocolate/Stitching/src/Stitching/Delegation/RemoteQueryBuilder.cs
+++ b/src/HotChocolate/Stitching/src/Stitching/Delegation/RemoteQueryBuilder.cs
@@ -141,22 +141,22 @@ namespace HotChocolate.Stitching.Delegation
             if (_additionalFields.Count == 0)
             {
                 return CreateDelegationQuery(
-                    targetSchema, 
-                    nameLookup, 
-                    _operation, 
-                    _path, 
+                    targetSchema,
+                    nameLookup,
+                    _operation,
+                    _path,
                     new[] { requestField });
             }
-            
+
             var fields = new List<FieldNode>();
             fields.Add(_requestField);
             fields.AddRange(_additionalFields);
 
             return CreateDelegationQuery(
-                targetSchema, 
-                nameLookup, 
-                _operation, 
-                _path, 
+                targetSchema,
+                nameLookup,
+                _operation,
+                _path,
                 fields);
         }
 
@@ -169,7 +169,7 @@ namespace HotChocolate.Stitching.Delegation
         {
             var usedVariables = new HashSet<string>();
             var fields = new List<FieldNode>();
-            
+
             foreach (FieldNode requestedField in requestedFields)
             {
                 IImmutableStack<SelectionPathComponent> currentPath = path;
@@ -261,6 +261,7 @@ namespace HotChocolate.Stitching.Delegation
                 null,
                 component.Name,
                 alias,
+                null,
                 requestedField.Directives,
                 arguments,
                 requestedField.SelectionSet
@@ -291,6 +292,7 @@ namespace HotChocolate.Stitching.Delegation
                 null,
                 next.Name,
                 aliasNode,
+                null,
                 Array.Empty<DirectiveNode>(),
                 RewriteVariableNames(next.Arguments).ToList(),
                 selectionSet

--- a/src/HotChocolate/Stitching/test/Stitching.Tests/Delegation/ArgumentScopedVariableResolverTests.cs
+++ b/src/HotChocolate/Stitching/test/Stitching.Tests/Delegation/ArgumentScopedVariableResolverTests.cs
@@ -73,6 +73,7 @@ namespace HotChocolate.Stitching.Delegation
                     null,
                     new NameNode("foo"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null));

--- a/src/HotChocolate/Stitching/test/Stitching.Tests/Delegation/FieldScopedVariableResolverTests.cs
+++ b/src/HotChocolate/Stitching/test/Stitching.Tests/Delegation/FieldScopedVariableResolverTests.cs
@@ -73,6 +73,7 @@ namespace HotChocolate.Stitching.Delegation
                     null,
                     new NameNode("foo"),
                     null,
+                    null,
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null));

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryHelper.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryHelper.cs
@@ -117,7 +117,10 @@ namespace HotChocolate.Utilities.Introspection
         }
 
         private static FieldNode CreateField(string name) =>
-            new(null, new NameNode(name), null,
+            new(null,
+                new NameNode(name),
+                null,
+                null,
                 Array.Empty<DirectiveNode>(),
                 Array.Empty<ArgumentNode>(),
                 null);

--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/EnumTypeUsageAnalyzer.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/EnumTypeUsageAnalyzer.cs
@@ -42,7 +42,9 @@ namespace StrawberryShake.CodeGeneration.Analyzers
             VariableDefinitionNode node,
             object? context)
         {
-            if (_schema.TryGetType(node.Type.NamedType().Name.Value, out INamedType type) &&
+            if (_schema.TryGetType<INamedType>(
+                node.Type.NamedType().Name.Value,
+                out INamedType? type) &&
                 type is IInputType inputType)
             {
                 VisitInputType(inputType);

--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/InputObjectTypeUsageAnalyzer.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/InputObjectTypeUsageAnalyzer.cs
@@ -38,7 +38,9 @@ namespace StrawberryShake.CodeGeneration.Analyzers
             VariableDefinitionNode node,
             object? context)
         {
-            if (_schema.TryGetType(node.Type.NamedType().Name.Value, out INamedType type)
+            if (_schema.TryGetType<INamedType>(
+                node.Type.NamedType().Name.Value,
+                out INamedType? type)
                 && type is IInputType inputType)
             {
                 VisitInputType(inputType);

--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Utilities/TypeNameQueryRewriter.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Utilities/TypeNameQueryRewriter.cs
@@ -13,6 +13,7 @@ namespace StrawberryShake.CodeGeneration.Utilities
             null,
             new NameNode(WellKnownNames.TypeName),
             null,
+            null,
             Array.Empty<DirectiveNode>(),
             Array.Empty<ArgumentNode>(),
             null);


### PR DESCRIPTION
This PR implements the Client Controlled Nullability RFC.

https://github.com/graphql/graphql-spec/pull/895/files

- [x] AST
- [ ] AST Tests
- [ ] AST Docs
- [x] Lexer
- [ ] Lexer Tests
- [ ] Lexer Docs
- [x] Parser
- [x] Parser Tests
- [ ] Parser Docs
- [x] SyntaxPrinter
- [ ] Visitor
- [x] Rewriter
- [x] Operation Compiler
- [x] Do we have changes in the execution or does a change in the operation compiler suffice?
- [ ] Benchmarks
  - [ ] Parser
  - [ ] OperationCompiler
  - [ ] QueryPlan
  - [ ] Execution
- [x] Validation Rules
- [ ] Naming is not quite right yet