### PR TITLE
Wrong field name in sample query in documentation about Unions

### DIFF
--- a/website/src/docs/hotchocolate/defining-a-schema/unions.md
+++ b/website/src/docs/hotchocolate/defining-a-schema/unions.md
@@ -23,7 +23,7 @@ Clients can query fields returning a union like the following.
 
 ```graphql
 {
-  postContent {
+  content {
     ... on TextContent {
       text
     }


### PR DESCRIPTION
The field name `postContent` in the sample query didn't match the server's schema (there the field has the name `content`).