### PR TITLE
Fix wrong name of constructor in docs example

### DIFF
--- a/website/src/docs/hotchocolate/integrations/entity-framework.md
+++ b/website/src/docs/hotchocolate/integrations/entity-framework.md
@@ -149,7 +149,7 @@ public class FooByIdDataLoader : BatchDataLoader<string, Foo>
 {
     private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
 
-    public UserByIdDataLoader(
+    public FooByIdDataLoader(
         IDbContextFactory<ApplicationDbContext> dbContextFactory,
         IBatchScheduler batchScheduler, DataLoaderOptions options)
         : base(batchScheduler, options)


### PR DESCRIPTION
Just a little fix of a mismatch between class name and constructor name in the example of using a pooled DbContext
