### PR TITLE
Allow static node resolver to be defined in type/external resolver base class

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Extensions/ExecutionSchemaExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution/Extensions/ExecutionSchemaExtensions.cs
@@ -17,7 +17,24 @@ public static class ExecutionSchemaExtensions
             throw new ArgumentNullException(nameof(schema));
         }
 
-        return new ServiceCollection()
+        return schema.MakeExecutable(new ServiceCollection());
+    }
+
+    public static IRequestExecutor MakeExecutable(
+        this ISchema schema,
+        IServiceCollection services)
+    {
+        if (schema is null)
+        {
+            throw new ArgumentNullException(nameof(schema));
+        }
+
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        return services
             .AddGraphQL()
             .Configure(o => o.Schema = schema)
             .Services

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
@@ -278,7 +278,7 @@ public class DefaultTypeInspector
         if (resolverType is null)
         {
             return nodeType
-                .GetMembers(BindingFlags.Static | BindingFlags.Public)
+                .GetMembers(BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy)
                 .OfType<MethodInfo>()
                 .FirstOrDefault(m => IsPossibleNodeResolver(m, nodeType));
         }
@@ -287,7 +287,7 @@ public class DefaultTypeInspector
         // include the type name and can be an instance method.
         // first we will check for static load methods.
         MethodInfo? method = resolverType
-            .GetMembers(BindingFlags.Static | BindingFlags.Public)
+            .GetMembers(BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy)
             .OfType<MethodInfo>()
             .FirstOrDefault(m => IsPossibleExternalNodeResolver(m, nodeType));
 

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Attributes/NodeAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Attributes/NodeAttribute.cs
@@ -74,7 +74,7 @@ public class NodeAttribute : ObjectTypeDescriptorAttribute
             {
                 if (NodeResolver is not null)
                 {
-                    MethodInfo? method = NodeResolverType.GetMethod(NodeResolver);
+                    MethodInfo? method = NodeResolverType.GetMethod(NodeResolver, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
 
                     if (method is null)
                     {
@@ -92,7 +92,7 @@ public class NodeAttribute : ObjectTypeDescriptorAttribute
             }
             else if (NodeResolver is not null)
             {
-                MethodInfo? method = type.GetMethod(NodeResolver);
+                MethodInfo? method = type.GetMethod(NodeResolver, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
 
                 if (method is null)
                 {

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/NodeFieldSupportTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/NodeFieldSupportTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
 using Snapshooter.Xunit;
 using Xunit;
 
@@ -244,6 +245,25 @@ namespace HotChocolate.Types.Relay
         }
 
         [Fact]
+        public async Task Node_Resolve_Implicit_Inherited_Resolver()
+        {
+            // arrange
+            ISchema schema = SchemaBuilder.New()
+                .AddGlobalObjectIdentification()
+                .AddQueryType<Foo6>()
+                .Create();
+
+            IRequestExecutor executor = schema.MakeExecutable();
+
+            // act
+            IExecutionResult result = await executor.ExecuteAsync(
+                "{ node(id: \"QmFyCmQxMjM=\") { id } }");
+
+            // assert
+            result.ToJson().MatchSnapshot();
+        }
+
+        [Fact]
         public async Task Node_Resolve_Implicit_External_Resolver()
         {
             // arrange
@@ -253,6 +273,66 @@ namespace HotChocolate.Types.Relay
                 .Create();
 
             IRequestExecutor executor = schema.MakeExecutable();
+
+            // act
+            IExecutionResult result = await executor.ExecuteAsync(
+                "{ node(id: \"QmFyCmQxMjM=\") { id } }");
+
+            // assert
+            result.ToJson().MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task Node_Resolve_Implicit_ExternalInheritedStatic_Resolver()
+        {
+            // arrange
+            ISchema schema = SchemaBuilder.New()
+                .AddGlobalObjectIdentification()
+                .AddQueryType<Foo7>()
+                .Create();
+
+            IRequestExecutor executor = schema.MakeExecutable();
+
+            // act
+            IExecutionResult result = await executor.ExecuteAsync(
+                "{ node(id: \"QmFyCmQxMjM=\") { id } }");
+
+            // assert
+            result.ToJson().MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task Node_Resolve_Implicit_ExternalInheritedInstance_Resolver()
+        {
+            // arrange
+            ISchema schema = SchemaBuilder.New()
+                .AddGlobalObjectIdentification()
+                .AddQueryType<Foo8>()
+                .Create();
+
+            IRequestExecutor executor = schema.MakeExecutable();
+
+            // act
+            IExecutionResult result = await executor.ExecuteAsync(
+                "{ node(id: \"QmFyCmQxMjM=\") { id } }");
+
+            // assert
+            result.ToJson().MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task Node_Resolve_Implicit_ExternalDefinedOnInterface_Resolver()
+        {
+            // arrange
+            var services = new ServiceCollection();
+            services.AddSingleton<IBar9Resolver, Bar9Resolver>();
+
+            ISchema schema = SchemaBuilder.New()
+                .AddGlobalObjectIdentification()
+                .AddQueryType<Foo9>()
+                .Create();
+
+            IRequestExecutor executor = schema.MakeExecutable(services);
 
             // act
             IExecutionResult result = await executor.ExecuteAsync(
@@ -364,6 +444,89 @@ namespace HotChocolate.Types.Relay
             public string Id { get; set; }
 
             public static Bar5 Get(string id) => new() { Id = id };
+        }
+
+        public class Foo6
+        {
+            public Bar6 Bar { get; set; } = new() { Id = "123" };
+        }
+
+        public abstract class Bar6Base<T> where T : Bar6Base<T>, new()
+        {
+            public string Id { get; set; }
+
+            public static T Get(string id) => new() { Id = id };
+
+        }
+
+        [ObjectType("Bar")]
+        [Node]
+        public class Bar6 : Bar6Base<Bar6>
+        {
+        }
+
+        public class Foo7
+        {
+            public Bar7 Bar { get; set; } = new() { Id = "123" };
+        }
+
+        [ObjectType("Bar")]
+        [Node(NodeResolverType = typeof(Bar7Resolver))]
+        public class Bar7
+        {
+            public string Id { get; set; }
+        }
+
+        public abstract class Bar7ResolverBase
+        {
+            public static Bar7 GetBar7(string id) => new() { Id = id };
+        }
+
+        public class Bar7Resolver : Bar7ResolverBase
+        {
+        }
+
+        public class Foo8
+        {
+            public Bar8 Bar { get; set; } = new() { Id = "123" };
+        }
+
+        [ObjectType("Bar")]
+        [Node(NodeResolverType = typeof(Bar8Resolver))]
+        public class Bar8
+        {
+            public string Id { get; set; }
+        }
+
+        public class Bar8ResolverBase
+        {
+            public Bar8 GetBar8(string id) => new() { Id = id };
+        }
+
+        public class Bar8Resolver : Bar8ResolverBase
+        {
+        }
+
+        public class Foo9
+        {
+            public Bar9 Bar { get; set; } = new() { Id = "123" };
+        }
+
+        [ObjectType("Bar")]
+        [Node(NodeResolverType = typeof(IBar9Resolver))]
+        public class Bar9
+        {
+            public string Id { get; set; }
+        }
+
+        public interface IBar9Resolver
+        {
+            public Bar9 GetBar9(string id);
+        }
+
+        public class Bar9Resolver : IBar9Resolver
+        {
+            public Bar9 GetBar9(string id) => new() { Id = id };
         }
 
         public class Parent

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_ExternalDefinedOnInterface_Resolver.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_ExternalDefinedOnInterface_Resolver.snap
@@ -1,0 +1,7 @@
+﻿{
+  "data": {
+    "node": {
+      "id": "QmFyCmQxMjM="
+    }
+  }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_ExternalInheritedInstance_Resolver.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_ExternalInheritedInstance_Resolver.snap
@@ -1,0 +1,7 @@
+﻿{
+  "data": {
+    "node": {
+      "id": "QmFyCmQxMjM="
+    }
+  }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_ExternalInheritedStatic_Resolver.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_ExternalInheritedStatic_Resolver.snap
@@ -1,0 +1,7 @@
+﻿{
+  "data": {
+    "node": {
+      "id": "QmFyCmQxMjM="
+    }
+  }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_ExternalInherited_Resolver.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_ExternalInherited_Resolver.snap
@@ -1,0 +1,7 @@
+﻿{
+  "data": {
+    "node": {
+      "id": "QmFyCmQxMjM="
+    }
+  }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_Inherited_Resolver.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/__snapshots__/NodeFieldSupportTests.Node_Resolve_Implicit_Inherited_Resolver.snap
@@ -1,0 +1,7 @@
+﻿{
+  "data": {
+    "node": {
+      "id": "QmFyCmQxMjM="
+    }
+  }
+}


### PR DESCRIPTION
- Allows node resolver to be defined as a static method in the entity's base class 
- Allows node resolver to be defined as an inherited static method of the `NodeResolverType`

Closes #5001
