### PR TITLE
Bump Stackexchange.Redis to 2.2.88

### DIFF
--- a/src/HotChocolate/Core/src/Subscriptions.Redis/HotChocolate.Subscriptions.Redis.csproj
+++ b/src/HotChocolate/Core/src/Subscriptions.Redis/HotChocolate.Subscriptions.Redis.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="StackExchange.Redis" Version="2.1.30" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/PersistedQueries/src/PersistedQueries.Redis/HotChocolate.PersistedQueries.Redis.csproj
+++ b/src/HotChocolate/PersistedQueries/src/PersistedQueries.Redis/HotChocolate.PersistedQueries.Redis.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.1.30" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Stitching/src/Stitching.Redis/HotChocolate.Stitching.Redis.csproj
+++ b/src/HotChocolate/Stitching/src/Stitching.Redis/HotChocolate.Stitching.Redis.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.1.30" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

Bump Stackexchange.Redis from 2.1.30 to 2.2.88

Closes #bugnumber (in this specific format)

I wasn't able to connect to a Redis Sentinel with the older version. Overriding with the newer version fixed it, so maybe this can be merged for the next version of HotChocolate 12.
More error details can be found [here](https://github.com/StackExchange/StackExchange.Redis/issues/1966).