### PR TITLE
added default timeout of 30 seconds when debugging

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
@@ -11,13 +11,22 @@ public class RequestExecutorOptions : IRequestExecutorOptionsAccessor
 {
     private const int _minQueryCacheSize = 10;
     private static readonly TimeSpan _minExecutionTimeout = TimeSpan.FromMilliseconds(100);
-    private TimeSpan _executionTimeout = TimeSpan.FromSeconds(30);
+    private TimeSpan _executionTimeout;
     private int _queryCacheSize = 100;
 
     /// <summary>
-    /// Gets or sets maximum allowed execution time of a query. The default
-    /// value is <c>30</c> seconds. The minimum allowed value is <c>100</c>
-    /// milliseconds.
+    /// Sets the maximum allowed execution time of a query to a default 
+    /// value of <c>30</c> seconds. If a debugger us attached the default
+    /// value id <c>30</c> minutes.
+    /// </summary>
+    public RequestExecutorOptions()
+    {
+        _executionTimeout = Debugger.IsAttached ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(30);
+    }
+
+    /// <summary>
+    /// Gets or sets maximum allowed execution time of a query.
+    /// The minimum allowed value is <c>100</c> milliseconds.
     /// </summary>
     public TimeSpan ExecutionTimeout
     {


### PR DESCRIPTION
default timeout of 30 minutes while debugging 

added constructor in RequestExecutorOptions which sets the timeout to 30 minutes when a debugger is attached, or 30 seconds when no debugger is present.

Closes #3656
