### PR TITLE
Fixed typo

### DIFF
--- a/src/StrawberryShake/Client/src/Core/OperationResultExtensions.cs
+++ b/src/StrawberryShake/Client/src/Core/OperationResultExtensions.cs
@@ -57,7 +57,7 @@ public static class OperationResultExtensions
     /// </summary>
     /// <param name="result">The operation result.</param>
     /// <returns>
-    /// <c>true</c>, if the result has errors; otherwise, <c>false</c>.
+    /// <c>true</c>, if the result has no errors; otherwise, <c>false</c>.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// The operation result is null.


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

There was a type in the comments of the method so fixed it

Closes #bugnumber (in this specific format)
