### PR TITLE
implemented concurrent processing for queries in an apollo style batch

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore/MiddlewareBase.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/MiddlewareBase.cs
@@ -172,7 +172,9 @@ public class MiddlewareBase : IDisposable
         }
 
         return await requestExecutor.ExecuteBatchAsync(
-            requestBatch, cancellationToken: context.RequestAborted);
+            requestBatch,
+            allowParallelExecution: true,
+            cancellationToken: context.RequestAborted);
     }
 
     protected static AllowedContentType ParseContentType(HttpContext context)

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_Basic.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_Basic.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  }
+]

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_Exports.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_Exports.snap
@@ -1,0 +1,38 @@
+﻿[
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 1
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 2
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 2,
+        "add": 3
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  }
+]

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_Limit.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_Limit.snap
@@ -1,0 +1,74 @@
+﻿[
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 1
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 2
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 3
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 4
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 5
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 2,
+        "print": 6
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  }
+]

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_Mutations.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_Mutations.snap
@@ -1,0 +1,110 @@
+﻿[
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 1
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1,
+        "print": 2
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "nop": {
+        "group": 2,
+        "print": 3
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 3,
+        "print": 4
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 3,
+        "print": 5
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "nop": {
+        "group": 4,
+        "print": 6
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "nop": {
+        "group": 5,
+        "print": 7
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 6,
+        "print": 8
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 6,
+        "print": 9
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  }
+]

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_OperationNames.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.BatchParallelExecution_OperationNames.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 1
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "node": {
+        "group": 2
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  }
+]

--- a/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.Enumerable.cs
+++ b/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.Enumerable.cs
@@ -119,7 +119,7 @@ internal partial class BatchExecutor
             }
         }
 
-        private class WorkItem
+        private sealed class WorkItem
         {
             private readonly BatchExecutorEnumerable _parent;
             private readonly IReadOnlyQueryRequest _request = default!;

--- a/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.Enumerable.cs
+++ b/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.Enumerable.cs
@@ -54,7 +54,7 @@ internal partial class BatchExecutor
             _executionDiagnosticEvents = executionDiagnosticEvents ??
                 throw new ArgumentNullException(nameof(executionDiagnosticEvents));
             _maxConcurrentQueries = maxConcurrentQueries;
-            if (_maxConcurrentQueries < 0)
+            if (_maxConcurrentQueries <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(maxConcurrentQueries));
             }

--- a/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.Enumerable.cs
+++ b/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.Enumerable.cs
@@ -56,7 +56,7 @@ internal partial class BatchExecutor
             _maxConcurrentQueries = maxConcurrentQueries;
             if (_maxConcurrentQueries < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(_maxConcurrentQueries));
+                throw new ArgumentOutOfRangeException(nameof(maxConcurrentQueries));
             }
             _visitor = new CollectVariablesVisitor(requestExecutor.Schema);
         }
