### PR TITLE
Update index.md blazor wasm template name

### DIFF
--- a/website/src/docs/strawberryshake/get-started/index.md
+++ b/website/src/docs/strawberryshake/get-started/index.md
@@ -45,7 +45,7 @@ dotnet new sln -n Demo
 2. Create a new Blazor for WebAssembly application.
 
 ```bash
-dotnet new wasm -n Demo
+dotnet new blazorwasm -n Demo
 ```
 
 3. Add the project to the solution `Demo.sln`.


### PR DESCRIPTION
Updated the template name for blazor web assembly project.

Summary of the changes (Less than 80 chars)

- Current documentation has the wrong template name (MS updated this in January)
- Only changes to the documentation

Closes #bugnumber (in this specific format)
