### PR TITLE
Fixed equals methods of SpreadReference causing slow execution times

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/OperationCompiler.Context.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/OperationCompiler.Context.cs
@@ -228,14 +228,14 @@ public sealed partial class OperationCompiler
 
         public ISelectionNode Spread { get; }
 
-        public bool Equals(SelectionReference other)
+        public bool Equals(SpreadReference other)
         {
-            return Path.Equals(other.Path) && Spread.Equals(other.Selection);
+            return Path.Equals(other.Path) && Spread.Equals(other.Spread);
         }
 
         public override bool Equals(object? obj)
         {
-            return obj is SelectionReference other && Equals(other);
+            return obj is SpreadReference other && Equals(other);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Summary:
The equals methods were copied from another place so the object type is incorrect, causing it to always return false.
As a consequence, the OperationCompiler.ResolveFragmentSpread method always not finding the SpreadReference in the context.Spreads, and adding another vaule to this dictionary.

Closes #5042