### PR TITLE
Fixing minor typo in mongodb documentation

### DIFF
--- a/website/src/docs/hotchocolate/integrations/mongodb.md
+++ b/website/src/docs/hotchocolate/integrations/mongodb.md
@@ -191,7 +191,7 @@ services
 To use cursor based pagination annoate you resolver with `[UsePaging]` or `.UsePaging()`
 
 ```csharp
-[UsePaging1]
+[UsePaging]
 public IExecutable<Person> GetPersons([Service] IMongoCollection<Person> collection)
 {
     return collection.AsExecutable();


### PR DESCRIPTION
There was a typo in the attribute name.

- It should read `[UsePaging]` instead of `[UsePaging1]` to match the [attribute name](https://chillicream.com/docs/hotchocolate/v10/schema/descriptor-attributes#usepagingattribute).