### PR TITLE
5345 more concise error message v12

### DIFF
--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
@@ -1460,5 +1460,11 @@ namespace HotChocolate.Properties {
                 return ResourceManager.GetString("ReflectionUtils_ExtractMethod_MethodExpected", resourceCulture);
             }
         }
+
+        internal static string TypeInitializer_CannotFindType {
+            get {
+                return ResourceManager.GetString("TypeInitializer_CannotFindType", resourceCulture);
+            }
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
@@ -840,4 +840,7 @@ Type: `{0}`</value>
   <data name="ReflectionUtils_ExtractMethod_MethodExpected" xml:space="preserve">
     <value>Member is not a method!</value>
   </data>
+  <data name="TypeInitializer_CannotFindType" xml:space="preserve">
+    <value>Unable to find type(s) {0}</value>
+  </data>
 </root>

--- a/src/HotChocolate/Core/test/Types.Tests/SchemaErrorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/SchemaErrorTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using HotChocolate.Configuration;
 using HotChocolate.Language;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
+using Snapshooter.Xunit;
 using Xunit;
 
 namespace HotChocolate
@@ -151,7 +153,27 @@ namespace HotChocolate
                 ex => Assert.IsType<SchemaException>(ex));
         }
 
-        private class ErrorInterceptor : SchemaInterceptor
+        [Fact]
+    public void IncorrectType_In_Parameters_ShouldThrow()
+    {
+        // arrange
+        var schema = SchemaBuilder.New()
+            .AddDocumentFromString(@"
+                    type Query {
+                        test(bar: Input123): String
+                    }
+                ")
+            .Use(next => context => default);
+
+        // act
+        var ex = Assert.Throws<SchemaException>(() => schema.Create());
+
+        // assert
+        Assert.Equal(2, ex.Errors.Count);
+        ex.Errors.First().Message.MatchSnapshot();
+    }
+
+    private class ErrorInterceptor : SchemaInterceptor
         {
             public List<Exception> Exceptions { get; } = new List<Exception>();
 

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/SchemaErrorTests.IncorrectType_In_Parameters_ShouldThrow.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/SchemaErrorTests.IncorrectType_In_Parameters_ShouldThrow.snap
@@ -1,0 +1,1 @@
+Unable to find type(s) None: Input123


### PR DESCRIPTION
Same PR as #5346 but for v12 specifically.

Add a more concise error message when stitching errors occur

- Altered `TryNormalizeDependencies` to provide a list of `notFound` items of type `IReadOnlyList<ITypeReference>`
- Added an `Unable to find type(s) {0}` resource string

In the example provided in the original issue #5345 the error message added should be:

`1. Unable to find type(s) None: [AuditLogEntitySortInput123!] (HotChocolate.Types.ObjectType)`

And the second - original message - is kept and showing too.

Closes #5345
