### PR TITLE
Fixed Optional.From when not having a value

### DIFF
--- a/src/HotChocolate/Core/src/Abstractions/Optional.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Optional.cs
@@ -161,5 +161,12 @@ public readonly struct Optional<T>
     /// Creates a new generic optional from a non-generic optional.
     /// </summary>
     public static Optional<T> From(IOptional optional)
-        => new((T?)optional.Value, optional.HasValue);
+    {
+        if (optional.HasValue)
+        {
+            return new Optional<T>((T?)optional.Value);
+        }
+
+        return new Optional<T>();
+    }
 }

--- a/src/HotChocolate/Core/test/Abstractions.Tests/OptionalTests.cs
+++ b/src/HotChocolate/Core/test/Abstractions.Tests/OptionalTests.cs
@@ -168,5 +168,26 @@ namespace HotChocolate
             // assert
             Assert.True(result);
         }
+
+        [Fact]
+        public void Optional_From_Value_Equals()
+        {
+            Optional<int> a = 1;
+            Optional<int> b = Optional<int>.From(a);
+
+            Assert.True(a.HasValue);
+            Assert.True(b.HasValue);
+            Assert.Equal(a.Value, b.Value);
+        }
+
+        [Fact]
+        public void Optional_From_Struct_Is_Not_Set()
+        {
+            var emptyOptional = new Optional<int?>();
+            var fromEmptyOptional = Optional<int>.From(emptyOptional);
+
+            Assert.False(fromEmptyOptional.HasValue);
+            Assert.True(fromEmptyOptional.IsEmpty);
+        }
     }
 }


### PR DESCRIPTION
Optional.From throws NullReferenceException when called with an IOptional without a value:

```cs
var emptyOptional = new Optional<int?>();
Optional<int>.From(emptyOptional);
```

Closes #4677

There might be an issue in some other part which causes inputs to create Optionals with nullable structs, but this piece of code should be there anyway.
I can add unit tests for this issue, but there were no tests for the `From` function, so I didn't add any.