### PR TITLE
Update entity-framework.md

### DIFF
--- a/website/src/docs/hotchocolate/integrations/entity-framework.md
+++ b/website/src/docs/hotchocolate/integrations/entity-framework.md
@@ -84,7 +84,7 @@ We can make this even simpler, by creating an attribute inheriting from the `Use
 public class UseSomeDbContext : UseDbContextAttribute
 {
     public UseSomeDbContext([CallerLineNumber] int order = 0)
-        : base(typeof(SomeDbContext))
+        : base(typeof(SomeDbContext), order)
     {
         Order = order;
     }


### PR DESCRIPTION
As best I can tell the example did not implement what was indicated:

>  If you are using a custom attribute, you have to forward the line number using the `CallerLineNumberAttribute`.

So this passes the line number along.