### PR TITLE
Description on `totalCount` field in connection type

### DIFF
--- a/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionType.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionType.cs
@@ -169,6 +169,7 @@ internal class ConnectionType
         {
             definition.Fields.Add(new(
                 Names.TotalCount,
+                ConnectionType_TotalCount_Description,
                 type: TypeReference.Parse($"{ScalarNames.Int}!"),
                 resolver: GetTotalCountAsync));
         }

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
@@ -1413,6 +1413,12 @@ namespace HotChocolate.Properties {
             }
         }
         
+        internal static string ConnectionType_TotalCount_Description {
+            get {
+                return ResourceManager.GetString("ConnectionType_TotalCount_Description", resourceCulture);
+            }
+        }
+
         internal static string CollectionSegmentType_PageInfo_Description {
             get {
                 return ResourceManager.GetString("CollectionSegmentType_PageInfo_Description", resourceCulture);

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
@@ -812,6 +812,9 @@ Type: `{0}`</value>
   <data name="ConnectionType_Edges_Description" xml:space="preserve">
     <value>A list of edges.</value>
   </data>
+  <data name="ConnectionType_TotalCount_Description" xml:space="preserve">
+    <value>Identifies the total count of items in the connection.</value>
+  </data>
   <data name="CollectionSegmentType_PageInfo_Description" xml:space="preserve">
     <value>Information to aid in pagination.</value>
   </data>


### PR DESCRIPTION
Adding in description too `totalCount` field that optionally appears on connection type.

- Used description from the GitHub.graphql file from within the execution benchmarks folder as content for description
- Only field (that I saw) on built in connection type that doesn't have a field comment, so rounding it out so all do
- (selfishly) makes our linter happy such that "all fields have descriptions"
