### PR TITLE
Make node resolver return a nullable type to match the Node query.

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Relay/NodeResolverDelegate.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/NodeResolverDelegate.cs
@@ -5,10 +5,10 @@ using HotChocolate.Resolvers;
 
 namespace HotChocolate.Types.Relay;
 
-public delegate Task<TNode> NodeResolverDelegate<TNode>(
+public delegate Task<TNode?> NodeResolverDelegate<TNode>(
     IResolverContext context,
     object id);
 
-public delegate Task<TNode> NodeResolverDelegate<TNode, in TId>(
+public delegate Task<TNode?> NodeResolverDelegate<TNode, in TId>(
     IResolverContext context,
     TId id);


### PR DESCRIPTION
Changed NodeResolverDelegate to return a nullable TNode.
