### PR TITLE
Apply Naming Convention

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -171,6 +171,7 @@ public class ObjectFieldDescriptor
     /// <inheritdoc />
     public new IObjectFieldDescriptor Name(NameString value)
     {
+        value = Context.Naming.GetMemberName(value), MemberKind.ObjectField);
         base.Name(value);
         return this;
     }


### PR DESCRIPTION
Apply Naming Convention to explicitly defined name. 

Analog to this constructor in ObjectFieldDescriptor.cs

```
ObjectFieldDescriptor(
        IDescriptorContext context,
        MemberInfo member,
        Type sourceType,
        Type? resolverType = null)
        : base(context)
```