### PR TITLE
Removed the schema resolver delegate

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/Contracts/ITypeCompletionContext.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Contracts/ITypeCompletionContext.cs
@@ -93,6 +93,4 @@ public interface ITypeCompletionContext : ITypeSystemObjectContext
     bool TryGetDirectiveType(
         IDirectiveReference directiveRef,
         [NotNullWhen(true)] out DirectiveType? directiveType);
-
-    Func<ISchema> GetSchemaResolver();
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/RegisteredType.CompletionContext.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/RegisteredType.CompletionContext.cs
@@ -14,7 +14,6 @@ namespace HotChocolate.Configuration;
 internal sealed partial class RegisteredType : ITypeCompletionContext
 {
     private TypeReferenceResolver? _typeReferenceResolver;
-    private Func<ISchema>? _schemaResolver;
 
     public TypeStatus Status { get; set; } = TypeStatus.Initialized;
 
@@ -43,12 +42,10 @@ internal sealed partial class RegisteredType : ITypeCompletionContext
 
     public void PrepareForCompletion(
         TypeReferenceResolver typeReferenceResolver,
-        Func<ISchema> schemaResolver,
         List<FieldMiddleware> globalComponents,
         IsOfTypeFallback? isOfType)
     {
         _typeReferenceResolver = typeReferenceResolver;
-        _schemaResolver = schemaResolver;
         GlobalComponents = globalComponents;
         IsOfType = isOfType;
     }
@@ -128,21 +125,5 @@ internal sealed partial class RegisteredType : ITypeCompletionContext
         }
 
         return _typeReferenceResolver.TryGetDirectiveType(directiveRef, out directiveType);
-    }
-
-    /// <inheritdoc />
-    public Func<ISchema> GetSchemaResolver()
-    {
-        if (_schemaResolver is null)
-        {
-            throw new InvalidOperationException(RegisteredType_Completion_NotYetReady);
-        }
-
-        if (Status == TypeStatus.Initialized)
-        {
-            throw new NotSupportedException();
-        }
-
-        return _schemaResolver;
     }
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -24,7 +24,6 @@ internal class TypeInitializer
     private readonly TypeInterceptor _interceptor;
     private readonly IsOfTypeFallback? _isOfType;
     private readonly Func<TypeSystemObjectBase, RootTypeKind> _getTypeKind;
-    private readonly Func<ISchema> _schemaResolver;
     private readonly IReadOnlySchemaOptions _options;
     private readonly TypeRegistry _typeRegistry;
     private readonly TypeLookup _typeLookup;
@@ -40,7 +39,6 @@ internal class TypeInitializer
         IReadOnlyList<ITypeReference> initialTypes,
         IsOfTypeFallback? isOfType,
         Func<TypeSystemObjectBase, RootTypeKind> getTypeKind,
