### PR TITLE
Add HashCode Bcl Library

### DIFF
--- a/src/HotChocolate/Language/src/Language.SyntaxTree/HotChocolate.Language.SyntaxTree.csproj
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/HotChocolate.Language.SyntaxTree.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'NETSTANDARD2.0'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Adds Bcl library for HashCode functions found in netstandard2.1+