### PR TITLE
Add scoped service for type extensions to docs

### DIFF
--- a/website/src/docs/hotchocolate/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/extending-types.md
@@ -48,6 +48,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddScoped<BookExtensions>();
         services
             .AddGraphQLServer()
             .AddTypeExtension<BookExtensions>();
@@ -71,6 +72,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddScoped<QueryBookResolvers>();
         services
             .AddGraphQLServer()
             .AddTypeExtension<QueryBookResolvers>();
@@ -102,6 +104,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddScoped<BookTypeExtensions>();
         services
             .AddGraphQLServer()
             .AddTypeExtension<BookTypeExtensions>();
@@ -130,6 +133,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddScoped<QueryTypeBookResolvers>();
         services
             .AddGraphQLServer()
             .AddTypeExtension<QueryTypeBookResolvers>();
@@ -163,6 +167,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddScoped<BookExtensions>();
         services
             .AddGraphQLServer()
             .AddTypeExtension<BookExtensions>();
@@ -186,6 +191,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddScoped<BookTypeExtensions>();
         services
             .AddGraphQLServer()
             .AddTypeExtension<BookTypeExtensions>();
@@ -225,6 +231,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddScoped<BookExtensions>();
         services
             .AddGraphQLServer()
             .AddTypeExtension<BookExtensions>();
@@ -259,6 +266,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddScoped<BookTypeExtensions>();
         services
             .AddGraphQLServer()
             .AddTypeExtension<BookTypeExtensions>();


### PR DESCRIPTION
When using EF core, I noticed that if I extended the Query with a class:

```c#
[ExtendObjectType("Query")]
public class CollectionsResolver {
    private readonly CollectionService collectionService;

    public CollectionsResolver([Service] CollectionService collectionService) =>
        this.collectionService = collectionService;

    public async Task<List<Collection>> GetCollections() =>
        await this.collectionService.GetCollections().ToListAsync();
}
```

every request after the 1st one would fail because the DbContext would get disposed. The solution was to register the CollectionsResolver as a scoped service: `services.AddScoped<CollectionsResolver>();`. I couldn't find this documented anywhere so I thought I should add it to the docs so others don't run into the same problem.