### PR TITLE
Website Markdown cleanup

### DIFF
--- a/.docker/website/dockerfile
+++ b/.docker/website/dockerfile
@@ -1,3 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM nginx:alpine
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY ./website/config/conf.d /etc/nginx/conf.d
+
 COPY ./website/public /usr/share/nginx/html

--- a/cSpell.json
+++ b/cSpell.json
@@ -31,7 +31,8 @@
     "struct",
     "Swashbuckle",
     "traversion",
-    "Websockets"
+    "Websockets",
+    "Newtonsoft"
   ],
   "ignoreWords": [
     "Specwise",
@@ -56,7 +57,7 @@
     "relayjs",
     "Rgba",
     "Postgraphile",
-    "Normen",
+    "Normen"
   ],
   "ignoreRegExpList": [
     "\\((.*)\\)", // Markdown links

--- a/website/config/conf.d/default.conf
+++ b/website/config/conf.d/default.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+
+    error_page 404 /404;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/website/src/components/layout/layout.tsx
+++ b/website/src/components/layout/layout.tsx
@@ -1,8 +1,10 @@
 import { MDXProvider } from "@mdx-js/react";
 import React, { FC } from "react";
+import { BlockQuote } from "../mdx/block-quote";
 import { CodeBlock } from "../mdx/code-block";
 import { Annotation, Code, ExampleTabs, Schema } from "../mdx/example-tabs";
 import { InlineCode } from "../mdx/inline-code";
+import { PackageInstallation } from "../mdx/package-installation";
 import { CookieConsent } from "../misc/cookie-consent";
 import { GlobalStyle } from "../misc/global-style";
 import { Header } from "./header";
@@ -12,10 +14,12 @@ export const Layout: FC = ({ children }) => {
   const components = {
     pre: CodeBlock,
     inlineCode: InlineCode,
+    blockquote: BlockQuote,
     ExampleTabs,
     Annotation,
     Code,
     Schema,
+    PackageInstallation,
   };
 
   return (

--- a/website/src/components/layout/layout.tsx
+++ b/website/src/components/layout/layout.tsx
@@ -1,6 +1,7 @@
 import { MDXProvider } from "@mdx-js/react";
 import React, { FC } from "react";
 import { CodeBlock } from "../mdx/code-block";
+import { Annotation, Code, ExampleTabs, Schema } from "../mdx/example-tabs";
 import { InlineCode } from "../mdx/inline-code";
 import { CookieConsent } from "../misc/cookie-consent";
 import { GlobalStyle } from "../misc/global-style";
@@ -11,6 +12,10 @@ export const Layout: FC = ({ children }) => {
   const components = {
     pre: CodeBlock,
     inlineCode: InlineCode,
+    ExampleTabs,
+    Annotation,
+    Code,
+    Schema,
   };
 
   return (

--- a/website/src/components/mdx/block-quote.tsx
+++ b/website/src/components/mdx/block-quote.tsx
@@ -1,0 +1,25 @@
+import React, { Children, FC } from "react";
+import { Warning } from "./warning";
+
+const warningText = "Warning: ";
+
+export const BlockQuote: FC = ({ children }) => {
+  const child = Children.only(children);
+
+  const texts = (child as any)?.props?.children;
+
+  if (
+    Array.isArray(texts) &&
+    texts.length > 0 &&
+    typeof texts[0] === "string"
+  ) {
+    if (texts[0].startsWith(warningText)) {
+      const mutatedTexts = texts.slice(0);
+      mutatedTexts[0] = texts[0].substring(warningText.length);
+
+      return <Warning>{mutatedTexts}</Warning>;
+    }
+  }
+
+  return <blockquote>{children}</blockquote>;
+};

--- a/website/src/components/mdx/block-quote.tsx
+++ b/website/src/components/mdx/block-quote.tsx
@@ -1,24 +1,58 @@
-import React, { Children, FC } from "react";
+import React, { Children, FC, ReactElement } from "react";
 import { Warning } from "./warning";
 
 const warningText = "Warning: ";
 
 export const BlockQuote: FC = ({ children }) => {
-  const child = Children.only(children);
+  const childArray = Children.toArray(children);
 
-  const texts = (child as any)?.props?.children;
+  const isWarning =
+    childArray.length > 0 &&
+    React.isValidElement(childArray[0]) &&
+    ((typeof childArray[0].props["children"] === "string" &&
+      childArray[0].props["children"].startsWith(warningText)) ||
+      (Array.isArray(childArray[0].props["children"]) &&
+        childArray[0].props["children"].length > 0 &&
+        typeof childArray[0].props["children"][0] === "string" &&
+        childArray[0].props["children"][0].startsWith(warningText)));
 
-  if (
-    Array.isArray(texts) &&
-    texts.length > 0 &&
-    typeof texts[0] === "string"
-  ) {
-    if (texts[0].startsWith(warningText)) {
-      const mutatedTexts = texts.slice(0);
-      mutatedTexts[0] = texts[0].substring(warningText.length);
+  if (isWarning) {
+    const elements = childArray.filter((child) =>
+      React.isValidElement(child)
+    ) as ReactElement[];
+    const texts = elements.map((elem) => {
+      const innerChildren = elem.props["children"];
 
-      return <Warning>{mutatedTexts}</Warning>;
-    }
+      if (
+        typeof innerChildren === "string" &&
+        innerChildren.startsWith(warningText)
+      ) {
+        return innerChildren.substring(warningText.length);
+      }
+
+      if (
+        Array.isArray(innerChildren) &&
+        typeof innerChildren[0] === "string"
+      ) {
+        return innerChildren.map((child) => {
+          if (typeof child === "string" && child.startsWith(warningText)) {
+            return child.substring(warningText.length);
+          }
+
+          return child;
+        });
+      }
+
+      return innerChildren;
+    });
+
+    return (
+      <Warning>
+        {texts.map((text, index) => (
+          <p key={index}>{text}</p>
+        ))}
+      </Warning>
+    );
   }
 
   return <blockquote>{children}</blockquote>;

--- a/website/src/components/mdx/code-block.tsx
+++ b/website/src/components/mdx/code-block.tsx
@@ -7,16 +7,19 @@ import { Copy } from "./copy";
 
 export interface CodeBlockProps {
   readonly children: any;
+  readonly language?: Language;
 }
 
-export const CodeBlock: FC<CodeBlockProps> = ({ children }) => {
-  const language = children.props.className.replace(
-    /language-/,
-    ""
-  ) as Language;
-  const meta = children.props.metastring;
+export const CodeBlock: FC<CodeBlockProps> = ({
+  children,
+  language: fallbackLanguage,
+}) => {
+  const language =
+    (children.props?.className?.replace(/language-/, "") as Language) ||
+    fallbackLanguage;
+  const meta = children.props?.metastring;
   const shouldHighlightLine = calculateLinesToHighlight(meta);
-  const code = children.props.children;
+  const code = children.props?.children || children;
 
   return (
     <Container className={`gatsby-highlight code-${language}`}>

--- a/website/src/components/mdx/package-installation.tsx
+++ b/website/src/components/mdx/package-installation.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from "react";
+import { CodeBlock } from "./code-block";
+import { InlineCode } from "./inline-code";
+import { InputChoiceTabs } from "./input-choice-tabs";
+import { Warning } from "./warning";
+
+type Props = {
+  readonly packageName: string;
+  readonly external?: boolean;
+};
+
+export const PackageInstallation: FC<Props> = ({ packageName, external }) => {
+  return (
+    <>
+      <InputChoiceTabs>
+        <InputChoiceTabs.CLI>
+          <CodeBlock
+            language="bash"
+            children={`dotnet add package ${packageName}`}
+          />
+        </InputChoiceTabs.CLI>
+
+        <InputChoiceTabs.VisualStudio>
+          <InputChoiceTabs.VisualStudio>
+            <p>
+              Add the <InlineCode>{packageName}</InlineCode> package using the
+              NuGet Package Manager within Visual Studio.
+            </p>
+
+            <p>
+              <a
+                href="https://docs.microsoft.com/nuget/quickstart/install-and-use-a-package-in-visual-studio#nuget-package-manager"
+                target="_blank"
+              >
+                Learn how you can use the NuGet Package Manager to install a
+                package
+              </a>
+            </p>
+          </InputChoiceTabs.VisualStudio>
+        </InputChoiceTabs.VisualStudio>
+      </InputChoiceTabs>
+
+      {!external && (
+        <Warning>
+          All <InlineCode>HotChocolate.*</InlineCode> packages need to have the
+          same version.
+        </Warning>
+      )}
+    </>
+  );
+};

--- a/website/src/components/mdx/warning.tsx
+++ b/website/src/components/mdx/warning.tsx
@@ -12,6 +12,7 @@ export const Warning: FC<Props> = ({ children }) => {
       <Heading>
         {warningIcon} <span>Warning</span>
       </Heading>
+
       {children}
     </Container>
   );
@@ -24,10 +25,7 @@ const warningIcon = (
     height="16"
     viewBox="0 0 16 16"
   >
-    <path
-      fill-rule="evenodd"
-      d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
-    />
+    <path d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z" />
   </svg>
 );
 
@@ -36,7 +34,6 @@ const Heading = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 10px;
 
   > span {
     margin-bottom: 3px;
@@ -57,22 +54,26 @@ const Container = styled.div`
   color: ${THEME_COLORS.textContrast};
   line-height: 1.4;
 
-  > br {
+  @media only screen and (min-width: 860px) {
+    padding: 20px 50px;
+  }
+
+  br {
     margin-bottom: 16px;
   }
 
-  > a {
+  a {
     color: white !important;
     font-weight: bold;
     text-decoration: underline;
   }
 
-  > code {
+  code {
     border-color: ${THEME_COLORS.textContrast};
     color: ${THEME_COLORS.textContrast};
   }
 
-  @media only screen and (min-width: 860px) {
-    padding: 20px 50px;
+  > p:last-child {
+    margin-bottom: 0;
   }
 `;

--- a/website/src/components/mdx/warning.tsx
+++ b/website/src/components/mdx/warning.tsx
@@ -1,0 +1,78 @@
+import React, { FC, ReactNode } from "react";
+import styled from "styled-components";
+import { THEME_COLORS } from "../../shared-style";
+
+type Props = {
+  readonly children: ReactNode;
+};
+
+export const Warning: FC<Props> = ({ children }) => {
+  return (
+    <Container>
+      <Heading>
+        {warningIcon} <span>Warning</span>
+      </Heading>
+      {children}
+    </Container>
+  );
+};
+
+const warningIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+    />
+  </svg>
+);
+
+const Heading = styled.div`
+  fill: ${THEME_COLORS.textContrast};
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+
+  > span {
+    margin-bottom: 3px;
+
+    font-weight: bold;
+    line-height: normal;
+  }
+
+  > svg {
+    margin-left: 4px;
+    transform: scale(1.3);
+  }
+`;
+
+const Container = styled.div`
+  padding: 20px 20px;
+  background-color: ${THEME_COLORS.warning};
+  color: ${THEME_COLORS.textContrast};
+  line-height: 1.4;
+
+  > br {
+    margin-bottom: 16px;
+  }
+
+  > a {
+    color: white !important;
+    font-weight: bold;
+    text-decoration: underline;
+  }
+
+  > code {
+    border-color: ${THEME_COLORS.textContrast};
+    color: ${THEME_COLORS.textContrast};
+  }
+
+  @media only screen and (min-width: 860px) {
+    padding: 20px 50px;
+  }
+`;

--- a/website/src/docs/hotchocolate/v10/advanced/index.md
+++ b/website/src/docs/hotchocolate/v10/advanced/index.md
@@ -10,9 +10,7 @@ If you want to build GraphQL tooling for .NET or your own type system and query-
 
 In order to use the parser, install the following package:
 
-```bash
-dotnet add package HotChocolate.Language
-```
+<PackageInstallation packageName="HotChocolate.Language" />
 
 In order to parse a GraphQL schema or query use it like the following:
 

--- a/website/src/docs/hotchocolate/v10/data-fetching/filters.md
+++ b/website/src/docs/hotchocolate/v10/data-fetching/filters.md
@@ -65,7 +65,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
 
 In the above example the person resolver just returns the `IQueryable` representing the data source. The `IQueryable` represents a not executed database query on which we are able to apply filters.
 
@@ -191,7 +191,7 @@ query {
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
 
 If you want to combine for instance paging, filtering and sorting make sure that the order is like follows:
 

--- a/website/src/docs/hotchocolate/v10/schema/descriptor-attributes.md
+++ b/website/src/docs/hotchocolate/v10/schema/descriptor-attributes.md
@@ -51,7 +51,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
 
 ## UseSortingAttribute
 
@@ -68,7 +68,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
 
 ## AuthorizeAttribute
 

--- a/website/src/docs/hotchocolate/v10/security/index.md
+++ b/website/src/docs/hotchocolate/v10/security/index.md
@@ -18,9 +18,7 @@ Authorization on the other hand is something Hot Chocolate can provide some valu
 
 But let's start at the beginning with this. In order to add authorization capabilities to our schema add the following package to our project:
 
-```bash
-dotnet add package HotChocolate.AspNetCore.Authorization
-```
+<PackageInstallation packageName="HotChocolate.AspNetCore.Authorization" />
 
 In order to use the `@authorize`-directive we have to register it like the following with our schema:
 

--- a/website/src/docs/hotchocolate/v10/stitching.md
+++ b/website/src/docs/hotchocolate/v10/stitching.md
@@ -146,15 +146,11 @@ With this we have now a functioning GraphQL server with a simple hello world exa
 
 In order to make this server a stitching server we now have to add the Hot Chocolate stitching engine.
 
-```bash
-dotnet add package HotChocolate.Stitching
-```
+<PackageInstallation packageName="HotChocolate.Stitching" />
 
 and Subscription package if using AspNetCore
 
-```bash
-dotnet add package HotChocolate.AspNetCore.Subscriptions
-```
+<PackageInstallation packageName="HotChocolate.AspNetCore.Subscriptions" />
 
 Now that our GraphQL server is ready we can start to configure the endpoints of our remote schemas.
 

--- a/website/src/docs/hotchocolate/v11/api-reference/custom-attributes.md
+++ b/website/src/docs/hotchocolate/v11/api-reference/custom-attributes.md
@@ -52,7 +52,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
 
 ## UseSortingAttribute
 
@@ -69,7 +69,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
 
 ## AuthorizeAttribute
 

--- a/website/src/docs/hotchocolate/v11/api-reference/filtering.md
+++ b/website/src/docs/hotchocolate/v11/api-reference/filtering.md
@@ -152,7 +152,7 @@ public class QueryType
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
 
 If you want to combine for instance paging, filtering, and sorting make sure that the order is like follows:
 
@@ -874,18 +874,18 @@ Hot Chocolate provides different APIs to customize filtering. You can write cust
 
 **As this can be a bit overwhelming the following questionnaire might help:**
 
-|                                                                                                                                         |                                 |
-| --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| _You do not want all the generated filters and only allow a specific set of filters in a specific case?_                                | Custom&nbsp;FilterInputType     |
-| _You want to change the name of a field or a whole type?_                                                                               | Custom&nbsp;FilterInputType     |
-| _You want to change the name of the `where` argument?_                                                                                  | Filter Conventions ArgumentName |
+|                                                                                                                                       |                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| _You do not want all the generated filters and only allow a specific set of filters in a specific case?_                              | Custom&nbsp;FilterInputType     |
+| _You want to change the name of a field or a whole type?_                                                                             | Custom&nbsp;FilterInputType     |
+| _You want to change the name of the `where` argument?_                                                                                | Filter Conventions ArgumentName |
 | _You want to configure how_Hot Chocolate_generates the name and the description of filters in globally? e.g. `PascalCaseFilterType`?_ | Filter&nbsp;Conventions         |
-| _You want to configure what the different types of filters are allowed globally?_                                                       | Filter&nbsp;Conventions         |
-| _Your database provider does not support certain operations of `IQueryable`_                                                            | Filter&nbsp;Conventions         |
-| _You want to change the naming of a specific lar filter type? e.g._ `foo_contains` _should be_ `foo_like`                               | Filter&nbsp;Conventions         |
-| _You want to customize the expression a filter is generating: e.g._ `_equals` _should not be case sensitive?_                           | Expression&nbsp;Visitor&nbsp;   |
-| _You want to create your own filter types with custom parameters and custom expressions? e.g. GeoJson?_                                 | Filter&nbsp;Conventions         |
-| _You have a database client that does not support `IQueryable` and wants to generate filters for it?_                                   | Custom&nbsp;Visitor             |
+| _You want to configure what the different types of filters are allowed globally?_                                                     | Filter&nbsp;Conventions         |
+| _Your database provider does not support certain operations of `IQueryable`_                                                          | Filter&nbsp;Conventions         |
+| _You want to change the naming of a specific lar filter type? e.g._ `foo_contains` _should be_ `foo_like`                             | Filter&nbsp;Conventions         |
+| _You want to customize the expression a filter is generating: e.g._ `_equals` _should not be case sensitive?_                         | Expression&nbsp;Visitor&nbsp;   |
+| _You want to create your own filter types with custom parameters and custom expressions? e.g. GeoJson?_                               | Filter&nbsp;Conventions         |
+| _You have a database client that does not support `IQueryable` and wants to generate filters for it?_                                 | Custom&nbsp;Visitor             |
 
 # Custom&nbsp;FilterInputType
 
@@ -996,7 +996,7 @@ input UserFilter {
 | `csharp±Object<TObject>( Expression<Func<T, TObject>> property)`                 | Defines a object filter for the selected property.                                                                                              |
 | `csharp±List( Expression<Func<T, IEnumerable<string>>> property)`                | Defines an array string filter for the selected property.                                                                                       |
 | `csharp±List( Expression<Func<T, IEnumerable<bool>>> property)`                  | Defines an array bool filter for the selected property.                                                                                         |
-| `csharp±List( Expression<Func<T, IEnumerable<IComparable>>> property)`           | Defines an array comparable filter for the selected property.                                                                                    |
+| `csharp±List( Expression<Func<T, IEnumerable<IComparable>>> property)`           | Defines an array comparable filter for the selected property.                                                                                   |
 | `csharp±Filter<TObject>( Expression<Func<T, IEnumerable<TObject>>> property)`    | Defines an array object filter for the selected property.                                                                                       |
 | `csharp±Directive<TDirective>(TDirective directiveInstance)`                     | Add directive `directiveInstance` to the type                                                                                                   |
 | `csharp±Directive<TDirective>(TDirective directiveInstance)`                     | Add directive of type `TDirective` to the type                                                                                                  |

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/arguments.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/arguments.md
@@ -2,8 +2,6 @@
 title: "Arguments"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 GraphQL allows us to specify arguments on a field and access their values in the field's resolver.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/documentation.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/documentation.md
@@ -2,8 +2,6 @@
 title: Documentation
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Documentation allows us to enrich our schema with additional information that is useful for a consumer of our API.
 
 In GraphQL we can do this by providing descriptions to our types, fields, etc.

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/enums.md
@@ -2,8 +2,6 @@
 title: "Enums"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 An Enum is a special kind of [scalar](/docs/hotchocolate/v11/defining-a-schema/scalars) that is restricted to a particular set of allowed values.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/extending-types.md
@@ -8,7 +8,7 @@ Because of these capabilities, they also allow for better organization of our ty
 
 Type extensions are especially useful if we want to modify third-party types, such as types that live in a separate assembly and are therefore not directly modifiable by us.
 
-> ⚠️ Note: Type extensions do not produce the [extend type syntax that GraphQL offers](http://spec.graphql.org/draft/#sec-Object-Extensions), since it would unnecessarily complicate the resulting schema. Instead, Hot Chocolate's type extensions are directly merged with the original type definition to create a single type at runtime.
+> Warning: Type extensions do not produce the [extend type syntax that GraphQL offers](http://spec.graphql.org/draft/#sec-Object-Extensions), since it would unnecessarily complicate the resulting schema. Instead, Hot Chocolate's type extensions are directly merged with the original type definition to create a single type at runtime.
 
 # Object Types
 

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/extending-types.md
@@ -2,8 +2,6 @@
 title: "Extending Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Type extensions allow us to add, remove or replace fields on existing types, without necessarily needing access to these types.
 
 Because of these capabilities, they also allow for better organization of our types. We could for example have classes that encapsulate part of our domain and extend our `Query` type with these functionalities.

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/input-object-types.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/input-object-types.md
@@ -2,8 +2,6 @@
 title: "Input Object Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 We already looked at [arguments](/docs/hotchocolate/v11/defining-a-schema/arguments), which allow us to use simple [scalars](/docs/hotchocolate/v11/defining-a-schema/scalars) like `String` to pass data into a field. GraphQL defines input object types to allow us to use objects as arguments on our fields.
 
 Input object type definitions differ from [object types](/docs/hotchocolate/v11/defining-a-schema/object-types) only in the used keyword and in that their fields can not have arguments.

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/input-object-types.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/input-object-types.md
@@ -159,7 +159,7 @@ public class Startup
 }
 ```
 
-> ⚠️ Note: Object types nested inside of an input object type need to also be declared as input object types.
+> Warning: Object types nested inside of an input object type need to also be declared as input object types.
 
 </Schema>
 </ExampleTabs>

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/interfaces.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/interfaces.md
@@ -2,8 +2,6 @@
 title: "Interfaces"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 An interface is an abstract type that defines a certain set of fields that an object type or another interface must include to implement the interface.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/lists.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/lists.md
@@ -2,8 +2,6 @@
 title: "Lists"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 GraphQL allows us to return lists of elements from our fields.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/mutations.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/mutations.md
@@ -2,8 +2,6 @@
 title: "Mutations"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The mutation type in GraphQL is used to mutate/change data. This means that when we are doing mutations, we are intending to cause side-effects in the system.
 
 GraphQL defines mutations as top-level fields on the mutation type. Meaning only the fields on the mutation root type itself are mutations. Everything that is returned from a mutation field represents the changed state of the server.

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/non-null.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/non-null.md
@@ -2,8 +2,6 @@
 title: "Non-Null"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Per default all fields on an object type can be either `null` or the specified type.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/object-types.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/object-types.md
@@ -2,8 +2,6 @@
 title: "Object Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The most important type in a GraphQL schema is the object type. It contains fields that can return simple scalars like `String`, `Int`, or again object types.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/queries.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/queries.md
@@ -2,8 +2,6 @@
 title: "Queries"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The query type in GraphQL represents a read-only view of all of our entities and ways to retrieve them. A query type is required for every GraphQL server.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/scalars.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/scalars.md
@@ -2,8 +2,6 @@
 title: "Scalars"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Scalar types are the primitives of our schema and can hold a specific type of data. They are leaf types, meaning we cannot use e.g. `{ fieldname }` to further drill down into the type. The main purpose of a scalar is to define how a value is serialized and deserialized.
 
 Besides basic scalars like `String` and `Int`, we can also create custom scalars like `CreditCardNumber` or `SocialSecurityNumber`. These custom scalars can greatly enhance the expressiveness of our schema and help new developers to get a grasp of our API.

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/scalars.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/scalars.md
@@ -280,9 +280,7 @@ We also offer a separate package with scalars for more specific use cases.
 
 To use these scalars we have to add the `HotChocolate.Types.Scalars` package.
 
-```bash
-dotnet add package HotChocolate.Types.Scalars
-```
+<PackageInstallation packageName="HotChocolate.Types.Scalars" />
 
 **Available Scalars:**
 
@@ -338,9 +336,7 @@ We also offer a package specifically for [NodaTime](https://github.com/nodatime/
 
 It can be installed like the following.
 
-```bash
-dotnet add package HotChocolate.Types.NodaTime
-```
+<PackageInstallation packageName="HotChocolate.Types.NodaTime" />
 
 **Available Scalars:**
 

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/subscriptions.md
@@ -2,8 +2,6 @@
 title: "Subscriptions"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The subscription type in GraphQL is used to add real-time capabilities to our applications. Clients can subscribe to events and receive the event data in real-time, as soon as the server publishes it.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/subscriptions.md
@@ -163,9 +163,7 @@ The Redis subscription provider enables us to run multiple instances of our Hot 
 
 In order to use the Redis provider we have to add the `HotChocolate.Subscriptions.Redis` package.
 
-```bash
-dotnet add package HotChocolate.Subscriptions.Redis
-```
+<PackageInstallation packageName="HotChocolate.Subscriptions.Redis" />
 
 After we have added the package we can setup the Redis subscription provider.
 

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/unions.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/unions.md
@@ -2,8 +2,6 @@
 title: "Unions"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 A union type represents a set of object types. It is very similar to an [interface](/docs/hotchocolate/v11/defining-a-schema/interfaces), except that there is no requirement for common fields between the specified types.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v11/defining-a-schema/versioning.md
+++ b/website/src/docs/hotchocolate/v11/defining-a-schema/versioning.md
@@ -2,8 +2,6 @@
 title: "Versioning"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Whilst we could version our GraphQL API similar to REST, i.e. `/graphql/v1`, it is not a best practice and often unnecessary.
 
 Many changes to a GraphQL schema are non-breaking. We can freely add new types and extend existing types with new fields. This does not break existing queries.

--- a/website/src/docs/hotchocolate/v11/distributed-schema/schema-federations.md
+++ b/website/src/docs/hotchocolate/v11/distributed-schema/schema-federations.md
@@ -14,9 +14,7 @@ With a cache, the gateway schema is also more stable and faster in bootstrapping
 
 You will need to add a package reference to `HotChocolate.Stitching.Redis` to all your services:
 
-```bash
-dotnet add package HotChocolate.Stitching.Redis
-```
+<PackageInstallation packageName="HotChocolate.Stitching.Redis" />
 
 ## Configuration of a domain service
 
@@ -99,9 +97,7 @@ Your schema will expose an additional field. This field is used by the Gateway t
 
 You will need to add a package reference to `HotChocolate.Stitching` to all your services:
 
-```cli
-dotnet add package HotChocolate.Stitching
-```
+<PackageInstallation packageName="HotChocolate.Stitching" />
 
 ## Configuration of a domain service
 

--- a/website/src/docs/hotchocolate/v11/distributed-schema/schema-stitching.md
+++ b/website/src/docs/hotchocolate/v11/distributed-schema/schema-stitching.md
@@ -8,9 +8,7 @@ Hot Chocolate uses the schema name as an identifier for schemas. This schema nam
 
 You will need to add a package reference to `HotChocolate.Stitching` to your gateway:
 
-```bash
-dotnet add package HotChocolate.Stitching
-```
+<PackageInstallation packageName="HotChocolate.Stitching" />
 
 ```csharp
 public static class WellKnownSchemaNames

--- a/website/src/docs/hotchocolate/v11/fetching-data/dataloader.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/dataloader.md
@@ -2,8 +2,6 @@
 title: "DataLoader"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 > If you want to read more about data loaders in general, you can head over to Facebook's [GitHub repository](https://github.com/facebook/dataloader).
 
 Every data fetching technology suffers the _n+1_ problem.

--- a/website/src/docs/hotchocolate/v11/fetching-data/fetching-from-databases.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/fetching-from-databases.md
@@ -2,8 +2,6 @@
 title: "Fetching from Databases"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 In this section, you find a simple example on how you can fetch data from a database and expose it as a GraphQL API.
 
 **Hot Chocolate is not bound to a specific database, pattern or architecture.**

--- a/website/src/docs/hotchocolate/v11/fetching-data/fetching-from-rest.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/fetching-from-rest.md
@@ -2,8 +2,6 @@
 title: "Fetching from REST"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 In this section, we will cover how you can easily integrate a REST API into your GraphQL API.
 
 GraphQL has a strongly-typed type system and therefore also has to know the dotnet runtime types of the data it returns in advance.

--- a/website/src/docs/hotchocolate/v11/fetching-data/fetching-from-rest.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/fetching-from-rest.md
@@ -62,9 +62,7 @@ In this file, you will find the client for your REST API.
 The generated needs `Newtonsoft.Json`.
 Make sure to also add this package by executing:
 
-```bash
-dotnet add package Newtonsoft.Json
-```
+<PackageInstallation packageName="Newtonsoft.Json" external />
 
 # Exposing the API
 

--- a/website/src/docs/hotchocolate/v11/fetching-data/filtering.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/filtering.md
@@ -40,11 +40,9 @@ input StringOperationFilterInput {
 
 # Getting started
 
-Filtering is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Filtering is part of the `HotChocolate.Data` package.
 
-```bash
-dotnet add package HotChocolate.Data
-```
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use filtering you need to register it on the schema:
 

--- a/website/src/docs/hotchocolate/v11/fetching-data/filtering.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/filtering.md
@@ -2,8 +2,6 @@
 title: Filtering
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 With Hot Chocolate filters, you can expose complex filter objects through your GraphQL API that translates to native database queries. The default filter implementation translates filters to expression trees that are applied to `IQueryable`.
 Hot Chocolate by default will inspect your .NET model and infer the possible filter operations from it.
 Filters use `IQueryable` (`IEnumerable`) by default, but you can also easily customize them to use other interfaces.

--- a/website/src/docs/hotchocolate/v11/fetching-data/pagination.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/pagination.md
@@ -2,8 +2,6 @@
 title: "Pagination"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs";
-
 Pagination is one of the most common problems that we have to solve when implementing our backend. Often, sets of data are too large to pass them directly to the consumer of our service.
 
 Pagination solves this problem by giving the consumer the ability to fetch a set in chunks.

--- a/website/src/docs/hotchocolate/v11/fetching-data/projections.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/projections.md
@@ -30,11 +30,9 @@ LEFT JOIN "Address" AS "a" ON "u"."AddressId" = "a"."Id"
 
 # Getting Started
 
-Filtering is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Filtering is part of the `HotChocolate.Data` package.
 
-```bash
-  dotnet add package HotChocolate.Data
-```
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use projections with your GraphQL endpoint you have to register projections on the schema:
 

--- a/website/src/docs/hotchocolate/v11/fetching-data/projections.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/projections.md
@@ -2,8 +2,6 @@
 title: Projections
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Every GraphQL request specifies exactly what data should be returned. Over or under fetching can be reduced
 or even eliminated. Hot Chocolate projections leverage this concept and directly projects incoming queries
 to the database.

--- a/website/src/docs/hotchocolate/v11/fetching-data/resolvers.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/resolvers.md
@@ -2,8 +2,6 @@
 title: "Resolvers"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 When it comes to fetching data in a GraphQL server, it will always come down to a resolver.
 
 **A resolver is a generic function that fetches data from an arbitrary data source for a particular field.**

--- a/website/src/docs/hotchocolate/v11/fetching-data/sorting.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/sorting.md
@@ -54,11 +54,9 @@ enum SortEnumType {
 
 # Getting started
 
-Sorting is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Sorting is part of the `HotChocolate.Data` package.
 
-```bash
-  dotnet add package HotChocolate.Data
-```
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use sorting you need to register it on the schema:
 

--- a/website/src/docs/hotchocolate/v11/fetching-data/sorting.md
+++ b/website/src/docs/hotchocolate/v11/fetching-data/sorting.md
@@ -2,8 +2,6 @@
 title: Sorting
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 # What is sorting
 
 Ordering results of a query dynamically is a common case. With Hot Chocolate sorting, you can expose a sorting argument, that abstracts the complexity of ordering logic.

--- a/website/src/docs/hotchocolate/v11/integrations/entity-framework.md
+++ b/website/src/docs/hotchocolate/v11/integrations/entity-framework.md
@@ -2,8 +2,6 @@
 title: Entity Framework
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The execution engine of Hot Chocolate executes resolvers in parallel. This can lead to exceptions because
 the database context of Entity Framework cannot handle more than one request in parallel.
 So if you are seeing exceptions like `A second operation started on this context before a previous operation completed.`

--- a/website/src/docs/hotchocolate/v11/integrations/entity-framework.md
+++ b/website/src/docs/hotchocolate/v11/integrations/entity-framework.md
@@ -12,11 +12,9 @@ The package was build on the foundation of EntityFramework Core v5.0.0.
 
 # Getting Started
 
-You first need to add the package reference to your project. You can do this with the `dotnet` cli:
+You first need to add the package reference to your project.
 
-```bash
-dotnet add package HotChocolate.Data.EntityFramework
-```
+<PackageInstallation packageName="HotChocolate.Data.EntityFramework" />
 
 The execution engine needs more than one database context. You should register the database context
 in a pool rather than transient. During execution database contexts are taken from this pool and returned

--- a/website/src/docs/hotchocolate/v11/integrations/mongodb.md
+++ b/website/src/docs/hotchocolate/v11/integrations/mongodb.md
@@ -11,9 +11,7 @@ You can find a example project in [Hot Chocolate Examples](https://github.com/Ch
 
 To use the MongoDB integration, you need to install the package `HotChocolate.Data.MongoDb`.
 
-```bash
-dotnet add package HotChocolate.Data.MongoDb
-```
+<PackageInstallation packageName="HotChocolate.Data.MongoDb" />
 
 # MongoExecutable
 

--- a/website/src/docs/hotchocolate/v11/integrations/spatial-data.md
+++ b/website/src/docs/hotchocolate/v11/integrations/spatial-data.md
@@ -20,11 +20,9 @@ can return NetTopologySuite shapes and they will be transformed into GeoJSON.
 
 # Getting Started
 
-You first need to add the package reference to your project. You can do this with the `dotnet` cli:
+You first need to add the package reference to your project.
 
-```bash
-  dotnet add package HotChocolate.Spatial
-```
+<PackageInstallation packageName="HotChocolate.Spatial" />
 
 To make the schema recognize the spatial types you need to register them on the schema builder.
 

--- a/website/src/docs/hotchocolate/v11/performance/automatic-persisted-queries.md
+++ b/website/src/docs/hotchocolate/v11/performance/automatic-persisted-queries.md
@@ -40,9 +40,7 @@ dotnet new graphql
 
 3. Add the in-memory query storage to your project.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.InMemory
-```
+<PackageInstallation packageName="HotChocolate.PersistedQueries.InMemory" />
 
 ## Step 2: Configure automatic persisted queries
 
@@ -227,9 +225,7 @@ docker run --name redis-stitching -p 7000:6379 -d redis
 
 2. Add the Redis persisted query storage package to your server.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.Redis
-```
+<PackageInstallation packageName="HotChocolate.PersistedQueries.Redis" />
 
 3. Next, we need to configure the server to use Redis as query storage.
 

--- a/website/src/docs/hotchocolate/v11/security/authentication.md
+++ b/website/src/docs/hotchocolate/v11/security/authentication.md
@@ -16,9 +16,7 @@ Setting up authentication is largely the same as in any other ASP.NET Core appli
 
 1. Install the `Microsoft.AspNetCore.Authentication.JwtBearer` package
 
-```bash
-dotnet add package Microsoft.AspNetCore.Authentication.JwtBearer
-```
+<PackageInstallation packageName="Microsoft.AspNetCore.Authentication.JwtBearer" external />
 
 2. Register the JWT authentication scheme
 
@@ -47,7 +45,7 @@ public class Startup
 }
 ```
 
-> ⚠️ Note: This is an example configuration that's not intended for use in a real world application.
+> Warning: This is an example configuration that's not intended for use in a real world application.
 
 3. Register the ASP.NET Core authentication middleware with the request pipeline by calling `UseAuthentication`
 
@@ -74,9 +72,7 @@ In order to make the authentication result available to our resolvers, we need t
 
 1. Install the `HotChocolate.AspNetCore.Authorization` package
 
-```bash
-dotnet add package HotChocolate.AspNetCore.Authorization
-```
+<PackageInstallation packageName="HotChocolate.AspNetCore.Authorization" />
 
 2. Call `AddAuthorization()` on the `IRequestExecutorBuilder`
 

--- a/website/src/docs/hotchocolate/v11/security/authentication.md
+++ b/website/src/docs/hotchocolate/v11/security/authentication.md
@@ -2,8 +2,6 @@
 title: Authentication
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Authentication allows us to determine a user's identity. This is of course a prerequisite for authorization, but it also allows us to access the authenticated user in our resolvers. This is useful, if we for example want to build a `me` field that fetches details about the authenticated user.
 
 Hot Chocolate fully embraces the authentication capabilities of ASP.NET Core, making it easy to reuse existing authentication configuration and integrating a variety of authentication providers.

--- a/website/src/docs/hotchocolate/v11/security/authorization.md
+++ b/website/src/docs/hotchocolate/v11/security/authorization.md
@@ -31,7 +31,7 @@ public class Startup
 }
 ```
 
-> ⚠️ Note: We need to call `AddAuthorization()` on the `IServiceCollection`, to register the services needed by ASP.NET Core, and on the `IRequestExecutorBuilder` to register the `@authorize` directive and middleware.
+> Warning: We need to call `AddAuthorization()` on the `IServiceCollection`, to register the services needed by ASP.NET Core, and on the `IRequestExecutorBuilder` to register the `@authorize` directive and middleware.
 
 2. Register the ASP.NET Core authorization middleware with the request pipeline by calling `UseAuthorization`
 
@@ -73,7 +73,7 @@ public class User
 }
 ```
 
-> ⚠️ Note: We need to use the `HotChocolate.AspNetCore.AuthorizationAttribute` instead of the `Microsoft.AspNetCore.AuthorizationAttribute`.
+> Warning: We need to use the `HotChocolate.AspNetCore.AuthorizationAttribute` instead of the `Microsoft.AspNetCore.AuthorizationAttribute`.
 
 </Annotation>
 <Code>
@@ -161,7 +161,7 @@ type User @authorize(roles: [ "Guest", "Administrator" ]) {
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: If multiple roles are specified, a user only has to match one of the specified roles, in order to be able to execute the resolver.
+> Warning: If multiple roles are specified, a user only has to match one of the specified roles, in order to be able to execute the resolver.
 
 [Learn more about role-based authorization in ASP.NET Core](https://docs.microsoft.com/aspnet/core/security/authorization/roles)
 
@@ -331,7 +331,7 @@ public class Startup
 }
 ```
 
-> ⚠️ Note: This will also block unauthenticated access to GraphQL IDEs hosted on that endpoint, like Banana Cake Pop.
+> Warning: This will also block unauthenticated access to GraphQL IDEs hosted on that endpoint, like Banana Cake Pop.
 
 This method also accepts [roles](#roles) and [policies](#policies) as arguments, similar to the `Authorize` attribute / methods.
 

--- a/website/src/docs/hotchocolate/v11/security/authorization.md
+++ b/website/src/docs/hotchocolate/v11/security/authorization.md
@@ -2,8 +2,6 @@
 title: Authorization
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Authorization allows us to determine a user's permissions within our system. We can for example limit access to resources or only allow certain users to execute specific mutations.
 
 Authentication is a prerequisite of Authorization, as we first need to validate a user's "authenticity" before we can evaluate his authorization claims.

--- a/website/src/docs/hotchocolate/v12/api-reference/custom-attributes.md
+++ b/website/src/docs/hotchocolate/v12/api-reference/custom-attributes.md
@@ -52,7 +52,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
 
 ## UseSortingAttribute
 
@@ -69,7 +69,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
 
 ## AuthorizeAttribute
 

--- a/website/src/docs/hotchocolate/v12/api-reference/filtering.md
+++ b/website/src/docs/hotchocolate/v12/api-reference/filtering.md
@@ -152,7 +152,7 @@ public class QueryType
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
 
 If you want to combine for instance paging, filtering, and sorting make sure that the order is like follows:
 
@@ -874,18 +874,18 @@ Hot Chocolate provides different APIs to customize filtering. You can write cust
 
 **As this can be a bit overwhelming the following questionnaire might help:**
 
-|                                                                                                                                         |                                 |
-| --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| _You do not want all the generated filters and only allow a specific set of filters in a specific case?_                                | Custom&nbsp;FilterInputType     |
-| _You want to change the name of a field or a whole type?_                                                                               | Custom&nbsp;FilterInputType     |
-| _You want to change the name of the `where` argument?_                                                                                  | Filter Conventions ArgumentName |
+|                                                                                                                                       |                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| _You do not want all the generated filters and only allow a specific set of filters in a specific case?_                              | Custom&nbsp;FilterInputType     |
+| _You want to change the name of a field or a whole type?_                                                                             | Custom&nbsp;FilterInputType     |
+| _You want to change the name of the `where` argument?_                                                                                | Filter Conventions ArgumentName |
 | _You want to configure how_Hot Chocolate_generates the name and the description of filters in globally? e.g. `PascalCaseFilterType`?_ | Filter&nbsp;Conventions         |
-| _You want to configure what the different types of filters are allowed globally?_                                                       | Filter&nbsp;Conventions         |
-| _Your database provider does not support certain operations of `IQueryable`_                                                            | Filter&nbsp;Conventions         |
-| _You want to change the naming of a specific lar filter type? e.g._ `foo_contains` _should be_ `foo_like`                               | Filter&nbsp;Conventions         |
-| _You want to customize the expression a filter is generating: e.g._ `_equals` _should not be case sensitive?_                           | Expression&nbsp;Visitor&nbsp;   |
-| _You want to create your own filter types with custom parameters and custom expressions? e.g. GeoJson?_                                 | Filter&nbsp;Conventions         |
-| _You have a database client that does not support `IQueryable` and wants to generate filters for it?_                                   | Custom&nbsp;Visitor             |
+| _You want to configure what the different types of filters are allowed globally?_                                                     | Filter&nbsp;Conventions         |
+| _Your database provider does not support certain operations of `IQueryable`_                                                          | Filter&nbsp;Conventions         |
+| _You want to change the naming of a specific lar filter type? e.g._ `foo_contains` _should be_ `foo_like`                             | Filter&nbsp;Conventions         |
+| _You want to customize the expression a filter is generating: e.g._ `_equals` _should not be case sensitive?_                         | Expression&nbsp;Visitor&nbsp;   |
+| _You want to create your own filter types with custom parameters and custom expressions? e.g. GeoJson?_                               | Filter&nbsp;Conventions         |
+| _You have a database client that does not support `IQueryable` and wants to generate filters for it?_                                 | Custom&nbsp;Visitor             |
 
 # Custom&nbsp;FilterInputType
 
@@ -996,7 +996,7 @@ input UserFilter {
 | `csharp±Object<TObject>( Expression<Func<T, TObject>> property)`                 | Defines a object filter for the selected property.                                                                                              |
 | `csharp±List( Expression<Func<T, IEnumerable<string>>> property)`                | Defines an array string filter for the selected property.                                                                                       |
 | `csharp±List( Expression<Func<T, IEnumerable<bool>>> property)`                  | Defines an array bool filter for the selected property.                                                                                         |
-| `csharp±List( Expression<Func<T, IEnumerable<IComparable>>> property)`           | Defines an array comparable filter for the selected property.                                                                                    |
+| `csharp±List( Expression<Func<T, IEnumerable<IComparable>>> property)`           | Defines an array comparable filter for the selected property.                                                                                   |
 | `csharp±Filter<TObject>( Expression<Func<T, IEnumerable<TObject>>> property)`    | Defines an array object filter for the selected property.                                                                                       |
 | `csharp±Directive<TDirective>(TDirective directiveInstance)`                     | Add directive `directiveInstance` to the type                                                                                                   |
 | `csharp±Directive<TDirective>(TDirective directiveInstance)`                     | Add directive of type `TDirective` to the type                                                                                                  |

--- a/website/src/docs/hotchocolate/v12/api-reference/migrate-from-11-to-12.md
+++ b/website/src/docs/hotchocolate/v12/api-reference/migrate-from-11-to-12.md
@@ -234,7 +234,7 @@ sevices
 
 If you just want to enable the feature without further configuration, you can omit the `options =>` action.
 
-> ⚠️ Note: Since `EnableRelaySupport()` previously always implied the usage of Global Object Identification, you might have to enable Global Object Identification separately as well.
+> Warning: Since `EnableRelaySupport()` previously always implied the usage of Global Object Identification, you might have to enable Global Object Identification separately as well.
 
 [Learn more about Query field in Mutation payloads](/docs/hotchocolate/v12/defining-a-schema/relay#query-field-in-mutation-payloads)
 
@@ -294,7 +294,7 @@ services
     .AddGraphQLServer()
     .AddConvention<INamingConventions>(sp => new CustomNamingConventions()) // or
     .AddConvention<INamingConventions, CustomNamingConventions>();
-```  
+```
 
 **v12**
 
@@ -305,7 +305,7 @@ public class CustomNamingConventions : DefaultNamingConventions
         : base(documentationProvider) { }
 }
 
-IReadOnlySchemaOptions capturedSchemaOptions;  
+IReadOnlySchemaOptions capturedSchemaOptions;
 services
     .AddGraphQLServer()
     .ModifyOptions(opt => capturedSchemaOptions = opt)
@@ -313,11 +313,11 @@ services
         new XmlDocumentationProvider(
             new XmlDocumentationFileResolver(
                 capturedSchemaOptions.ResolveXmlDocumentationFileName),
-            sp.GetApplicationService<ObjectPool<StringBuilder>>() 
+            sp.GetApplicationService<ObjectPool<StringBuilder>>()
                 ?? new NoOpStringBuilderPool())));
-```  
+```
 
 # Miscellaneous
 
-* `IObjectField`
-  * If you were using `IObjectField.Member`, you'll likely want to move to `IObjectField.ResolverMember` (as `.Member` can be `null` in some cases now where it previously wasn't; and `.ResolverMember` will fall back to `.Member`).
+- `IObjectField`
+  - If you were using `IObjectField.Member`, you'll likely want to move to `IObjectField.ResolverMember` (as `.Member` can be `null` in some cases now where it previously wasn't; and `.ResolverMember` will fall back to `.Member`).

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/arguments.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/arguments.md
@@ -2,8 +2,6 @@
 title: "Arguments"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 GraphQL allows us to specify arguments on a field and access their values in the field's resolver.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/documentation.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/documentation.md
@@ -2,8 +2,6 @@
 title: Documentation
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Documentation allows us to enrich our schema with additional information that is useful for a consumer of our API.
 
 In GraphQL we can do this by providing descriptions to our types, fields, etc.

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/enums.md
@@ -238,7 +238,7 @@ services
     });
 ```
 
-> ⚠️ Note: This changes the binding behavior for all types, not only enum types.
+> Warning: This changes the binding behavior for all types, not only enum types.
 
 We can also override it on a per type basis:
 

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/enums.md
@@ -2,8 +2,6 @@
 title: "Enums"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 An Enum is a special kind of [scalar](/docs/hotchocolate/v12/defining-a-schema/scalars) that is restricted to a particular set of allowed values. It can be used as both an input and an output type.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/extending-types.md
@@ -12,7 +12,7 @@ Type extensions are especially useful if we want to modify third-party types, su
 src="https://www.youtube.com/embed/EHTr4Fq6GlA"frameborder="0"
 allowfullscreen></iframe>
 
-> ⚠️ Note: Type extensions do not produce the [extend type syntax that GraphQL offers](http://spec.graphql.org/draft/#sec-Object-Extensions), since it would unnecessarily complicate the resulting schema. Instead, Hot Chocolate's type extensions are directly merged with the original type definition to create a single type at runtime.
+> Warning: Type extensions do not produce the [extend type syntax that GraphQL offers](http://spec.graphql.org/draft/#sec-Object-Extensions), since it would unnecessarily complicate the resulting schema. Instead, Hot Chocolate's type extensions are directly merged with the original type definition to create a single type at runtime.
 
 # Object Types
 

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/extending-types.md
@@ -2,8 +2,6 @@
 title: "Extending Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Type extensions allow us to add, remove or replace fields on existing types, without necessarily needing access to these types.
 
 Because of these capabilities, they also allow for better organization of our types. We could for example have classes that encapsulate part of our domain and extend our `Query` type with these functionalities.

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/input-object-types.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/input-object-types.md
@@ -224,7 +224,7 @@ public record BookInput([property:DefaultValue("")]Optional<string> Title, strin
 
 `Oneof` Input Objects are a special variant of Input Objects where the type system asserts that exactly one of the fields must be set and non-null, all others being omitted. This is represented in introspection with the \_\_Type.oneField: Boolean field, and in SDL via the @oneOf directive on the input object.
 
-> ⚠️ Note: `Oneof` Input Objects is currently a draft feature to the GraphQL spec. <https://github.com/graphql/graphql-spec/pull/825>
+> Warning: `Oneof` Input Objects is currently a draft feature to the GraphQL spec. <https://github.com/graphql/graphql-spec/pull/825>
 
 <iframe width="560" height="315"
 src="https://www.youtube.com/embed/tztXm15grU0"frameborder="0"

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/input-object-types.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/input-object-types.md
@@ -2,8 +2,6 @@
 title: "Input Object Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 We already looked at [arguments](/docs/hotchocolate/v12/defining-a-schema/arguments), which allow us to use simple [scalars](/docs/hotchocolate/v12/defining-a-schema/scalars) like `String` to pass data into a field. GraphQL defines input object types to allow us to use objects as arguments on our fields.
 
 Input object type definitions differ from [object types](/docs/hotchocolate/v12/defining-a-schema/object-types) only in the used keyword and in that their fields can not have arguments.

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/interfaces.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/interfaces.md
@@ -2,8 +2,6 @@
 title: "Interfaces"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 An interface is an abstract type that defines a certain set of fields that an object type or another interface must include to implement the interface. Interfaces can only be used as output types, meaning we can't use interfaces as arguments or as fields on input object types.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/interfaces.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/interfaces.md
@@ -270,7 +270,7 @@ services
     });
 ```
 
-> ⚠️ Note: This changes the binding behavior for all types, not only interface types.
+> Warning: This changes the binding behavior for all types, not only interface types.
 
 We can also override it on a per type basis:
 

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/lists.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/lists.md
@@ -2,8 +2,6 @@
 title: "Lists"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 GraphQL allows us to return lists of elements from our fields.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/mutations.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/mutations.md
@@ -2,8 +2,6 @@
 title: "Mutations"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The mutation type in GraphQL is used to mutate/change data. This means that when we are doing mutations, we are intending to cause side-effects in the system.
 
 GraphQL defines mutations as top-level fields on the mutation type. Meaning only the fields on the mutation root type itself are mutations. Everything that is returned from a mutation field represents the changed state of the server.

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/mutations.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/mutations.md
@@ -135,7 +135,7 @@ public class Startup
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: Only **one** mutation type can be registered using `AddMutationType()`. If we want to split up our mutation type into multiple classes, we can do so using type extensions.
+> Warning: Only **one** mutation type can be registered using `AddMutationType()`. If we want to split up our mutation type into multiple classes, we can do so using type extensions.
 >
 > [Learn more about extending types](/docs/hotchocolate/v12/defining-a-schema/extending-types)
 

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/non-null.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/non-null.md
@@ -2,8 +2,6 @@
 title: "Non-Null"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Per default all fields on an object type can be either `null` or the specified type.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/object-types.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/object-types.md
@@ -144,7 +144,7 @@ services
     });
 ```
 
-> ⚠️ Note: This changes the binding behavior for all types, not only object types.
+> Warning: This changes the binding behavior for all types, not only object types.
 
 We can also override it on a per type basis:
 

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/object-types.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/object-types.md
@@ -2,8 +2,6 @@
 title: "Object Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The most important type in a GraphQL schema is the object type. It contains fields that can return simple scalars like `String`, `Int`, or again object types.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/queries.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/queries.md
@@ -2,8 +2,6 @@
 title: "Queries"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The query type in GraphQL represents a read-only view of all of our entities and ways to retrieve them. A query type is required for every GraphQL server.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/queries.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/queries.md
@@ -138,7 +138,7 @@ public class Startup
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: Only **one** query type can be registered using `AddQueryType()`. If we want to split up our query type into multiple classes, we can do so using type extensions.
+> Warning: Only **one** query type can be registered using `AddQueryType()`. If we want to split up our query type into multiple classes, we can do so using type extensions.
 >
 > [Learn more about extending types](/docs/hotchocolate/v12/defining-a-schema/extending-types)
 

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/relay.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/relay.md
@@ -2,8 +2,6 @@
 title: "Relay"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 > Note: Even though they originated in Relay, the design principles described in this document are not exclusive to Relay. They lead to an overall better schema design, which is why we recommend them to **all** users of Hot Chocolate.
 
 [Relay](https://relay.dev) is a JavaScript framework for building data-driven React applications with GraphQL, which is developed and used by _Facebook_.

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/relay.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/relay.md
@@ -240,7 +240,7 @@ public class Startup
 
 This registers the `Node` interface type and adds the `node(id: ID!): Node` and the `nodes(ids: [ID!]!): [Node]!` field to our query type. At least one type in our schema needs to implement the `Node` interface or an exception is raised.
 
-> ⚠️ Note: Using `AddGlobalObjectIdentification()` in two upstream stitched services does currently not work out of the box.
+> Warning: Using `AddGlobalObjectIdentification()` in two upstream stitched services does currently not work out of the box.
 
 Next we need to extend our object types with the `Global Object Identification` functionality. Therefore 3 criteria need to be fulfilled:
 
@@ -375,7 +375,7 @@ public class ProductType : ObjectType<Product>
 }
 ```
 
-> ⚠️ Note: When using middleware such as `UseDbContext` it needs to be chained after the `ResolveNode` call. The order of middleware still matters.
+> Warning: When using middleware such as `UseDbContext` it needs to be chained after the `ResolveNode` call. The order of middleware still matters.
 
 If the `Id` property of our class is not called `id`, we can either [rename it](/docs/hotchocolate/v12/defining-a-schema/object-types#naming) or specify it through the `IdField` method on the `IObjectTypeDescriptor`. Hot Chocolate will then automatically rename this property to `id` in the schema to properly implement the contract of the `Node` interface.
 
@@ -543,4 +543,4 @@ services
 
 This would add a field of type `Query` with the name of `rootQuery` to each top-level mutation field type, whose name ends in `Result`.
 
-> ⚠️ Note: This feature currently doesn't work on a stitching gateway, however this will be addressed in a future release focused on stitching. It's tracked as [#3158](https://github.com/ChilliCream/hotchocolate/issues/3158).
+> Warning: This feature currently doesn't work on a stitching gateway, however this will be addressed in a future release focused on stitching. It's tracked as [#3158](https://github.com/ChilliCream/hotchocolate/issues/3158).

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/scalars.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/scalars.md
@@ -301,11 +301,7 @@ We also offer a separate package with scalars for more specific use cases.
 
 To use these scalars we have to add the `HotChocolate.Types.Scalars` package.
 
-```bash
-dotnet add package HotChocolate.Types.Scalars
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Types.Scalars" />
 
 **Available Scalars:**
 
@@ -363,11 +359,7 @@ We also offer a package specifically for [NodaTime](https://github.com/nodatime/
 
 It can be installed like the following.
 
-```bash
-dotnet add package HotChocolate.Types.NodaTime
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Types.NodaTime" />
 
 **Available Scalars:**
 

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/scalars.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/scalars.md
@@ -2,8 +2,6 @@
 title: "Scalars"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Scalar types are the primitives of our schema and can hold a specific type of data. They are leaf types, meaning we cannot use e.g. `{ fieldname }` to further drill down into the type. The main purpose of a scalar is to define how a value is serialized and deserialized.
 
 Besides basic scalars like `String` and `Int`, we can also create custom scalars like `CreditCardNumber` or `SocialSecurityNumber`. These custom scalars can greatly enhance the expressiveness of our schema and help new developers to get a grasp of our API.

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/subscriptions.md
@@ -124,7 +124,7 @@ public class Startup
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: Only **one** subscription type can be registered using `AddSubscriptionType()`. If we want to split up our subscription type into multiple classes, we can do so using type extensions.
+> Warning: Only **one** subscription type can be registered using `AddSubscriptionType()`. If we want to split up our subscription type into multiple classes, we can do so using type extensions.
 >
 > [Learn more about extending types](/docs/hotchocolate/v12/defining-a-schema/extending-types)
 
@@ -171,11 +171,7 @@ The Redis subscription provider enables us to run multiple instances of our Hot 
 
 In order to use the Redis provider we have to add the `HotChocolate.Subscriptions.Redis` package.
 
-```bash
-dotnet add package HotChocolate.Subscriptions.Redis
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Subscriptions.Redis" />
 
 After we have added the package we can setup the Redis subscription provider.
 

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/subscriptions.md
@@ -2,8 +2,6 @@
 title: "Subscriptions"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The subscription type in GraphQL is used to add real-time capabilities to our applications. Clients can subscribe to events and receive the event data in real-time, as soon as the server publishes it.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/unions.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/unions.md
@@ -2,8 +2,6 @@
 title: "Unions"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 A union type represents a set of object types. It is very similar to an [interface](/docs/hotchocolate/v12/defining-a-schema/interfaces), except that there is no requirement for common fields between the specified types.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v12/defining-a-schema/versioning.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/versioning.md
@@ -2,8 +2,6 @@
 title: "Versioning"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Whilst we could version our GraphQL API similar to REST, i.e. `/graphql/v1`, it is not a best practice and often unnecessary.
 
 Many changes to a GraphQL schema are non-breaking. We can freely add new types and extend existing types with new fields. This does not break existing queries.

--- a/website/src/docs/hotchocolate/v12/distributed-schema/schema-federations.md
+++ b/website/src/docs/hotchocolate/v12/distributed-schema/schema-federations.md
@@ -14,11 +14,7 @@ With a cache, the gateway schema is also more stable and faster in bootstrapping
 
 You will need to add a package reference to `HotChocolate.Stitching.Redis` to all your services:
 
-```bash
-dotnet add package HotChocolate.Stitching.Redis
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Stitching.Redis" />
 
 ## Configuration of a domain service
 
@@ -101,11 +97,7 @@ Your schema will expose an additional field. This field is used by the Gateway t
 
 You will need to add a package reference to `HotChocolate.Stitching` to all your services:
 
-```cli
-dotnet add package HotChocolate.Stitching
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Stitching" />
 
 ## Configuration of a domain service
 

--- a/website/src/docs/hotchocolate/v12/distributed-schema/schema-stitching.md
+++ b/website/src/docs/hotchocolate/v12/distributed-schema/schema-stitching.md
@@ -8,11 +8,7 @@ Hot Chocolate uses the schema name as an identifier for schemas. This schema nam
 
 You will need to add a package reference to `HotChocolate.Stitching` to your gateway:
 
-```bash
-dotnet add package HotChocolate.Stitching
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Stitching" />
 
 ```csharp
 public static class WellKnownSchemaNames

--- a/website/src/docs/hotchocolate/v12/distributed-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v12/distributed-schema/subscriptions.md
@@ -6,7 +6,7 @@ A Subscription type cannot be stitched from downstream services so it must be de
 
 > [Learn more about defining a Subscription type](/docs/hotchocolate/v12/defining-a-schema/subscriptions)
 
-> ⚠️ Note: Subscription stitching is coming in v13
+> Warning: Subscription stitching is coming in v13
 
 After adding a Subscription type to the gateway service, you may encounter an error when building the gateway schema.
 

--- a/website/src/docs/hotchocolate/v12/fetching-data/dataloader.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/dataloader.md
@@ -2,8 +2,6 @@
 title: "DataLoader"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 > If you want to read more about data loaders in general, you can head over to Facebook's [GitHub repository](https://github.com/facebook/dataloader).
 
 Every data fetching technology suffers the _n+1_ problem.

--- a/website/src/docs/hotchocolate/v12/fetching-data/fetching-from-databases.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/fetching-from-databases.md
@@ -2,8 +2,6 @@
 title: "Fetching from Databases"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 In this section, you find a simple example on how you can fetch data from a database and expose it as a GraphQL API.
 
 **Hot Chocolate is not bound to a specific database, pattern or architecture.**

--- a/website/src/docs/hotchocolate/v12/fetching-data/fetching-from-rest.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/fetching-from-rest.md
@@ -2,8 +2,6 @@
 title: "Fetching from REST"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 In this section, we will cover how you can easily integrate a REST API into your GraphQL API.
 
 If you want to have an outlook into the upcoming native REST integration with Hot Chocolate 13 you can head over to YouTube and have a look.

--- a/website/src/docs/hotchocolate/v12/fetching-data/fetching-from-rest.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/fetching-from-rest.md
@@ -69,9 +69,7 @@ In this file, you will find the client for your REST API.
 The generated needs `Newtonsoft.Json`.
 Make sure to also add this package by executing:
 
-```bash
-dotnet add package Newtonsoft.Json
-```
+<PackageInstallation packageName="Newtonsoft.Json" external />
 
 # Exposing the API
 

--- a/website/src/docs/hotchocolate/v12/fetching-data/filtering.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/filtering.md
@@ -40,13 +40,9 @@ input StringOperationFilterInput {
 
 # Getting started
 
-Filtering is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Filtering is part of the `HotChocolate.Data` package.
 
-```bash
-dotnet add package HotChocolate.Data
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use filtering you need to register it on the schema:
 

--- a/website/src/docs/hotchocolate/v12/fetching-data/filtering.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/filtering.md
@@ -2,8 +2,6 @@
 title: Filtering
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 With Hot Chocolate filters, you can expose complex filter objects through your GraphQL API that translates to native database queries. The default filter implementation translates filters to expression trees that are applied to `IQueryable`.
 Hot Chocolate by default will inspect your .NET model and infer the possible filter operations from it.
 Filters use `IQueryable` (`IEnumerable`) by default, but you can also easily customize them to use other interfaces.

--- a/website/src/docs/hotchocolate/v12/fetching-data/pagination.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/pagination.md
@@ -2,8 +2,6 @@
 title: "Pagination"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs";
-
 Pagination is one of the most common problems that we have to solve when implementing our backend. Often, sets of data are too large to pass them directly to the consumer of our service.
 
 Pagination solves this problem by giving the consumer the ability to fetch a set in chunks.

--- a/website/src/docs/hotchocolate/v12/fetching-data/projections.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/projections.md
@@ -30,13 +30,9 @@ LEFT JOIN "Address" AS "a" ON "u"."AddressId" = "a"."Id"
 
 # Getting Started
 
-Filtering is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Filtering is part of the `HotChocolate.Data` package.
 
-```bash
-dotnet add package HotChocolate.Data
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use projections with your GraphQL endpoint you have to register projections on the schema:
 

--- a/website/src/docs/hotchocolate/v12/fetching-data/projections.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/projections.md
@@ -2,8 +2,6 @@
 title: Projections
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Every GraphQL request specifies exactly what data should be returned. Over or under fetching can be reduced
 or even eliminated. Hot Chocolate projections leverage this concept and directly projects incoming queries
 to the database.

--- a/website/src/docs/hotchocolate/v12/fetching-data/resolvers.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/resolvers.md
@@ -2,8 +2,6 @@
 title: "Resolvers"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 When it comes to fetching data in a GraphQL server, it will always come down to a resolver.
 
 **A resolver is a generic function that fetches data from an arbitrary data source for a particular field.**

--- a/website/src/docs/hotchocolate/v12/fetching-data/sorting.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/sorting.md
@@ -54,13 +54,9 @@ enum SortEnumType {
 
 # Getting started
 
-Sorting is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Sorting is part of the `HotChocolate.Data` package.
 
-```bash
-dotnet add package HotChocolate.Data
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use sorting you need to register it on the schema:
 

--- a/website/src/docs/hotchocolate/v12/fetching-data/sorting.md
+++ b/website/src/docs/hotchocolate/v12/fetching-data/sorting.md
@@ -2,8 +2,6 @@
 title: Sorting
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 # What is sorting
 
 Ordering results of a query dynamically is a common case. With Hot Chocolate sorting, you can expose a sorting argument that abstracts the complexity of ordering logic.

--- a/website/src/docs/hotchocolate/v12/get-started.md
+++ b/website/src/docs/hotchocolate/v12/get-started.md
@@ -42,24 +42,7 @@ Create a new project from within Visual Studio using the "ASP.NET Core Empty" te
 
 This package includes everything that's needed to get your GraphQL server up and running.
 
-<InputChoiceTabs>
-<InputChoiceTabs.CLI>
-
-```bash
-dotnet add package HotChocolate.AspNetCore
-```
-
-</InputChoiceTabs.CLI>
-<InputChoiceTabs.VisualStudio>
-
-You can add the `HotChocolate.AspNetCore` package using the NuGet Package Manager within Visual Studio.
-
-[Learn how you can use the NuGet Package Manager to install a package](https://docs.microsoft.com/nuget/quickstart/install-and-use-a-package-in-visual-studio#nuget-package-manager)
-
-</InputChoiceTabs.VisualStudio>
-</InputChoiceTabs>
-
-> ⚠️ Note: Additional `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.AspNetCore" />
 
 ## 3. Define the types
 

--- a/website/src/docs/hotchocolate/v12/integrations/entity-framework.md
+++ b/website/src/docs/hotchocolate/v12/integrations/entity-framework.md
@@ -2,8 +2,6 @@
 title: Entity Framework Core
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 [Entity Framework Core](https://docs.microsoft.com/ef/core/) is a powerful object-relational mapping framework that has become a staple when working with SQL-based Databases in .NET Core applications.
 
 When working with Entity Framework Core's [DbContext](https://docs.microsoft.com/dotnet/api/system.data.entity.dbcontext), it is most commonly registered as a scoped service.

--- a/website/src/docs/hotchocolate/v12/integrations/entity-framework.md
+++ b/website/src/docs/hotchocolate/v12/integrations/entity-framework.md
@@ -54,11 +54,7 @@ Since this is a lot of code to write, just to inject a `DbContext`, you can use 
 
 In order to simplify the injection of a `DbContext` we have introduced a method called `RegisterDbContext<T>`, similar to the [`RegisterService<T>`](/docs/hotchocolate/v12/server/dependency-injection#registerservice) method for regular services. This method is part of the `HotChocolate.Data.EntityFramework` package, which you'll have to install.
 
-```bash
-dotnet add package HotChocolate.Data.EntityFramework
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data.EntityFramework" />
 
 Once installed you can simply call the `RegisterDbContext<T>` method on the `IRequestExecutorBuilder`. The Hot Chocolate Resolver Compiler will then take care of correctly injecting your scoped `DbContext` instance into your resolvers and also ensuring that the resolvers using it are never run in parallel.
 
@@ -80,7 +76,7 @@ public class Query
 }
 ```
 
-> ⚠️ Note: You still have to register your `DbContext` in the actual dependency injection container, by calling `services.AddDbContext<T>`. `RegisterDbContext<T>` on its own is not enough.
+> Warning: You still have to register your `DbContext` in the actual dependency injection container, by calling `services.AddDbContext<T>`. `RegisterDbContext<T>` on its own is not enough.
 
 You can also specify a [DbContextKind](#dbcontextkind) as argument to the `RegisterDbContext<T>` method, to change how the `DbContext` should be injected.
 
@@ -168,7 +164,7 @@ public class FooByIdDataLoader : BatchDataLoader<string, Foo>
 }
 ```
 
-> ⚠️ Note: It is important that you dispose the `DbContext` to return it to the pool. In the above example we are using `await using` to dispose the `DbContext` after it is no longer required.
+> Warning: It is important that you dispose the `DbContext` to return it to the pool. In the above example we are using `await using` to dispose the `DbContext` after it is no longer required.
 
 ## Services
 
@@ -212,4 +208,4 @@ public class FooService : IAsyncDisposable
 }
 ```
 
-> ⚠️ Note: It is important that you dispose the `DbContext` to return it to the pool, once your transient service is being disposed. In the above example we are implementing `IAsyncDisposable` and disposing the created `DbContext` in the `DisposeAsync` method. This method will be invoked by the dependency injection system.
+> Warning: It is important that you dispose the `DbContext` to return it to the pool, once your transient service is being disposed. In the above example we are implementing `IAsyncDisposable` and disposing the created `DbContext` in the `DisposeAsync` method. This method will be invoked by the dependency injection system.

--- a/website/src/docs/hotchocolate/v12/integrations/mongodb.md
+++ b/website/src/docs/hotchocolate/v12/integrations/mongodb.md
@@ -11,11 +11,7 @@ You can find a example project in [Hot Chocolate Examples](https://github.com/Ch
 
 To use the MongoDB integration, you need to install the package `HotChocolate.Data.MongoDb`.
 
-```bash
-dotnet add package HotChocolate.Data.MongoDb
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data.MongoDb" />
 
 # MongoExecutable
 

--- a/website/src/docs/hotchocolate/v12/integrations/neo4j.md
+++ b/website/src/docs/hotchocolate/v12/integrations/neo4j.md
@@ -11,11 +11,7 @@ You can find a example project in [HotChocolate Examples](https://github.com/Chi
 
 To use the Neo4J integration, you need to install the package `HotChocolate.Data.Neo4J`.
 
-```bash
-dotnet add package HotChocolate.Data.Neo4J
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data.Neo4J" />
 
 # Neo4JExecutable
 

--- a/website/src/docs/hotchocolate/v12/integrations/spatial-data.md
+++ b/website/src/docs/hotchocolate/v12/integrations/spatial-data.md
@@ -20,13 +20,9 @@ can return NetTopologySuite shapes and they will be transformed into GeoJSON.
 
 # Getting Started
 
-You first need to add the `HotChocolate.Spatial` package reference to your project. You can do this with the `dotnet` cli:
+You first need to add the `HotChocolate.Spatial` package reference to your project.
 
-```bash
-dotnet add package HotChocolate.Spatial
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Spatial" />
 
 To make the schema recognize the spatial types you need to register them on the schema builder.
 
@@ -38,9 +34,7 @@ services
 
 If you are using our data extensions to project data from a database you also need to add the package `HotChocolate.Data.Spatial` to your project.
 
-```bash
-dotnet add package HotChocolate.Data.Spatial
-```
+<PackageInstallation packageName="HotChocolate.Data.Spatial" />
 
 In order to use the data extensions in your resolvers you need to register them with the GraphQL configuration builder.
 

--- a/website/src/docs/hotchocolate/v12/performance/automatic-persisted-queries.md
+++ b/website/src/docs/hotchocolate/v12/performance/automatic-persisted-queries.md
@@ -40,11 +40,7 @@ dotnet new graphql
 
 3. Add the in-memory query storage to your project.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.InMemory
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.PersistedQueries.InMemory" />
 
 ## Step 2: Configure automatic persisted queries
 
@@ -229,11 +225,7 @@ docker run --name redis-stitching -p 7000:6379 -d redis
 
 2. Add the Redis persisted query storage package to your server.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.Redis
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.PersistedQueries.Redis" />
 
 3. Next, we need to configure the server to use Redis as query storage.
 

--- a/website/src/docs/hotchocolate/v12/performance/persisted-queries.md
+++ b/website/src/docs/hotchocolate/v12/performance/persisted-queries.md
@@ -57,11 +57,7 @@ Hot Chocolate supports two query storages for regular persisted queries.
 
 To load persisted queries from the filesystem, we have to add the following package.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.FileSystem
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.PersistedQueries.FileSystem" />
 
 After this we need to specify where the persisted queries are located. The argument of `AddReadOnlyFileSystemQueryStorage()` specifies the directory in which the persisted queries are stored.
 
@@ -82,17 +78,13 @@ Example: `0c95d31ca29272475bf837f944f4e513.graphql`
 
 This file is expected to contain the query the hash was generated from.
 
-> ⚠️ Note: Do not forget to ensure that the server has access to the directory.
+> Warning: Do not forget to ensure that the server has access to the directory.
 
 ### Redis
 
 To load persisted queries from Redis, we have to add the following package.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.Redis
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.PersistedQueries.Redis" />
 
 After this we need to specify where the persisted queries are located. Using `AddReadOnlyRedisQueryStorage()` we can point to a specific Redis database in which the persisted queries are stored.
 

--- a/website/src/docs/hotchocolate/v12/security/authentication.md
+++ b/website/src/docs/hotchocolate/v12/security/authentication.md
@@ -2,8 +2,6 @@
 title: Authentication
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Authentication allows us to determine a user's identity. This is of course a prerequisite for authorization, but it also allows us to access the authenticated user in our resolvers. This is useful, if we for example want to build a `me` field that fetches details about the authenticated user.
 
 Hot Chocolate fully embraces the authentication capabilities of ASP.NET Core, making it easy to reuse existing authentication configuration and integrating a variety of authentication providers.

--- a/website/src/docs/hotchocolate/v12/security/authentication.md
+++ b/website/src/docs/hotchocolate/v12/security/authentication.md
@@ -16,9 +16,7 @@ Setting up authentication is largely the same as in any other ASP.NET Core appli
 
 1. Install the `Microsoft.AspNetCore.Authentication.JwtBearer` package
 
-```bash
-dotnet add package Microsoft.AspNetCore.Authentication.JwtBearer
-```
+<PackageInstallation packageName="Microsoft.AspNetCore.Authentication.JwtBearer" external />
 
 2. Register the JWT authentication scheme
 
@@ -47,7 +45,7 @@ public class Startup
 }
 ```
 
-> ⚠️ Note: This is an example configuration that's not intended for use in a real world application.
+> Warning: This is an example configuration that's not intended for use in a real world application.
 
 3. Register the ASP.NET Core authentication middleware with the request pipeline by calling `UseAuthentication`
 
@@ -74,11 +72,7 @@ In order to make the authentication result available to our resolvers, we need t
 
 1. Install the `HotChocolate.AspNetCore.Authorization` package
 
-```bash
-dotnet add package HotChocolate.AspNetCore.Authorization
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.AspNetCore.Authorization" />
 
 2. Call `AddAuthorization()` on the `IRequestExecutorBuilder`
 

--- a/website/src/docs/hotchocolate/v12/security/authorization.md
+++ b/website/src/docs/hotchocolate/v12/security/authorization.md
@@ -14,11 +14,7 @@ After we have successfully setup authentication, there are only a few things lef
 
 1. Install the `HotChocolate.AspNetCore.Authorization` package
 
-```bash
-dotnet add package HotChocolate.AspNetCore.Authorization
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.AspNetCore.Authorization" />
 
 2. Register the necessary ASP.NET Core services
 
@@ -39,7 +35,7 @@ public class Startup
 }
 ```
 
-> ⚠️ Note: We need to call `AddAuthorization()` on the `IServiceCollection`, to register the services needed by ASP.NET Core, and on the `IRequestExecutorBuilder` to register the `@authorize` directive and middleware.
+> Warning: We need to call `AddAuthorization()` on the `IServiceCollection`, to register the services needed by ASP.NET Core, and on the `IRequestExecutorBuilder` to register the `@authorize` directive and middleware.
 
 3. Register the ASP.NET Core authorization middleware with the request pipeline by calling `UseAuthorization`
 
@@ -81,7 +77,7 @@ public class User
 }
 ```
 
-> ⚠️ Note: We need to use the `HotChocolate.AspNetCore.Authorization.AuthorizeAttribute` instead of the `Microsoft.AspNetCore.AuthorizationAttribute`.
+> Warning: We need to use the `HotChocolate.AspNetCore.Authorization.AuthorizeAttribute` instead of the `Microsoft.AspNetCore.AuthorizationAttribute`.
 
 </Annotation>
 <Code>
@@ -115,7 +111,7 @@ Specified on a type the `@authorize` directive will be applied to each field of 
 
 If we do not specify any arguments to the `@authorize` directive, it will only enforce that the requestor is authenticated, nothing more. If he is not and tries to access an authorized field, a GraphQL error will be raised and the field result set to `null`.
 
-> ⚠️ Note: Using the @authorize directive, all unauthorized requests by default will return status code 200 and a payload like this:
+> Warning: Using the @authorize directive, all unauthorized requests by default will return status code 200 and a payload like this:
 
 ```json
 {
@@ -194,7 +190,7 @@ type User @authorize(roles: [ "Guest", "Administrator" ]) {
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: If multiple roles are specified, a user only has to match one of the specified roles, in order to be able to execute the resolver.
+> Warning: If multiple roles are specified, a user only has to match one of the specified roles, in order to be able to execute the resolver.
 
 [Learn more about role-based authorization in ASP.NET Core](https://docs.microsoft.com/aspnet/core/security/authorization/roles)
 
@@ -366,7 +362,7 @@ public class Startup
 
 This method also accepts [roles](#roles) and [policies](#policies) as arguments, similar to the `Authorize` attribute / methods.
 
-> ⚠️ Note: Unlike the `@authorize directive` this will return status code 401 and prevent unauthorized access to all middleware included in `MapGraphQL`. This includes our GraphQL IDE Banana Cake Pop. If we do not want to block unauthorized access to Banana Cake Pop, we can split up the `MapGraphQL` middleware and for example only apply the `RequireAuthorization` to the `MapGraphQLHttp` middleware.
+> Warning: Unlike the `@authorize directive` this will return status code 401 and prevent unauthorized access to all middleware included in `MapGraphQL`. This includes our GraphQL IDE Banana Cake Pop. If we do not want to block unauthorized access to Banana Cake Pop, we can split up the `MapGraphQL` middleware and for example only apply the `RequireAuthorization` to the `MapGraphQLHttp` middleware.
 
 [Learn more about available middleware](/docs/hotchocolate/v12/server/endpoints)
 

--- a/website/src/docs/hotchocolate/v12/security/authorization.md
+++ b/website/src/docs/hotchocolate/v12/security/authorization.md
@@ -2,8 +2,6 @@
 title: Authorization
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Authorization allows us to determine a user's permissions within our system. We can for example limit access to resources or only allow certain users to execute specific mutations.
 
 Authentication is a prerequisite of Authorization, as we first need to validate a user's "authenticity" before we can evaluate his authorization claims.

--- a/website/src/docs/hotchocolate/v12/server/dependency-injection.md
+++ b/website/src/docs/hotchocolate/v12/server/dependency-injection.md
@@ -103,7 +103,7 @@ public class Query
 }
 ```
 
-> ⚠️ Note: You still have to register the service with a lifetime in the actual dependency injection container, for example by calling `services.AddTransient<T>`. `RegisterService<T>` on its own is not enough.
+> Warning: You still have to register the service with a lifetime in the actual dependency injection container, for example by calling `services.AddTransient<T>`. `RegisterService<T>` on its own is not enough.
 
 You can also specify a [ServiceKind](#servicekind) as argument to the `RegisterService<T>` method.
 
@@ -189,7 +189,7 @@ The services are injected according to their [service lifetime](https://docs.mic
 
 Per default (most) resolvers are executed in parallel. Your service might not support being accessed concurrently. If this is the case, you can inject the service using the `ServiceKind.Synchronized`. This will cause the resolver to run serially, which means that no other resolver will be executed, while this resolver is still running.
 
-> ⚠️ Note: This synchronization only applies within the same request. If your service is a Singleton the `ServiceKind.Synchronized` does not prevent the resolver from running concurrently in two separate requests.
+> Warning: This synchronization only applies within the same request. If your service is a Singleton the `ServiceKind.Synchronized` does not prevent the resolver from running concurrently in two separate requests.
 
 ## ServiceKind.Resolver
 

--- a/website/src/docs/hotchocolate/v12/server/dependency-injection.md
+++ b/website/src/docs/hotchocolate/v12/server/dependency-injection.md
@@ -2,8 +2,6 @@
 title: Dependency Injection
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 If you are unfamiliar with the term "dependency injection", we recommend the following articles to get you started:
 
 - [Dependency injection in .NET](https://docs.microsoft.com/dotnet/core/extensions/dependency-injection)

--- a/website/src/docs/hotchocolate/v12/server/endpoints.md
+++ b/website/src/docs/hotchocolate/v12/server/endpoints.md
@@ -199,7 +199,7 @@ endpoints.MapBananaCakePop("/ui").WithOptions(new GraphQLToolOptions
 
 If set to `true` the current Web Browser URL is treated as the GraphQL endpoint when creating new documents within Banana Cake Pop.
 
-> ⚠️ Note: [GraphQLEndpoint](#graphqlendpoint) takes precedence over this setting.
+> Warning: [GraphQLEndpoint](#graphqlendpoint) takes precedence over this setting.
 
 ### Document
 

--- a/website/src/docs/hotchocolate/v12/server/files.md
+++ b/website/src/docs/hotchocolate/v12/server/files.md
@@ -27,7 +27,7 @@ Hot Chocolate implements the [GraphQL multipart request specification](https://g
 src="https://www.youtube.com/embed/XeF3IuGDq4A"frameborder="0"
 allowfullscreen></iframe>
 
-> ⚠️ Note: Files can not yet be uploaded through a gateway to stitched services using the `Upload` scalar.
+> Warning: Files can not yet be uploaded through a gateway to stitched services using the `Upload` scalar.
 
 ### Usage
 
@@ -179,7 +179,7 @@ Both Relay and Apollo support this specification through community packages:
 - [react-relay-network-modern](https://github.com/relay-tools/react-relay-network-modern) using the `uploadMiddleware`
 - [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client)
 
-> ⚠️ Note: [Strawberry Shake](/docs/strawberryshake) does not yet support the `Upload` scalar.
+> Warning: [Strawberry Shake](/docs/strawberryshake) does not yet support the `Upload` scalar.
 
 ### Options
 

--- a/website/src/docs/hotchocolate/v12/server/files.md
+++ b/website/src/docs/hotchocolate/v12/server/files.md
@@ -2,8 +2,6 @@
 title: Files
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs";
-
 Handling files is traditionally not a concern of a GraphQL server, which is also why the [GraphQL over HTTP](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md) specification doesn't mention it.
 
 That being said, we recognize that at some point in the development of a new application you'll likely have to deal with files in some way or another. Which is why we want to give you some guidance on this topic.

--- a/website/src/docs/hotchocolate/v12/server/global-state.md
+++ b/website/src/docs/hotchocolate/v12/server/global-state.md
@@ -96,7 +96,7 @@ public class QueryType : ObjectType
 }
 ```
 
-> ⚠️ Note: If no value exists for the specified `key` a default value is returned an no exception is thrown.
+> Warning: If no value exists for the specified `key` a default value is returned an no exception is thrown.
 
 We can also access the Global State through the `ContextData` dictionary on the `IResolverContext`.
 

--- a/website/src/docs/hotchocolate/v12/server/global-state.md
+++ b/website/src/docs/hotchocolate/v12/server/global-state.md
@@ -2,8 +2,6 @@
 title: Global State
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Global State allows us to define properties on a per-request basis to be made available to all resolvers and middleware.
 
 # Initializing Global State

--- a/website/src/docs/hotchocolate/v12/server/instrumentation.md
+++ b/website/src/docs/hotchocolate/v12/server/instrumentation.md
@@ -46,7 +46,7 @@ public class MyExecutionEventListener : ExecutionDiagnosticEventListener
 }
 ```
 
-> ⚠️ Note: Diagnostic event handlers are executed synchronously as part of the GraphQL request. Long-running operations inside a diagnostic event handler will negatively impact the query performance. Expensive operations should only be enqueued from within the handler and processed by a background service.
+> Warning: Diagnostic event handlers are executed synchronously as part of the GraphQL request. Long-running operations inside a diagnostic event handler will negatively impact the query performance. Expensive operations should only be enqueued from within the handler and processed by a background service.
 
 ## Scopes
 
@@ -156,7 +156,7 @@ The following methods can be overridden.
 | ParseDocument                       | Scope that encloses the parsing of a document.                                                                                                 |
 | SyntaxError                         | Called if a document could not be parsed due to a syntax error.                                                                                |
 | ValidateDocument                    | Scope that encloses the validation of a document.                                                                                              |
-| ValidationErrors                    | Called if errors occurred during the validation of the document.                                                                                |
+| ValidationErrors                    | Called if errors occurred during the validation of the document.                                                                               |
 | AnalyzeOperationComplexity          | Called when starting to analyze the operation complexity.                                                                                      |
 | OperationComplexityAnalyzerCompiled | Called within AnalyzeOperationComplexity scope and reports that an analyzer was compiled.                                                      |
 | OperationComplexityResult           | Called within AnalyzeOperationComplexity scope and reports the outcome of the analyzer.                                                        |
@@ -234,13 +234,9 @@ allowfullscreen></iframe>
 
 ## Setup
 
-To get started, add the HotChocolate.Diagnostics package to your project.
+To get started, add the `HotChocolate.Diagnostics` package to your project.
 
-```bash
-dotnet add package HotChocolate.Diagnostics
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Diagnostics" />
 
 Next, head over to your `Program.cs` and add `AddInstrumentation` to your GraphQL configuration.
 

--- a/website/src/docs/hotchocolate/v12/server/interceptors.md
+++ b/website/src/docs/hotchocolate/v12/server/interceptors.md
@@ -47,7 +47,7 @@ public override ValueTask OnCreateAsync(HttpContext context,
 }
 ```
 
-> ⚠️ Note: `base.OnCreateAsync` should always be invoked, since the default implementation takes care of adding the dependency injection services as well as some important global state variables, such as the `ClaimsPrinicpal`. Not doing this can lead to unexpected issues.
+> Warning: `base.OnCreateAsync` should always be invoked, since the default implementation takes care of adding the dependency injection services as well as some important global state variables, such as the `ClaimsPrinicpal`. Not doing this can lead to unexpected issues.
 
 Most of the configuration will be done through the `IQueryRequestBuilder`, injected as argument to this method.
 
@@ -145,7 +145,7 @@ public override ValueTask OnRequestAsync(ISocketConnection connection,
 }
 ```
 
-> ⚠️ Note: `base.OnRequestAsync` should always be invoked, since the default implementation takes care of adding the dependency injection services as well as some important global state variables, such as the `ClaimsPrinicpal`. Not doing this can lead to unexpected issues.
+> Warning: `base.OnRequestAsync` should always be invoked, since the default implementation takes care of adding the dependency injection services as well as some important global state variables, such as the `ClaimsPrinicpal`. Not doing this can lead to unexpected issues.
 
 Most of the configuration will be done through the `IQueryRequestBuilder`, injected as argument to this method.
 
@@ -198,7 +198,7 @@ var properties = new Dictionary<string, object>
 requestBuilder.SetProperties(properties);
 ```
 
-> ⚠️ Note: This overwrites all previous properties, which is especially catastrophic, when called after the default implementation of an interceptor has added properties.
+> Warning: This overwrites all previous properties, which is especially catastrophic, when called after the default implementation of an interceptor has added properties.
 
 ## SetServices
 

--- a/website/src/docs/hotchocolate/v13/api-reference/custom-attributes.md
+++ b/website/src/docs/hotchocolate/v13/api-reference/custom-attributes.md
@@ -52,7 +52,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Filters` NuGet package.
 
 ## UseSortingAttribute
 
@@ -69,7 +69,7 @@ public class Query
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
 
 ## AuthorizeAttribute
 

--- a/website/src/docs/hotchocolate/v13/api-reference/filtering.md
+++ b/website/src/docs/hotchocolate/v13/api-reference/filtering.md
@@ -152,7 +152,7 @@ public class QueryType
 }
 ```
 
-> ⚠️ **Note**: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
+> Warning: Be sure to install the `HotChocolate.Types.Sorting` NuGet package.
 
 If you want to combine for instance paging, filtering, and sorting make sure that the order is like follows:
 
@@ -874,18 +874,18 @@ Hot Chocolate provides different APIs to customize filtering. You can write cust
 
 **As this can be a bit overwhelming the following questionnaire might help:**
 
-|                                                                                                                                         |                                 |
-| --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| _You do not want all the generated filters and only allow a specific set of filters in a specific case?_                                | Custom&nbsp;FilterInputType     |
-| _You want to change the name of a field or a whole type?_                                                                               | Custom&nbsp;FilterInputType     |
-| _You want to change the name of the `where` argument?_                                                                                  | Filter Conventions ArgumentName |
-| _You want to configure how _Hot Chocolate_ generates the name and the description of filters in globally? e.g. `PascalCaseFilterType`?_ | Filter&nbsp;Conventions         |
-| _You want to configure what the different types of filters are allowed globally?_                                                       | Filter&nbsp;Conventions         |
-| _Your database provider does not support certain operations of `IQueryable`_                                                            | Filter&nbsp;Conventions         |
-| _You want to change the naming of a specific lar filter type? e.g._ `foo_contains` _should be_ `foo_like`                               | Filter&nbsp;Conventions         |
-| _You want to customize the expression a filter is generating: e.g._ `_equals` _should not be case sensitive?_                           | Expression&nbsp;Visitor&nbsp;   |
-| _You want to create your own filter types with custom parameters and custom expressions? e.g. GeoJson?_                                 | Filter&nbsp;Conventions         |
-| _You have a database client that does not support `IQueryable` and wants to generate filters for it?_                                   | Custom&nbsp;Visitor             |
+|                                                                                                                                           |                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| _You do not want all the generated filters and only allow a specific set of filters in a specific case?_                                  | Custom&nbsp;FilterInputType     |
+| _You want to change the name of a field or a whole type?_                                                                                 | Custom&nbsp;FilterInputType     |
+| _You want to change the name of the `where` argument?_                                                                                    | Filter Conventions ArgumentName |
+| _You want to configure how \_Hot Chocolate_ generates the name and the description of filters in globally? e.g. `PascalCaseFilterType`?\_ | Filter&nbsp;Conventions         |
+| _You want to configure what the different types of filters are allowed globally?_                                                         | Filter&nbsp;Conventions         |
+| _Your database provider does not support certain operations of `IQueryable`_                                                              | Filter&nbsp;Conventions         |
+| _You want to change the naming of a specific lar filter type? e.g._ `foo_contains` _should be_ `foo_like`                                 | Filter&nbsp;Conventions         |
+| _You want to customize the expression a filter is generating: e.g._ `_equals` _should not be case sensitive?_                             | Expression&nbsp;Visitor&nbsp;   |
+| _You want to create your own filter types with custom parameters and custom expressions? e.g. GeoJson?_                                   | Filter&nbsp;Conventions         |
+| _You have a database client that does not support `IQueryable` and wants to generate filters for it?_                                     | Custom&nbsp;Visitor             |
 
 # Custom&nbsp;FilterInputType
 
@@ -996,7 +996,7 @@ input UserFilter {
 | `csharp±Object<TObject>( Expression<Func<T, TObject>> property)`                 | Defines a object filter for the selected property.                                                                                              |
 | `csharp±List( Expression<Func<T, IEnumerable<string>>> property)`                | Defines an array string filter for the selected property.                                                                                       |
 | `csharp±List( Expression<Func<T, IEnumerable<bool>>> property)`                  | Defines an array bool filter for the selected property.                                                                                         |
-| `csharp±List( Expression<Func<T, IEnumerable<IComparable>>> property)`           | Defines an array comparable filter for the selected property.                                                                                    |
+| `csharp±List( Expression<Func<T, IEnumerable<IComparable>>> property)`           | Defines an array comparable filter for the selected property.                                                                                   |
 | `csharp±Filter<TObject>( Expression<Func<T, IEnumerable<TObject>>> property)`    | Defines an array object filter for the selected property.                                                                                       |
 | `csharp±Directive<TDirective>(TDirective directiveInstance)`                     | Add directive `directiveInstance` to the type                                                                                                   |
 | `csharp±Directive<TDirective>(TDirective directiveInstance)`                     | Add directive of type `TDirective` to the type                                                                                                  |

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/arguments.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/arguments.md
@@ -2,8 +2,6 @@
 title: "Arguments"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 GraphQL allows us to specify arguments on a field and access their values in the field's resolver.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/documentation.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/documentation.md
@@ -2,8 +2,6 @@
 title: Documentation
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Documentation allows us to enrich our schema with additional information that is useful for a consumer of our API.
 
 In GraphQL we can do this by providing descriptions to our types, fields, etc.

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/enums.md
@@ -238,7 +238,7 @@ services
     });
 ```
 
-> ⚠️ Note: This changes the binding behavior for all types, not only enum types.
+> Warning: This changes the binding behavior for all types, not only enum types.
 
 We can also override it on a per type basis:
 

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/enums.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/enums.md
@@ -2,8 +2,6 @@
 title: "Enums"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 An Enum is a special kind of [scalar](/docs/hotchocolate/v13/defining-a-schema/scalars) that is restricted to a particular set of allowed values. It can be used as both an input and an output type.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/extending-types.md
@@ -12,7 +12,7 @@ Type extensions are especially useful if we want to modify third-party types, su
 src="https://www.youtube.com/embed/EHTr4Fq6GlA"frameborder="0"
 allowfullscreen></iframe>
 
-> ⚠️ Note: Type extensions do not produce the [extend type syntax that GraphQL offers](http://spec.graphql.org/draft/#sec-Object-Extensions), since it would unnecessarily complicate the resulting schema. Instead, Hot Chocolate's type extensions are directly merged with the original type definition to create a single type at runtime.
+> Warning: Type extensions do not produce the [extend type syntax that GraphQL offers](http://spec.graphql.org/draft/#sec-Object-Extensions), since it would unnecessarily complicate the resulting schema. Instead, Hot Chocolate's type extensions are directly merged with the original type definition to create a single type at runtime.
 
 # Object Types
 

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/extending-types.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/extending-types.md
@@ -2,8 +2,6 @@
 title: "Extending Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Type extensions allow us to add, remove or replace fields on existing types, without necessarily needing access to these types.
 
 Because of these capabilities, they also allow for better organization of our types. We could for example have classes that encapsulate part of our domain and extend our `Query` type with these functionalities.

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/input-object-types.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/input-object-types.md
@@ -224,7 +224,7 @@ public record BookInput([property:DefaultValue("")]Optional<string> Title, strin
 
 `OneOf` Input Objects are a special variant of Input Objects where the type system asserts that exactly one of the fields must be set and non-null, all others being omitted. This is represented in introspection with the \_\_Type.oneField: Boolean field, and in SDL via the @oneOf directive on the input object.
 
-> ⚠️ Note: `OneOf` Input Objects is currently a draft feature to the GraphQL spec. <https://github.com/graphql/graphql-spec/pull/825>
+> Warning: `OneOf` Input Objects is currently a draft feature to the GraphQL spec. <https://github.com/graphql/graphql-spec/pull/825>
 
 <iframe width="560" height="315"
 src="https://www.youtube.com/embed/tztXm15grU0"frameborder="0"

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/input-object-types.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/input-object-types.md
@@ -2,8 +2,6 @@
 title: "Input Object Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 We already looked at [arguments](/docs/hotchocolate/v13/defining-a-schema/arguments), which allow us to use simple [scalars](/docs/hotchocolate/v13/defining-a-schema/scalars) like `String` to pass data into a field. GraphQL defines input object types to allow us to use objects as arguments on our fields.
 
 Input object type definitions differ from [object types](/docs/hotchocolate/v13/defining-a-schema/object-types) only in the used keyword and in that their fields can not have arguments.

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/interfaces.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/interfaces.md
@@ -2,8 +2,6 @@
 title: "Interfaces"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 An interface is an abstract type that defines a certain set of fields that an object type or another interface must include to implement the interface. Interfaces can only be used as output types, meaning we can't use interfaces as arguments or as fields on input object types.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/interfaces.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/interfaces.md
@@ -270,7 +270,7 @@ services
     });
 ```
 
-> ⚠️ Note: This changes the binding behavior for all types, not only interface types.
+> Warning: This changes the binding behavior for all types, not only interface types.
 
 We can also override it on a per type basis:
 

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/lists.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/lists.md
@@ -2,8 +2,6 @@
 title: "Lists"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 GraphQL allows us to return lists of elements from our fields.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/mutations.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/mutations.md
@@ -2,8 +2,6 @@
 title: "Mutations"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The mutation type in GraphQL is used to mutate/change data. This means that when we are doing mutations, we are intending to cause side-effects in the system.
 
 GraphQL defines mutations as top-level fields on the mutation type. Meaning only the fields on the mutation root type itself are mutations. Everything that is returned from a mutation field represents the changed state of the server.

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/mutations.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/mutations.md
@@ -135,7 +135,7 @@ public class Startup
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: Only **one** mutation type can be registered using `AddMutationType()`. If we want to split up our mutation type into multiple classes, we can do so using type extensions.
+> Warning: Only **one** mutation type can be registered using `AddMutationType()`. If we want to split up our mutation type into multiple classes, we can do so using type extensions.
 >
 > [Learn more about extending types](/docs/hotchocolate/v13/defining-a-schema/extending-types)
 

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/non-null.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/non-null.md
@@ -2,8 +2,6 @@
 title: "Non-Null"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Per default all fields on an object type can be either `null` or the specified type.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/object-types.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/object-types.md
@@ -144,7 +144,7 @@ services
     });
 ```
 
-> ⚠️ Note: This changes the binding behavior for all types, not only object types.
+> Warning: This changes the binding behavior for all types, not only object types.
 
 We can also override it on a per type basis:
 

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/object-types.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/object-types.md
@@ -2,8 +2,6 @@
 title: "Object Types"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The most important type in a GraphQL schema is the object type. It contains fields that can return simple scalars like `String`, `Int`, or again object types.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/queries.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/queries.md
@@ -138,7 +138,7 @@ public class Startup
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: Only **one** query type can be registered using `AddQueryType()`. If we want to split up our query type into multiple classes, we can do so using type extensions.
+> Warning: Only **one** query type can be registered using `AddQueryType()`. If we want to split up our query type into multiple classes, we can do so using type extensions.
 >
 > [Learn more about extending types](/docs/hotchocolate/v13/defining-a-schema/extending-types)
 

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/queries.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/queries.md
@@ -2,8 +2,6 @@
 title: "Queries"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The query type in GraphQL represents a read-only view of all of our entities and ways to retrieve them. A query type is required for every GraphQL server.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/relay.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/relay.md
@@ -240,7 +240,7 @@ public class Startup
 
 This registers the `Node` interface type and adds the `node(id: ID!): Node` and the `nodes(ids: [ID!]!): [Node]!` field to our query type. At least one type in our schema needs to implement the `Node` interface or an exception is raised.
 
-> ⚠️ Note: Using `AddGlobalObjectIdentification()` in two upstream stitched services does currently not work out of the box.
+> Warning: Using `AddGlobalObjectIdentification()` in two upstream stitched services does currently not work out of the box.
 
 Next we need to extend our object types with the `Global Object Identification` functionality. Therefore 3 criteria need to be fulfilled:
 
@@ -375,7 +375,7 @@ public class ProductType : ObjectType<Product>
 }
 ```
 
-> ⚠️ Note: When using middleware such as `UseDbContext` it needs to be chained after the `ResolveNode` call. The order of middleware still matters.
+> Warning: When using middleware such as `UseDbContext` it needs to be chained after the `ResolveNode` call. The order of middleware still matters.
 
 If the `Id` property of our class is not called `id`, we can either [rename it](/docs/hotchocolate/v13/defining-a-schema/object-types#naming) or specify it through the `IdField` method on the `IObjectTypeDescriptor`. Hot Chocolate will then automatically rename this property to `id` in the schema to properly implement the contract of the `Node` interface.
 
@@ -543,4 +543,4 @@ services
 
 This would add a field of type `Query` with the name of `rootQuery` to each top-level mutation field type, whose name ends in `Result`.
 
-> ⚠️ Note: This feature currently doesn't work on a stitching gateway, however this will be addressed in a future release focused on stitching. It's tracked as [#3158](https://github.com/ChilliCream/hotchocolate/issues/3158).
+> Warning: This feature currently doesn't work on a stitching gateway, however this will be addressed in a future release focused on stitching. It's tracked as [#3158](https://github.com/ChilliCream/hotchocolate/issues/3158).

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/relay.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/relay.md
@@ -2,8 +2,6 @@
 title: "Relay"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 > Note: Even though they originated in Relay, the design principles described in this document are not exclusive to Relay. They lead to an overall better schema design, which is why we recommend them to **all** users of Hot Chocolate.
 
 [Relay](https://relay.dev) is a JavaScript framework for building data-driven React applications with GraphQL, which is developed and used by _Facebook_.

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/scalars.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/scalars.md
@@ -301,11 +301,7 @@ We also offer a separate package with scalars for more specific use cases.
 
 To use these scalars we have to add the `HotChocolate.Types.Scalars` package.
 
-```bash
-dotnet add package HotChocolate.Types.Scalars
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Types.Scalars" />
 
 **Available Scalars:**
 
@@ -363,11 +359,7 @@ We also offer a package specifically for [NodaTime](https://github.com/nodatime/
 
 It can be installed like the following.
 
-```bash
-dotnet add package HotChocolate.Types.NodaTime
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Types.NodaTime" />
 
 **Available Scalars:**
 

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/scalars.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/scalars.md
@@ -2,8 +2,6 @@
 title: "Scalars"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Scalar types are the primitives of our schema and can hold a specific type of data. They are leaf types, meaning we cannot use e.g. `{ fieldname }` to further drill down into the type. The main purpose of a scalar is to define how a value is serialized and deserialized.
 
 Besides basic scalars like `String` and `Int`, we can also create custom scalars like `CreditCardNumber` or `SocialSecurityNumber`. These custom scalars can greatly enhance the expressiveness of our schema and help new developers to get a grasp of our API.

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/subscriptions.md
@@ -2,8 +2,6 @@
 title: "Subscriptions"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 The subscription type in GraphQL is used to add real-time capabilities to our applications. Clients can subscribe to events and receive the event data in real-time, as soon as the server publishes it.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/subscriptions.md
@@ -124,7 +124,7 @@ public class Startup
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: Only **one** subscription type can be registered using `AddSubscriptionType()`. If we want to split up our subscription type into multiple classes, we can do so using type extensions.
+> Warning: Only **one** subscription type can be registered using `AddSubscriptionType()`. If we want to split up our subscription type into multiple classes, we can do so using type extensions.
 >
 > [Learn more about extending types](/docs/hotchocolate/v13/defining-a-schema/extending-types)
 
@@ -171,11 +171,7 @@ The Redis subscription provider enables us to run multiple instances of our Hot 
 
 In order to use the Redis provider we have to add the `HotChocolate.Subscriptions.Redis` package.
 
-```bash
-dotnet add package HotChocolate.Subscriptions.Redis
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Subscriptions.Redis" />
 
 After we have added the package we can setup the Redis subscription provider.
 

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/unions.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/unions.md
@@ -2,8 +2,6 @@
 title: "Unions"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 A union type represents a set of object types. It is very similar to an [interface](/docs/hotchocolate/v13/defining-a-schema/interfaces), except that there is no requirement for common fields between the specified types.
 
 ```sdl

--- a/website/src/docs/hotchocolate/v13/defining-a-schema/versioning.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/versioning.md
@@ -2,8 +2,6 @@
 title: "Versioning"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Whilst we could version our GraphQL API similar to REST, i.e. `/graphql/v1`, it is not a best practice and often unnecessary.
 
 Many changes to a GraphQL schema are non-breaking. We can freely add new types and extend existing types with new fields. This does not break existing queries.

--- a/website/src/docs/hotchocolate/v13/distributed-schema/schema-federations.md
+++ b/website/src/docs/hotchocolate/v13/distributed-schema/schema-federations.md
@@ -14,11 +14,7 @@ With a cache, the gateway schema is also more stable and faster in bootstrapping
 
 You will need to add a package reference to `HotChocolate.Stitching.Redis` to all your services:
 
-```bash
-dotnet add package HotChocolate.Stitching.Redis
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Stitching.Redis" />
 
 ## Configuration of a domain service
 
@@ -101,11 +97,7 @@ Your schema will expose an additional field. This field is used by the Gateway t
 
 You will need to add a package reference to `HotChocolate.Stitching` to all your services:
 
-```cli
-dotnet add package HotChocolate.Stitching
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Stitching" />
 
 ## Configuration of a domain service
 

--- a/website/src/docs/hotchocolate/v13/distributed-schema/schema-stitching.md
+++ b/website/src/docs/hotchocolate/v13/distributed-schema/schema-stitching.md
@@ -8,11 +8,7 @@ Hot Chocolate uses the schema name as an identifier for schemas. This schema nam
 
 You will need to add a package reference to `HotChocolate.Stitching` to your gateway:
 
-```bash
-dotnet add package HotChocolate.Stitching
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Stitching" />
 
 ```csharp
 public static class WellKnownSchemaNames

--- a/website/src/docs/hotchocolate/v13/distributed-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v13/distributed-schema/subscriptions.md
@@ -6,7 +6,7 @@ A Subscription type cannot be stitched from downstream services so it must be de
 
 > [Learn more about defining a Subscription type](/docs/hotchocolate/v13/defining-a-schema/subscriptions)
 
-> ⚠️ Note: Subscription stitching is coming in v13
+> Warning: Subscription stitching is coming in v13
 
 After adding a Subscription type to the gateway service, you may encounter an error when building the gateway schema.
 

--- a/website/src/docs/hotchocolate/v13/fetching-data/dataloader.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/dataloader.md
@@ -2,8 +2,6 @@
 title: "DataLoader"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 > If you want to read more about data loaders in general, you can head over to Facebook's [GitHub repository](https://github.com/facebook/dataloader).
 
 Every data fetching technology suffers the _n+1_ problem.

--- a/website/src/docs/hotchocolate/v13/fetching-data/fetching-from-databases.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/fetching-from-databases.md
@@ -2,8 +2,6 @@
 title: "Fetching from Databases"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 In this section, you find a simple example on how you can fetch data from a database and expose it as a GraphQL API.
 
 **Hot Chocolate is not bound to a specific database, pattern or architecture.**

--- a/website/src/docs/hotchocolate/v13/fetching-data/fetching-from-rest.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/fetching-from-rest.md
@@ -2,8 +2,6 @@
 title: "Fetching from REST"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 In this section, we will cover how you can easily integrate a REST API into your GraphQL API.
 
 If you want to have an outlook into the upcoming native REST integration with Hot Chocolate 13 you can head over to YouTube and have a look.

--- a/website/src/docs/hotchocolate/v13/fetching-data/fetching-from-rest.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/fetching-from-rest.md
@@ -69,9 +69,7 @@ In this file, you will find the client for your REST API.
 The generated needs `Newtonsoft.Json`.
 Make sure to also add this package by executing:
 
-```bash
-dotnet add package Newtonsoft.Json
-```
+<PackageInstallation packageName="Newtonsoft.Json" external />
 
 # Exposing the API
 

--- a/website/src/docs/hotchocolate/v13/fetching-data/filtering.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/filtering.md
@@ -40,13 +40,9 @@ input StringOperationFilterInput {
 
 # Getting started
 
-Filtering is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Filtering is part of the `HotChocolate.Data` package.
 
-```bash
-dotnet add package HotChocolate.Data
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use filtering you need to register it on the schema:
 

--- a/website/src/docs/hotchocolate/v13/fetching-data/filtering.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/filtering.md
@@ -2,8 +2,6 @@
 title: Filtering
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 With Hot Chocolate filters, you can expose complex filter objects through your GraphQL API that translates to native database queries. The default filter implementation translates filters to expression trees that are applied to `IQueryable`.
 Hot Chocolate by default will inspect your .NET model and infer the possible filter operations from it.
 Filters use `IQueryable` (`IEnumerable`) by default, but you can also easily customize them to use other interfaces.

--- a/website/src/docs/hotchocolate/v13/fetching-data/pagination.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/pagination.md
@@ -2,8 +2,6 @@
 title: "Pagination"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs";
-
 Pagination is one of the most common problems that we have to solve when implementing our backend. Often, sets of data are too large to pass them directly to the consumer of our service.
 
 Pagination solves this problem by giving the consumer the ability to fetch a set in chunks.

--- a/website/src/docs/hotchocolate/v13/fetching-data/projections.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/projections.md
@@ -30,13 +30,9 @@ LEFT JOIN "Address" AS "a" ON "u"."AddressId" = "a"."Id"
 
 # Getting Started
 
-Filtering is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Filtering is part of the `HotChocolate.Data` package.
 
-```bash
-dotnet add package HotChocolate.Data
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use projections with your GraphQL endpoint you have to register projections on the schema:
 

--- a/website/src/docs/hotchocolate/v13/fetching-data/projections.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/projections.md
@@ -2,8 +2,6 @@
 title: Projections
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Every GraphQL request specifies exactly what data should be returned. Over or under fetching can be reduced
 or even eliminated. Hot Chocolate projections leverage this concept and directly projects incoming queries
 to the database.

--- a/website/src/docs/hotchocolate/v13/fetching-data/resolvers.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/resolvers.md
@@ -2,8 +2,6 @@
 title: "Resolvers"
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 When it comes to fetching data in a GraphQL server, it will always come down to a resolver.
 
 **A resolver is a generic function that fetches data from an arbitrary data source for a particular field.**

--- a/website/src/docs/hotchocolate/v13/fetching-data/sorting.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/sorting.md
@@ -54,13 +54,9 @@ enum SortEnumType {
 
 # Getting started
 
-Sorting is part of the `HotChocolate.Data` package. You can add the dependency with the `dotnet` cli
+Sorting is part of the `HotChocolate.Data` package.
 
-```bash
-dotnet add package HotChocolate.Data
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data" />
 
 To use sorting you need to register it on the schema:
 

--- a/website/src/docs/hotchocolate/v13/fetching-data/sorting.md
+++ b/website/src/docs/hotchocolate/v13/fetching-data/sorting.md
@@ -2,8 +2,6 @@
 title: Sorting
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 # What is sorting
 
 Ordering results of a query dynamically is a common case. With Hot Chocolate sorting, you can expose a sorting argument that abstracts the complexity of ordering logic.

--- a/website/src/docs/hotchocolate/v13/get-started.md
+++ b/website/src/docs/hotchocolate/v13/get-started.md
@@ -42,24 +42,7 @@ Create a new project from within Visual Studio using the "ASP.NET Core Empty" te
 
 This package includes everything that's needed to get your GraphQL server up and running.
 
-<InputChoiceTabs>
-<InputChoiceTabs.CLI>
-
-```bash
-dotnet add package HotChocolate.AspNetCore
-```
-
-</InputChoiceTabs.CLI>
-<InputChoiceTabs.VisualStudio>
-
-You can add the `HotChocolate.AspNetCore` package using the NuGet Package Manager within Visual Studio.
-
-[Learn how you can use the NuGet Package Manager to install a package](https://docs.microsoft.com/nuget/quickstart/install-and-use-a-package-in-visual-studio#nuget-package-manager)
-
-</InputChoiceTabs.VisualStudio>
-</InputChoiceTabs>
-
-> ⚠️ Note: Additional `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.AspNetCore" />
 
 ## 3. Define the types
 

--- a/website/src/docs/hotchocolate/v13/integrations/entity-framework.md
+++ b/website/src/docs/hotchocolate/v13/integrations/entity-framework.md
@@ -2,8 +2,6 @@
 title: Entity Framework Core
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 [Entity Framework Core](https://docs.microsoft.com/ef/core/) is a powerful object-relational mapping framework that has become a staple when working with SQL-based Databases in .NET Core applications.
 
 When working with Entity Framework Core's [DbContext](https://docs.microsoft.com/dotnet/api/system.data.entity.dbcontext), it is most commonly registered as a scoped service.

--- a/website/src/docs/hotchocolate/v13/integrations/entity-framework.md
+++ b/website/src/docs/hotchocolate/v13/integrations/entity-framework.md
@@ -54,11 +54,7 @@ Since this is a lot of code to write, just to inject a `DbContext`, you can use 
 
 In order to simplify the injection of a `DbContext` we have introduced a method called `RegisterDbContext<T>`, similar to the [`RegisterService<T>`](/docs/hotchocolate/v13/server/dependency-injection#registerservice) method for regular services. This method is part of the `HotChocolate.Data.EntityFramework` package, which you'll have to install.
 
-```bash
-dotnet add package HotChocolate.Data.EntityFramework
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data.EntityFramework" />
 
 Once installed you can simply call the `RegisterDbContext<T>` method on the `IRequestExecutorBuilder`. The Hot Chocolate Resolver Compiler will then take care of correctly injecting your scoped `DbContext` instance into your resolvers and also ensuring that the resolvers using it are never run in parallel.
 
@@ -80,7 +76,7 @@ public class Query
 }
 ```
 
-> ⚠️ Note: You still have to register your `DbContext` in the actual dependency injection container, by calling `services.AddDbContext<T>`. `RegisterDbContext<T>` on its own is not enough.
+> Warning: You still have to register your `DbContext` in the actual dependency injection container, by calling `services.AddDbContext<T>`. `RegisterDbContext<T>` on its own is not enough.
 
 You can also specify a [DbContextKind](#dbcontextkind) as argument to the `RegisterDbContext<T>` method, to change how the `DbContext` should be injected.
 
@@ -168,7 +164,7 @@ public class FooByIdDataLoader : BatchDataLoader<string, Foo>
 }
 ```
 
-> ⚠️ Note: It is important that you dispose the `DbContext` to return it to the pool. In the above example we are using `await using` to dispose the `DbContext` after it is no longer required.
+> Warning: It is important that you dispose the `DbContext` to return it to the pool. In the above example we are using `await using` to dispose the `DbContext` after it is no longer required.
 
 ## Services
 
@@ -212,4 +208,4 @@ public class FooService : IAsyncDisposable
 }
 ```
 
-> ⚠️ Note: It is important that you dispose the `DbContext` to return it to the pool, once your transient service is being disposed. In the above example we are implementing `IAsyncDisposable` and disposing the created `DbContext` in the `DisposeAsync` method. This method will be invoked by the dependency injection system.
+> Warning: It is important that you dispose the `DbContext` to return it to the pool, once your transient service is being disposed. In the above example we are implementing `IAsyncDisposable` and disposing the created `DbContext` in the `DisposeAsync` method. This method will be invoked by the dependency injection system.

--- a/website/src/docs/hotchocolate/v13/integrations/mongodb.md
+++ b/website/src/docs/hotchocolate/v13/integrations/mongodb.md
@@ -11,11 +11,7 @@ You can find a example project in [Hot Chocolate Examples](https://github.com/Ch
 
 To use the MongoDB integration, you need to install the package `HotChocolate.Data.MongoDb`.
 
-```bash
-dotnet add package HotChocolate.Data.MongoDb
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data.MongoDb" />
 
 # MongoExecutable
 

--- a/website/src/docs/hotchocolate/v13/integrations/neo4j.md
+++ b/website/src/docs/hotchocolate/v13/integrations/neo4j.md
@@ -11,11 +11,7 @@ You can find a example project in [HotChocolate Examples](https://github.com/Chi
 
 To use the Neo4J integration, you need to install the package `HotChocolate.Data.Neo4J`.
 
-```bash
-dotnet add package HotChocolate.Data.Neo4J
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Data.Neo4J" />
 
 # Neo4JExecutable
 

--- a/website/src/docs/hotchocolate/v13/integrations/spatial-data.md
+++ b/website/src/docs/hotchocolate/v13/integrations/spatial-data.md
@@ -20,13 +20,9 @@ can return NetTopologySuite shapes and they will be transformed into GeoJSON.
 
 # Getting Started
 
-You first need to add the `HotChocolate.Spatial` package reference to your project. You can do this with the `dotnet` cli:
+You first need to add the `HotChocolate.Spatial` package reference to your project.
 
-```bash
-dotnet add package HotChocolate.Spatial
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Spatial" />
 
 To make the schema recognize the spatial types you need to register them on the schema builder.
 
@@ -38,9 +34,7 @@ services
 
 If you are using our data extensions to project data from a database you also need to add the package `HotChocolate.Data.Spatial` to your project.
 
-```bash
-dotnet add package HotChocolate.Data.Spatial
-```
+<PackageInstallation packageName="HotChocolate.Data.Spatial" />
 
 In order to use the data extensions in your resolvers you need to register them with the GraphQL configuration builder.
 

--- a/website/src/docs/hotchocolate/v13/migrating/migrate-from-11-to-12.md
+++ b/website/src/docs/hotchocolate/v13/migrating/migrate-from-11-to-12.md
@@ -234,7 +234,7 @@ sevices
 
 If you just want to enable the feature without further configuration, you can omit the `options =>` action.
 
-> ⚠️ Note: Since `EnableRelaySupport()` previously always implied the usage of Global Object Identification, you might have to enable Global Object Identification separately as well.
+> Warning: Since `EnableRelaySupport()` previously always implied the usage of Global Object Identification, you might have to enable Global Object Identification separately as well.
 
 [Learn more about Query field in Mutation payloads](/docs/hotchocolate/v13/defining-a-schema/relay#query-field-in-mutation-payloads)
 

--- a/website/src/docs/hotchocolate/v13/performance/automatic-persisted-queries.md
+++ b/website/src/docs/hotchocolate/v13/performance/automatic-persisted-queries.md
@@ -40,11 +40,7 @@ dotnet new graphql
 
 3. Add the in-memory query storage to your project.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.InMemory
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.PersistedQueries.InMemory" />
 
 ## Step 2: Configure automatic persisted queries
 
@@ -229,11 +225,7 @@ docker run --name redis-stitching -p 7000:6379 -d redis
 
 2. Add the Redis persisted query storage package to your server.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.Redis
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.PersistedQueries.Redis" />
 
 3. Next, we need to configure the server to use Redis as query storage.
 

--- a/website/src/docs/hotchocolate/v13/performance/persisted-queries.md
+++ b/website/src/docs/hotchocolate/v13/performance/persisted-queries.md
@@ -57,11 +57,7 @@ Hot Chocolate supports two query storages for regular persisted queries.
 
 To load persisted queries from the filesystem, we have to add the following package.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.FileSystem
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.PersistedQueries.FileSystem" />
 
 After this we need to specify where the persisted queries are located. The argument of `AddReadOnlyFileSystemQueryStorage()` specifies the directory in which the persisted queries are stored.
 
@@ -82,17 +78,13 @@ Example: `0c95d31ca29272475bf837f944f4e513.graphql`
 
 This file is expected to contain the query the hash was generated from.
 
-> ⚠️ Note: Do not forget to ensure that the server has access to the directory.
+> Warning: Do not forget to ensure that the server has access to the directory.
 
 ### Redis
 
 To load persisted queries from Redis, we have to add the following package.
 
-```bash
-dotnet add package HotChocolate.PersistedQueries.Redis
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.PersistedQueries.Redis" />
 
 After this we need to specify where the persisted queries are located. Using `AddReadOnlyRedisQueryStorage()` we can point to a specific Redis database in which the persisted queries are stored.
 

--- a/website/src/docs/hotchocolate/v13/security/authentication.md
+++ b/website/src/docs/hotchocolate/v13/security/authentication.md
@@ -2,8 +2,6 @@
 title: Authentication
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Authentication allows us to determine a user's identity. This is of course a prerequisite for authorization, but it also allows us to access the authenticated user in our resolvers. This is useful, if we for example want to build a `me` field that fetches details about the authenticated user.
 
 Hot Chocolate fully embraces the authentication capabilities of ASP.NET Core, making it easy to reuse existing authentication configuration and integrating a variety of authentication providers.

--- a/website/src/docs/hotchocolate/v13/security/authentication.md
+++ b/website/src/docs/hotchocolate/v13/security/authentication.md
@@ -16,9 +16,7 @@ Setting up authentication is largely the same as in any other ASP.NET Core appli
 
 1. Install the `Microsoft.AspNetCore.Authentication.JwtBearer` package
 
-```bash
-dotnet add package Microsoft.AspNetCore.Authentication.JwtBearer
-```
+<PackageInstallation packageName="Microsoft.AspNetCore.Authentication.JwtBearer" external />
 
 2. Register the JWT authentication scheme
 
@@ -47,7 +45,7 @@ public class Startup
 }
 ```
 
-> ⚠️ Note: This is an example configuration that's not intended for use in a real world application.
+> Warning: This is an example configuration that's not intended for use in a real world application.
 
 3. Register the ASP.NET Core authentication middleware with the request pipeline by calling `UseAuthentication`
 
@@ -74,11 +72,7 @@ In order to make the authentication result available to our resolvers, we need t
 
 1. Install the `HotChocolate.AspNetCore.Authorization` package
 
-```bash
-dotnet add package HotChocolate.AspNetCore.Authorization
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.AspNetCore.Authorization" />
 
 2. Call `AddAuthorization()` on the `IRequestExecutorBuilder`
 

--- a/website/src/docs/hotchocolate/v13/security/authorization.md
+++ b/website/src/docs/hotchocolate/v13/security/authorization.md
@@ -14,11 +14,7 @@ After we have successfully setup authentication, there are only a few things lef
 
 1. Install the `HotChocolate.AspNetCore.Authorization` package
 
-```bash
-dotnet add package HotChocolate.AspNetCore.Authorization
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.AspNetCore.Authorization" />
 
 2. Register the necessary ASP.NET Core services
 
@@ -39,7 +35,7 @@ public class Startup
 }
 ```
 
-> ⚠️ Note: We need to call `AddAuthorization()` on the `IServiceCollection`, to register the services needed by ASP.NET Core, and on the `IRequestExecutorBuilder` to register the `@authorize` directive and middleware.
+> Warning: We need to call `AddAuthorization()` on the `IServiceCollection`, to register the services needed by ASP.NET Core, and on the `IRequestExecutorBuilder` to register the `@authorize` directive and middleware.
 
 3. Register the ASP.NET Core authorization middleware with the request pipeline by calling `UseAuthorization`
 
@@ -81,7 +77,7 @@ public class User
 }
 ```
 
-> ⚠️ Note: We need to use the `HotChocolate.AspNetCore.Authorization.AuthorizeAttribute` instead of the `Microsoft.AspNetCore.AuthorizationAttribute`.
+> Warning: We need to use the `HotChocolate.AspNetCore.Authorization.AuthorizeAttribute` instead of the `Microsoft.AspNetCore.AuthorizationAttribute`.
 
 </Annotation>
 <Code>
@@ -115,7 +111,7 @@ Specified on a type the `@authorize` directive will be applied to each field of 
 
 If we do not specify any arguments to the `@authorize` directive, it will only enforce that the requestor is authenticated, nothing more. If he is not and tries to access an authorized field, a GraphQL error will be raised and the field result set to `null`.
 
-> ⚠️ Note: Using the @authorize directive, all unauthorized requests by default will return status code 200 and a payload like this:
+> Warning: Using the @authorize directive, all unauthorized requests by default will return status code 200 and a payload like this:
 
 ```json
 {
@@ -194,7 +190,7 @@ type User @authorize(roles: [ "Guest", "Administrator" ]) {
 </Schema>
 </ExampleTabs>
 
-> ⚠️ Note: If multiple roles are specified, a user only has to match one of the specified roles, in order to be able to execute the resolver.
+> Warning: If multiple roles are specified, a user only has to match one of the specified roles, in order to be able to execute the resolver.
 
 [Learn more about role-based authorization in ASP.NET Core](https://docs.microsoft.com/aspnet/core/security/authorization/roles)
 
@@ -366,7 +362,7 @@ public class Startup
 
 This method also accepts [roles](#roles) and [policies](#policies) as arguments, similar to the `Authorize` attribute / methods.
 
-> ⚠️ Note: Unlike the `@authorize directive` this will return status code 401 and prevent unauthorized access to all middleware included in `MapGraphQL`. This includes our GraphQL IDE Banana Cake Pop. If we do not want to block unauthorized access to Banana Cake Pop, we can split up the `MapGraphQL` middleware and for example only apply the `RequireAuthorization` to the `MapGraphQLHttp` middleware.
+> Warning: Unlike the `@authorize directive` this will return status code 401 and prevent unauthorized access to all middleware included in `MapGraphQL`. This includes our GraphQL IDE Banana Cake Pop. If we do not want to block unauthorized access to Banana Cake Pop, we can split up the `MapGraphQL` middleware and for example only apply the `RequireAuthorization` to the `MapGraphQLHttp` middleware.
 
 [Learn more about available middleware](/docs/hotchocolate/v13/server/endpoints)
 

--- a/website/src/docs/hotchocolate/v13/security/authorization.md
+++ b/website/src/docs/hotchocolate/v13/security/authorization.md
@@ -2,8 +2,6 @@
 title: Authorization
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Authorization allows us to determine a user's permissions within our system. We can for example limit access to resources or only allow certain users to execute specific mutations.
 
 Authentication is a prerequisite of Authorization, as we first need to validate a user's "authenticity" before we can evaluate his authorization claims.

--- a/website/src/docs/hotchocolate/v13/server/dependency-injection.md
+++ b/website/src/docs/hotchocolate/v13/server/dependency-injection.md
@@ -103,7 +103,7 @@ public class Query
 }
 ```
 
-> ⚠️ Note: You still have to register the service with a lifetime in the actual dependency injection container, for example by calling `services.AddTransient<T>`. `RegisterService<T>` on its own is not enough.
+> Warning: You still have to register the service with a lifetime in the actual dependency injection container, for example by calling `services.AddTransient<T>`. `RegisterService<T>` on its own is not enough.
 
 You can also specify a [ServiceKind](#servicekind) as argument to the `RegisterService<T>` method.
 
@@ -189,7 +189,7 @@ The services are injected according to their [service lifetime](https://docs.mic
 
 Per default (most) resolvers are executed in parallel. Your service might not support being accessed concurrently. If this is the case, you can inject the service using the `ServiceKind.Synchronized`. This will cause the resolver to run serially, which means that no other resolver will be executed, while this resolver is still running.
 
-> ⚠️ Note: This synchronization only applies within the same request. If your service is a Singleton the `ServiceKind.Synchronized` does not prevent the resolver from running concurrently in two separate requests.
+> Warning: This synchronization only applies within the same request. If your service is a Singleton the `ServiceKind.Synchronized` does not prevent the resolver from running concurrently in two separate requests.
 
 ## ServiceKind.Resolver
 

--- a/website/src/docs/hotchocolate/v13/server/dependency-injection.md
+++ b/website/src/docs/hotchocolate/v13/server/dependency-injection.md
@@ -2,8 +2,6 @@
 title: Dependency Injection
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 If you are unfamiliar with the term "dependency injection", we recommend the following articles to get you started:
 
 - [Dependency injection in .NET](https://docs.microsoft.com/dotnet/core/extensions/dependency-injection)

--- a/website/src/docs/hotchocolate/v13/server/endpoints.md
+++ b/website/src/docs/hotchocolate/v13/server/endpoints.md
@@ -199,7 +199,7 @@ endpoints.MapBananaCakePop("/ui").WithOptions(new GraphQLToolOptions
 
 If set to `true` the current Web Browser URL is treated as the GraphQL endpoint when creating new documents within Banana Cake Pop.
 
-> ⚠️ Note: [GraphQLEndpoint](#graphqlendpoint) takes precedence over this setting.
+> Warning: [GraphQLEndpoint](#graphqlendpoint) takes precedence over this setting.
 
 ### Document
 

--- a/website/src/docs/hotchocolate/v13/server/files.md
+++ b/website/src/docs/hotchocolate/v13/server/files.md
@@ -27,7 +27,7 @@ Hot Chocolate implements the [GraphQL multipart request specification](https://g
 src="https://www.youtube.com/embed/XeF3IuGDq4A"frameborder="0"
 allowfullscreen></iframe>
 
-> ⚠️ Note: Files can not yet be uploaded through a gateway to stitched services using the `Upload` scalar.
+> Warning: Files can not yet be uploaded through a gateway to stitched services using the `Upload` scalar.
 
 ### Usage
 
@@ -179,7 +179,7 @@ Both Relay and Apollo support this specification through community packages:
 - [react-relay-network-modern](https://github.com/relay-tools/react-relay-network-modern) using the `uploadMiddleware`
 - [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client)
 
-> ⚠️ Note: [Strawberry Shake](/docs/strawberryshake) does not yet support the `Upload` scalar.
+> Warning: [Strawberry Shake](/docs/strawberryshake) does not yet support the `Upload` scalar.
 
 ### Options
 

--- a/website/src/docs/hotchocolate/v13/server/files.md
+++ b/website/src/docs/hotchocolate/v13/server/files.md
@@ -2,8 +2,6 @@
 title: Files
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs";
-
 Handling files is traditionally not a concern of a GraphQL server, which is also why the [GraphQL over HTTP](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md) specification doesn't mention it.
 
 That being said, we recognize that at some point in the development of a new application you'll likely have to deal with files in some way or another. Which is why we want to give you some guidance on this topic.

--- a/website/src/docs/hotchocolate/v13/server/global-state.md
+++ b/website/src/docs/hotchocolate/v13/server/global-state.md
@@ -96,7 +96,7 @@ public class QueryType : ObjectType
 }
 ```
 
-> ⚠️ Note: If no value exists for the specified `key` a default value is returned an no exception is thrown.
+> Warning: If no value exists for the specified `key` a default value is returned an no exception is thrown.
 
 We can also access the Global State through the `ContextData` dictionary on the `IResolverContext`.
 

--- a/website/src/docs/hotchocolate/v13/server/global-state.md
+++ b/website/src/docs/hotchocolate/v13/server/global-state.md
@@ -2,8 +2,6 @@
 title: Global State
 ---
 
-import { ExampleTabs, Annotation, Code, Schema } from "../../../../components/mdx/example-tabs"
-
 Global State allows us to define properties on a per-request basis to be made available to all resolvers and middleware.
 
 # Initializing Global State

--- a/website/src/docs/hotchocolate/v13/server/instrumentation.md
+++ b/website/src/docs/hotchocolate/v13/server/instrumentation.md
@@ -46,7 +46,7 @@ public class MyExecutionEventListener : ExecutionDiagnosticEventListener
 }
 ```
 
-> ⚠️ Note: Diagnostic event handlers are executed synchronously as part of the GraphQL request. Long-running operations inside a diagnostic event handler will negatively impact the query performance. Expensive operations should only be enqueued from within the handler and processed by a background service.
+> Warning: Diagnostic event handlers are executed synchronously as part of the GraphQL request. Long-running operations inside a diagnostic event handler will negatively impact the query performance. Expensive operations should only be enqueued from within the handler and processed by a background service.
 
 ## Scopes
 
@@ -156,7 +156,7 @@ The following methods can be overridden.
 | ParseDocument                       | Scope that encloses the parsing of a document.                                                                                                 |
 | SyntaxError                         | Called if a document could not be parsed due to a syntax error.                                                                                |
 | ValidateDocument                    | Scope that encloses the validation of a document.                                                                                              |
-| ValidationErrors                    | Called if errors occurred during the validation of the document.                                                                                |
+| ValidationErrors                    | Called if errors occurred during the validation of the document.                                                                               |
 | AnalyzeOperationComplexity          | Called when starting to analyze the operation complexity.                                                                                      |
 | OperationComplexityAnalyzerCompiled | Called within AnalyzeOperationComplexity scope and reports that an analyzer was compiled.                                                      |
 | OperationComplexityResult           | Called within AnalyzeOperationComplexity scope and reports the outcome of the analyzer.                                                        |
@@ -234,13 +234,9 @@ allowfullscreen></iframe>
 
 ## Setup
 
-To get started, add the HotChocolate.Diagnostics package to your project.
+To get started, add the `HotChocolate.Diagnostics` package to your project.
 
-```bash
-dotnet add package HotChocolate.Diagnostics
-```
-
-> ⚠️ Note: All `HotChocolate.*` packages need to have the same version.
+<PackageInstallation packageName="HotChocolate.Diagnostics" />
 
 Next, head over to your `Program.cs` and add `AddInstrumentation` to your GraphQL configuration.
 

--- a/website/src/docs/hotchocolate/v13/server/interceptors.md
+++ b/website/src/docs/hotchocolate/v13/server/interceptors.md
@@ -47,7 +47,7 @@ public override ValueTask OnCreateAsync(HttpContext context,
 }
 ```
 
-> ⚠️ Note: `base.OnCreateAsync` should always be invoked, since the default implementation takes care of adding the dependency injection services as well as some important global state variables, such as the `ClaimsPrinicpal`. Not doing this can lead to unexpected issues.
+> Warning: `base.OnCreateAsync` should always be invoked, since the default implementation takes care of adding the dependency injection services as well as some important global state variables, such as the `ClaimsPrinicpal`. Not doing this can lead to unexpected issues.
 
 Most of the configuration will be done through the `IQueryRequestBuilder`, injected as argument to this method.
 
@@ -145,7 +145,7 @@ public override ValueTask OnRequestAsync(ISocketConnection connection,
 }
 ```
 
-> ⚠️ Note: `base.OnRequestAsync` should always be invoked, since the default implementation takes care of adding the dependency injection services as well as some important global state variables, such as the `ClaimsPrinicpal`. Not doing this can lead to unexpected issues.
+> Warning: `base.OnRequestAsync` should always be invoked, since the default implementation takes care of adding the dependency injection services as well as some important global state variables, such as the `ClaimsPrinicpal`. Not doing this can lead to unexpected issues.
 
 Most of the configuration will be done through the `IQueryRequestBuilder`, injected as argument to this method.
 
@@ -198,7 +198,7 @@ var properties = new Dictionary<string, object>
 requestBuilder.SetProperties(properties);
 ```
 
-> ⚠️ Note: This overwrites all previous properties, which is especially catastrophic, when called after the default implementation of an interceptor has added properties.
+> Warning: This overwrites all previous properties, which is especially catastrophic, when called after the default implementation of an interceptor has added properties.
 
 ## SetServices
 


### PR DESCRIPTION
Just some small changes that should make the documentation more consistent from a visual standpoint.

- Makes the ExampleTabs known to MDX, so you can just use them without having to import them

- Adds a Warning component that can be rendered by prefixing the markdown message with `> Warning:`

![image](https://user-images.githubusercontent.com/45513122/196237850-ba94e4b3-d5b0-42cc-a3bd-a38a51e478d5.png)

- Adds a PackageInstallation component that renders (consistent) instructions on how to install the package. Usage: `<PackageInstallation packageName="HotChocolate.Data.EnitytFramework" />`

![image](https://user-images.githubusercontent.com/45513122/196237573-148979f3-40e4-4c97-be81-67ab7e2a405d.png)

- Correctly redirects to 404 page in nginx configuration
