### PR TITLE
Update BCP preview links

### DIFF
--- a/website/src/docs/bananacakepop/index.md
+++ b/website/src/docs/bananacakepop/index.md
@@ -8,11 +8,11 @@ Banana Cake Pop makes it easy and enjoyable to test your GraphQL server implemen
 
 Banana Cake Pop is currently in preview and the current version is `1.0.0-preview.22`. It has an auto update feature built in, so as new releases come out you will get notifications in the app.
 
-- [MacOS Installer (Intel)](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.22-mac-x64.dmg)
-- [MacOS Installer (Apple Silicon)](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.22-mac-arm64.dmg)
-- [Windows Installer](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.22-win-x64.exe)
-- [Ubuntu Installer (AppImage)](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.22-linux-x86_64.AppImage)
-- [Ubuntu Installer (Snap)](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.22-linux-amd64.snap)
+- [MacOS Installer (Intel)](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.31-mac-x64.dmg)
+- [MacOS Installer (Apple Silicon)](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.31-mac-arm64.dmg)
+- [Windows Installer](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.31-win-x64.exe)
+- [Ubuntu Installer (AppImage)](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.31-linux-x86_64.AppImage)
+- [Ubuntu Installer (Snap)](https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.31-linux-amd64.snap)
 
 After downloading head over to [getting started](/docs/bananacakepop/getting-started) and lets make our first GraphQL query in Banana Cake Pop.
 


### PR DESCRIPTION
Updated Banana Cake Pop preview links on the website. This should allow tools such as Homebrew to parse the page to get the latest version for each platform and architecture.

- Updated all links to `preview.31`
