### PR TITLE
Fix spelling error

### DIFF
--- a/website/src/pages/platform.tsx
+++ b/website/src/pages/platform.tsx
@@ -70,7 +70,7 @@ const PlatformPage: FC = () => {
           <ContentContainer>
             <SectionTitle>Strawberry Shake</SectionTitle>
             <p>
-              Strawberry Shake is a command line tool that generates custom .Net
+              Strawberry Shake is a tool that generates custom .Net
               clients for any GraphQL endpoint.
             </p>
             <Link to="/docs/strawberryshake">Learn more</Link>

--- a/website/src/pages/platform.tsx
+++ b/website/src/pages/platform.tsx
@@ -70,7 +70,7 @@ const PlatformPage: FC = () => {
           <ContentContainer>
             <SectionTitle>Strawberry Shake</SectionTitle>
             <p>
-              Strawberry Shake is our client tool to generates custom .Net
+              Strawberry Shake is a command line tool that generates custom .Net
               clients for any GraphQL endpoint.
             </p>
             <Link to="/docs/strawberryshake">Learn more</Link>


### PR DESCRIPTION
Grammar issues fixed.

Summary of the changes (Less than 80 chars)

- Just a spelling error removed ("to generates")