### PR TITLE
Fixes Interface Field Naming Convention.

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -39,13 +39,13 @@ public class InterfaceFieldDescriptor
 
         Definition.Name = context.Naming.GetMemberName(
             member,
-            MemberKind.InputObjectField);
+            MemberKind.InterfaceField);
         Definition.Description = context.Naming.GetMemberDescription(
             member,
-            MemberKind.InputObjectField);
+            MemberKind.InterfaceField);
         Definition.Type = context.TypeInspector.GetOutputReturnTypeRef(member);
 
-        if (context.Naming.IsDeprecated(member, out string reason))
+        if (context.Naming.IsDeprecated(member, out var reason))
         {
             Deprecated(reason);
         }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Ensure_Interface_Field_Is_Requested_When_Applying_NamingConvention.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/InterfaceTypeTests.Ensure_Interface_Field_Is_Requested_When_Applying_NamingConvention.snap
@@ -1,0 +1,17 @@
+﻿schema {
+  query: Query
+}
+
+interface IFooNaming {
+  foo_bar_baz: String
+}
+
+type Query {
+  foo: IFooNaming
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! = 0 "Streamed when true." if: Boolean) on FIELD


### PR DESCRIPTION
Interface fields specified the wrong member kind when getting the name from the naming convention.

Fixes #5124