### PR TITLE
Adds the property back for backwards compatibility

### DIFF
--- a/src/HotChocolate/Core/src/Types/Resolvers/IResolverContext.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/IResolverContext.cs
@@ -170,4 +170,9 @@ public interface IResolverContext : IPureResolverContext
     /// Returns the query root instance.
     /// </returns>
     T GetQueryRoot<T>();
+
+     /// <summary>
+     /// Gets the current execution path.
+     /// </summary>
+     new Path Path { get; }
 }


### PR DESCRIPTION
Fixed `IResolverContext` 