@@ -122,8 +122,8 @@ internal partial class BatchExecutor
         private sealed class WorkItem
         {
             private readonly BatchExecutorEnumerable _parent;
-            private readonly IReadOnlyQueryRequest _request = default!;
-            private readonly OperationDefinitionNode _operation = default!;
+            private readonly IReadOnlyQueryRequest _request;
+            private readonly OperationDefinitionNode _operation;
             private readonly int _exportCount;
             private readonly IQueryResult _error = default!;
 

--- a/src/HotChocolate/Core/src/Execution/Batching/CollectVariablesVisitor.cs
+++ b/src/HotChocolate/Core/src/Execution/Batching/CollectVariablesVisitor.cs
@@ -28,6 +28,8 @@ internal class CollectVariablesVisitor
     private readonly HashSet<string> _touchedFragments =
         new HashSet<string>();
     private readonly ISchema _schema;
+    // the amount of export directives visited
+    private int _exportCount;
 
     public CollectVariablesVisitor(ISchema schema)
     {
@@ -39,6 +41,9 @@ internal class CollectVariablesVisitor
             _variables.Values;
     public IReadOnlyCollection<string> TouchedFragments =>
         _touchedFragments;
+
+    public int ExportCount =>
+    _exportCount;
 
     public VisitorAction Enter(
         OperationDefinitionNode node,
@@ -80,6 +85,8 @@ internal class CollectVariablesVisitor
         IReadOnlyList<object> path,
         IReadOnlyList<ISyntaxNode> ancestors)
     {
+        _exportCount += node.Directives.Count(x => string.Equals(x.Name.Value, ExportDirectiveHelper.Name));
+
         if (_type.Peek().NamedType() is IComplexOutputType complexType
             && complexType.Fields.TryGetField(
                 node.Name.Value, out IOutputField? field))

--- a/src/HotChocolate/Core/src/Execution/Instrumentation/AggregateExecutionDiagnosticEvents.cs
+++ b/src/HotChocolate/Core/src/Execution/Instrumentation/AggregateExecutionDiagnosticEvents.cs
@@ -168,6 +168,18 @@ internal sealed class AggregateExecutionDiagnosticEvents : IExecutionDiagnosticE
         return new AggregateActivityScope(scopes);
     }
 
+    public IDisposable ExecuteBatchedQueryGroup()
+    {
+        var scopes = new IDisposable[_listeners.Length];
+
+        for (var i = 0; i < _listeners.Length; i++)
+        {
+            scopes[i] = _listeners[i].ExecuteBatchedQueryGroup();
+        }
+
+        return new AggregateActivityScope(scopes);
+    }
+
     public IDisposable ResolveFieldValue(IMiddlewareContext context)
     {
         if (_listeners.Length == 0)

--- a/src/HotChocolate/Core/src/Execution/Instrumentation/ExecutionDiagnosticEventListener.cs
+++ b/src/HotChocolate/Core/src/Execution/Instrumentation/ExecutionDiagnosticEventListener.cs
@@ -88,6 +88,9 @@ public class ExecutionDiagnosticEventListener : IExecutionDiagnosticEventListene
     public virtual IDisposable ExecuteDeferredTask()
         => EmptyScope;
 
+    public virtual IDisposable ExecuteBatchedQueryGroup()
+        => EmptyScope;
+
     /// <inheritdoc />
     public virtual IDisposable ResolveFieldValue(IMiddlewareContext context)
         => EmptyScope;

--- a/src/HotChocolate/Core/src/Execution/Instrumentation/IExecutionDiagnosticEvents.cs
+++ b/src/HotChocolate/Core/src/Execution/Instrumentation/IExecutionDiagnosticEvents.cs
@@ -185,6 +185,17 @@ public interface IExecutionDiagnosticEvents
     IDisposable ExecuteDeferredTask();
 
     /// <summary>
+    /// Called when starting to execute a group of queries from a batch request.
+    /// A group of queries are all items from the batch that can be run in parallel.
+    /// If parallel execution is not possible, each group only contains 1 query.
+    /// </summary>
+    /// <returns>
+    /// A scope that will be disposed when all queries in the group have been completed
+    /// or an error has occurred that caused the execution to be aborted.
+    /// </returns>
+    IDisposable ExecuteBatchedQueryGroup();
+
+    /// <summary>
     /// Called when starting to resolve a field value.
     /// </summary>
     /// <remarks>

--- a/src/HotChocolate/Core/src/Execution/Instrumentation/NoopExecutionDiagnosticEvents.cs
+++ b/src/HotChocolate/Core/src/Execution/Instrumentation/NoopExecutionDiagnosticEvents.cs
@@ -52,6 +52,8 @@ internal sealed class NoopExecutionDiagnosticEvents
 
     public IDisposable ExecuteDeferredTask() => this;
 
+    public IDisposable ExecuteBatchedQueryGroup() => this;
+
     public IDisposable ResolveFieldValue(IMiddlewareContext context) => this;
 
     public void ResolverError(IMiddlewareContext context, IError error)

--- a/src/HotChocolate/Core/src/Execution/Options/IRequestBatchOptions.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/IRequestBatchOptions.cs
@@ -1,0 +1,16 @@
+
+namespace HotChocolate.Execution.Options;
+
+/// <summary>
+/// Represents a dedicated options accessor to read the configured batching options.
+/// </summary>
+public interface IRequestBatchOptions
+{
+    /// <summary>
+    /// The maximum amount of queries from a single batch that will be executed in parallel for a single batched request.
+    /// This value is ignored if allowParallelExecution is false in IRequestExecutor.ExecuteBatchAsync.
+    /// This will NOT limit the total amount of concurrent batched queries accross requests.
+    /// </summary>
+    /// <see cref="IRequestExecutor.ExecuteBatchAsync"/>
+    public int MaxConcurrentBatchQueries { get; } 
+}

--- a/src/HotChocolate/Core/src/Execution/Options/IRequestExecutorOptionsAccessor.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/IRequestExecutorOptionsAccessor.cs
@@ -12,4 +12,5 @@ public interface IRequestExecutorOptionsAccessor
     , IDocumentCacheSizeOptionsAccessor
     , IRequestTimeoutOptionsAccessor
     , IComplexityAnalyzerOptionsAccessor
+    , IRequestBatchOptions
 { }

--- a/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
@@ -69,4 +69,12 @@ public class RequestExecutorOptions : IRequestExecutorOptionsAccessor
 
     [Obsolete("Use Complexity", true)]
     public bool? UseComplexityMultipliers { get; set; }
+
+    /// <summary>
+    /// The maximum amount of queries from a single batch that will be executed in parallel for a single batched request.
+    /// This value is ignored if allowParallelExecution is false in IRequestExecutor.ExecuteBatchAsync.
+    /// This will NOT limit the total amount of concurrent batched queries accross requests.
+    /// </summary>
+    /// <see cref="IRequestExecutor.ExecuteBatchAsync"/>
+    public int MaxConcurrentBatchQueries { get; set; } = 1;
 }

--- a/src/HotChocolate/Core/src/Execution/RequestExecutor.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutor.cs
@@ -119,7 +119,7 @@ internal sealed class RequestExecutor : IRequestExecutor
 
         return Task.FromResult<IBatchQueryResult>(
             new BatchQueryResult(
-                () => _batchExecutor.ExecuteAsync(this, requestBatch),
+                () => _batchExecutor.ExecuteAsync(this, requestBatch, allowParallelExecution),
                 null));
     }
 }

