### PR TITLE
Can we optimize request batching parallelization safely?

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.cs
+++ b/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.cs
@@ -27,13 +27,15 @@ internal partial class BatchExecutor
 
     public IAsyncEnumerable<IQueryResult> ExecuteAsync(
         IRequestExecutor requestExecutor,
-        IEnumerable<IQueryRequest> requestBatch)
+        IEnumerable<IQueryRequest> requestBatch,
+        bool allowParallelExecution)
     {
         return new BatchExecutorEnumerable(
             requestBatch,
             requestExecutor,
             _errorHandler,
             _typeConverter,
-            _inputFormatter);
+            _inputFormatter,
+            /*allowParallelExecution*/true); // TODO: How to set this from caller?
     }
 }

--- a/src/HotChocolate/Core/src/Execution/RequestExecutor.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutor.cs
@@ -119,7 +119,7 @@ internal sealed class RequestExecutor : IRequestExecutor
 
         return Task.FromResult<IBatchQueryResult>(
             new BatchQueryResult(
-                () => _batchExecutor.ExecuteAsync(this, requestBatch),
+                () => _batchExecutor.ExecuteAsync(this, requestBatch, allowParallelExecution),
                 null));
     }
 }


### PR DESCRIPTION
The Apollo client has an automatic request batching option that tries to minimize the number of requests to the backends.
https://www.apollographql.com/docs/react/api/link/apollo-link-batch-http/

By using this unmodified in a GraphQL gateway, this forces the requests to execute sequentially. There are valid cases for having to do this, such as when requests have side effects or exports variables to further requests, however it should be possible to optimize this.

This draft PR outlines an idea where we try to run as much as possible in parallel.

In addition to the obvious benefit of running requests in parallel, this also enables the use of data loaders in domain services, as a stitching gateway using this branch would merge the queries before sending them to the domain services.

I'm posting this as a foundation for further discussion. I'm not sure if there are any obvious things I've missed here. Using the standard apollo link, this branch improves our performance by almost an order of magnitude in some cases.

Alternate solutions we are pursuing:
* Disable batch link in Apollo and rely on Http2 multiplexing: Improves performance but still introduces overhead and possibly browser-dependent behaviour. Additionally, the DataLoader context will not be reused between the parallel requests, since it is per request only.
* Use query merging: Gives us very good performance, but we lose a lot of diagnostics from the gateway, such as operation names. Additionally, I don't see how we could make this compatible with automatic persisted queries.