### PR TITLE
Fix typo under projections documentation.

### DIFF
--- a/website/src/docs/hotchocolate/v11/fetching-data/projections.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/projections.md
@@ -49,7 +49,7 @@ services.AddGraphQLServer()
 Projections can be registered on a field. A middleware will apply the selected fields on the result.
 Support for `IQueryable` comes out of the box.
 The projection middleware will create a projection for the whole subtree of its field. Only fields that
-are members of a type will be projected. Fields that define a customer resolver cannot be projected
+are members of a type will be projected. Fields that define a custom resolver cannot be projected
 to the database. If the middleware encounters a field that specifies `UseProjection()` this field will be skipped.
 
 <ExampleTabs>


### PR DESCRIPTION
Summary:

- Documentation on projection was misleading due to a typo under https://github.com/ChilliCream/hotchocolate/blob/ca95b4cab360ba643f5c7fd009a01e907190428d/website/src/docs/hotchocolate/v11/fetching-data/projections.md?plain=1#L52

Closes #5010 