-        Func<ISchema> schemaResolver,
         IReadOnlySchemaOptions options)
     {
         _context = descriptorContext ??
@@ -51,8 +49,6 @@ internal class TypeInitializer
             throw new ArgumentNullException(nameof(initialTypes));
         _getTypeKind = getTypeKind ??
             throw new ArgumentNullException(nameof(getTypeKind));
-        _schemaResolver = schemaResolver ??
-            throw new ArgumentNullException(nameof(schemaResolver));
         _options = options ??
             throw new ArgumentNullException(nameof(options));
 
@@ -227,7 +223,6 @@ internal class TypeInitializer
     {
         registeredType.PrepareForCompletion(
             _typeReferenceResolver,
-            _schemaResolver,
             _globalComps,
             _isOfType);
 

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
@@ -1496,5 +1496,17 @@ namespace HotChocolate.Properties {
                 return ResourceManager.GetString("ResolverContextExtensions_ContextData_KeyNotFound", resourceCulture);
             }
         }
+        
+        internal static string SchemaTypes_GetType_DoesNotExist {
+            get {
+                return ResourceManager.GetString("SchemaTypes_GetType_DoesNotExist", resourceCulture);
+            }
+        }
+        
+        internal static string SchemaTypes_DefinitionInvalid {
+            get {
+                return ResourceManager.GetString("SchemaTypes_DefinitionInvalid", resourceCulture);
+            }
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
@@ -858,4 +858,10 @@ Type: `{0}`</value>
   <data name="ResolverContextExtensions_ContextData_KeyNotFound" xml:space="preserve">
     <value>The specified key `{0}` does not exist on `context.ContextData`</value>
   </data>
+  <data name="SchemaTypes_GetType_DoesNotExist" xml:space="preserve">
+    <value>The specified type `{0}` does not exist or is not of the specified kind `{1}`.</value>
+  </data>
+  <data name="SchemaTypes_DefinitionInvalid" xml:space="preserve">
+    <value>The schema types definition is in an invalid state.</value>
+  </data>
 </root>

--- a/src/HotChocolate/Core/src/Types/Schema.cs
+++ b/src/HotChocolate/Core/src/Types/Schema.cs
@@ -122,7 +122,7 @@ public partial class Schema
             throw new ArgumentNullException(nameof(abstractType));
         }
 
-        if (_types.TryGetPossibleTypes(abstractType.Name, out IReadOnlyList<ObjectType> types))
+        if (_types.TryGetPossibleTypes(abstractType.Name, out IReadOnlyList<ObjectType>? types))
         {
             return types;
         }

--- a/src/HotChocolate/Core/src/Types/SchemaTypesDefinition.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaTypesDefinition.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using HotChocolate.Types;
 
@@ -5,10 +7,10 @@ namespace HotChocolate;
 
 internal sealed class SchemaTypesDefinition
 {
-    public ObjectType QueryType { get; set; }
-    public ObjectType MutationType { get; set; }
-    public ObjectType SubscriptionType { get; set; }
+    public ObjectType? QueryType { get; set; }
+    public ObjectType? MutationType { get; set; }
+    public ObjectType? SubscriptionType { get; set; }
 
-    public IReadOnlyList<INamedType> Types { get; set; }
-    public IReadOnlyList<DirectiveType> DirectiveTypes { get; set; }
+    public IReadOnlyList<INamedType>? Types { get; set; }
+    public IReadOnlyList<DirectiveType>? DirectiveTypes { get; set; }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DescriptorContext.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DescriptorContext.cs
@@ -62,6 +62,7 @@ public sealed class DescriptorContext : IDescriptorContext
         void OnSchemaOnCompleted(object? sender, EventArgs args)
         {
             SchemaCompleted?.Invoke(this, new SchemaCompletedEventArgs(schema.Schema));
+            SchemaCompleted = null;
         }
     }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeInitializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeInitializerTests.cs
@@ -30,7 +30,6 @@ namespace HotChocolate.Configuration
                 },
                 null,
                 t => t is FooType ? RootTypeKind.Query : RootTypeKind.None,
-                () => null,
                 new SchemaOptions());
 
             // act
@@ -86,7 +85,6 @@ namespace HotChocolate.Configuration
                         _ => RootTypeKind.None
                     };
                 },
-                () => null,
                 new SchemaOptions());
 
             // act
@@ -117,40 +115,6 @@ namespace HotChocolate.Configuration
         }
 
         [Fact]
-        public void Initializer_SchemaResolver_Is_Null()
-        {
-            // arrange
-            var typeInterceptor = new AggregateTypeInterceptor();
-            typeInterceptor.SetInterceptors(new[] { new IntrospectionTypeInterceptor() });
-            IDescriptorContext context = DescriptorContext.Create(
-                typeInterceptor: typeInterceptor);
-            var typeRegistry = new TypeRegistry(context.TypeInterceptor);
-
-            // act
-            void Action() => new TypeInitializer(
-                context,
-                typeRegistry,
-                new List<ITypeReference>
-                {
-                    context.TypeInspector.GetTypeRef(typeof(Foo), TypeContext.Output)
-                },
-                null!,
-                t =>
-                {
-                    return t switch
-                    {
-                        ObjectType<Foo> => RootTypeKind.Query,
-                        _ => RootTypeKind.None
-                    };
-                },
-                null!,
-                new SchemaOptions());
-
-            // assert
-            Assert.Throws<ArgumentNullException>(Action);
-        }
-
-        [Fact]
         public void Initializer_SchemaOptions_Are_Null()
         {
             // arrange
@@ -177,7 +141,6 @@ namespace HotChocolate.Configuration
                         _ => RootTypeKind.None
                     };
                 },
-                () => null,
                 null!);
 
             // assert


### PR DESCRIPTION
We removed the schema resolver delegate since it captured setup objects which then weren't GCed.