### PR TITLE
Fix event stream formatter so that support graphql-sse protocol

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/GraphQLOverHttpSpecTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/GraphQLOverHttpSpecTests.cs
@@ -861,9 +861,8 @@ public class GraphQLOverHttpSpecTests : ServerTestBase
     }
 
     /// <summary>
-    /// This request specifies the application/graphql-response+json and
-    /// the multipart/mixed content type as accept header value.
-    /// expected response content-type: multipart/mixed
+    /// This request specifies the text/event-stream content type as accept header value.
+    /// expected response content-type: text/event-stream
     /// expected status code: 200
     /// </summary>
     [Fact]
@@ -894,7 +893,7 @@ public class GraphQLOverHttpSpecTests : ServerTestBase
         using var response = await client.SendAsync(request, ResponseHeadersRead);
 
         // assert
-        // expected response content-type: multipart/mixed
+        // expected response content-type: text/event-stream
         // expected status code: 200
         Snapshot
             .Create()
@@ -905,10 +904,15 @@ public class GraphQLOverHttpSpecTests : ServerTestBase
                 -------------------------->
                 Status Code: OK
                 -------------------------->
-                {""event"":""next"",""data"":{""data"":{},""hasNext"":true}}
-                {""event"":""next"",""data"":{""incremental"":[{""data"":{" +
-                @"""__typename"":""Query""},""path"":[]}],""hasNext"":false}}
-                {""event"":""complete""}
+                event:next
+                data: {""data"":{},""hasNext"":true}
+
+                event:next
+                data: {""incremental"":[{""data"":{""__typename"":""Query""}," +
+                @"""path"":[]}],""hasNext"":false}
+
+                event:complete
+
                 ");
     }
 }


### PR DESCRIPTION
Fix `EventStreamResultFormatter` to format an event stream for [decoding](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation).
