### PR TITLE
Paging EnsureConnectionNameCasing updated with ToUpperInvariant

### DIFF
--- a/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/PagingObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/PagingObjectFieldDescriptorExtensions.cs
@@ -415,6 +415,6 @@ public static class PagingObjectFieldDescriptorExtensions
             return connectionName;
         }
 
-        return string.Concat(char.ToUpper(connectionName[0]), connectionName.Substring(1));
+        return string.Concat(char.ToUpperInvariant(connectionName[0]), connectionName.Substring(1));
     }
 }


### PR DESCRIPTION
For some languages like Turkish, if connection name starts with 'i' character ToUpper function changes this character with 'İ'. To prevent this issue I changed ToUpper with ToUpperInvariant.

Closes #5134  