--- a/src/HotChocolate/Core/src/Execution/RequestExecutorResolver.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutorResolver.cs
@@ -242,7 +242,9 @@ internal sealed class RequestExecutorResolver
             sp => new BatchExecutor(
                 sp.GetRequiredService<IErrorHandler>(),
                 _applicationServices.GetRequiredService<ITypeConverter>(),
-                _applicationServices.GetRequiredService<InputFormatter>()));
+                _applicationServices.GetRequiredService<InputFormatter>(),
+                sp.GetRequiredService<IExecutionDiagnosticEvents>(),
+                sp.GetRequiredService<IRequestExecutorOptionsAccessor>()));
 
         serviceCollection.TryAddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
 

--- a/src/HotChocolate/Core/test/Execution.Tests/Batching/CollectVariablesVisitorTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Batching/CollectVariablesVisitorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using HotChocolate.Language;
@@ -49,6 +50,8 @@ namespace HotChocolate.Execution.Batching
                 {
                     operation
                 }).Print().MatchSnapshot();
+
+            Assert.Equal(0, visitor.ExportCount);
         }
 
         [Fact]
@@ -92,6 +95,8 @@ namespace HotChocolate.Execution.Batching
                 {
                     operation
                 }).Print().MatchSnapshot();
+
+            Assert.Equal(0, visitor.ExportCount);
         }
 
         [Fact]
@@ -142,6 +147,54 @@ namespace HotChocolate.Execution.Batching
                 document.Definitions.OfType<FragmentDefinitionNode>());
 
             new DocumentNode(definitions).Print().MatchSnapshot();
+
+            Assert.Equal(0, visitor.ExportCount);
+        }
+
+        [Fact]
+        public void ExportCount()
+        {
+            // arrange
+            ISchema schema = SchemaBuilder.New()
+                .AddStarWarsTypes()
+                .Create();
+
+            DocumentNode document = Utf8GraphQLParser.Parse(
+                @"
+                query getHero {
+                    ... q
+                }
+                fragment q on Query {
+                    hero(episode: $ep) @export(as: ""hero"") {
+                        name @export(as: ""name"")
+                        name2: name @export(as: ""name"")
+                    }
+                }
+                ");
+
+            OperationDefinitionNode operation = document.Definitions
+                .OfType<OperationDefinitionNode>()
+                .First();
+
+            var visitor = new CollectVariablesVisitor(schema);
+            var visitationMap = new CollectVariablesVisitationMap();
+            visitationMap.Initialize(
+                document.Definitions.OfType<FragmentDefinitionNode>()
+                    .ToDictionary(t => t.Name.Value));
+
+            // act
+            operation.Accept(
+                visitor,
+                visitationMap,
+                _ => VisitorAction.Continue);
+
+            Assert.Equal(3, visitor.ExportCount);
+        }
+
+        [Fact]
+        public void ConstructorExceptions()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CollectVariablesVisitor(null));
         }
     }
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/Batching/__snapshots__/BatchQueryExecutorTests.Invalid_Query.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Batching/__snapshots__/BatchQueryExecutorTests.Invalid_Query.snap
@@ -1,0 +1,1 @@
+﻿[{"errors":[{"message":"Unexpected Execution Error"}]}]


### PR DESCRIPTION
Concurrent batch query processing feature extracted from https://github.com/ChilliCream/hotchocolate/pull/3620.

Attached are results from Core benchmark including the still pending tests from https://github.com/ChilliCream/hotchocolate/pull/4660

[Core-Benchmark-Execution MaxConcurrentBatchQueries is 5.md](https://github.com/ChilliCream/hotchocolate/files/7896302/Core-Benchmark-Execution.MaxConcurrentBatchQueries.is.5.md)
[Core-Benchmark-Execution before changes.md](https://github.com/ChilliCream/hotchocolate/files/7896303/Core-Benchmark-Execution.before.changes.md)
[Core-Benchmark-Execution MaxConcurrentBatchQueries is 1.md](https://github.com/ChilliCream/hotchocolate/files/7896304/Core-Benchmark-Execution.MaxConcurrentBatchQueries.is.1.md)
