### PR TITLE
Update error type

### DIFF
--- a/website/src/docs/hotchocolate/defining-a-schema/mutations.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/mutations.md
@@ -436,7 +436,7 @@ input UpdateUserNameInput {
 
 type UpdateUserNamePayload {
   user: User
-  errors: [CreateUserError!]
+  errors: [UpdateUserNameError!]
 }
 
 type User {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Replaced `CreateUserError` with `UpdateUserNameError` in the Mutations documentation, as I believe that was a mistake. (?)

Closes n/a