### PR TITLE
Fixed value overflows break query validation.

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Scalars/IntType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/IntType.cs
@@ -50,9 +50,9 @@ public class IntType : IntegerTypeBase<int>
         Description = description;
     }
 
-    protected override int ParseLiteral(IntValueNode valueSyntax) =>
-        valueSyntax.ToInt32();
+    protected override int ParseLiteral(IntValueNode valueSyntax)
+        => valueSyntax.ToInt32();
 
-    protected override IntValueNode ParseValue(int runtimeValue) =>
-        new(runtimeValue);
+    protected override IntValueNode ParseValue(int runtimeValue)
+        => new(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/IntegerTypeBase.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/IntegerTypeBase.cs
@@ -27,7 +27,14 @@ public abstract class IntegerTypeBase<TRuntimeType>
 
     protected override bool IsInstanceOfType(IntValueNode valueSyntax)
     {
-        return IsInstanceOfType(ParseLiteral(valueSyntax));
+        try
+        {
+            return IsInstanceOfType(ParseLiteral(valueSyntax));
+        }
+        catch (InvalidFormatException)
+        {
+            return false;
+        }
     }
 
     protected override bool IsInstanceOfType(TRuntimeType runtimeValue)

--- a/src/HotChocolate/Core/src/Validation/Rules/ValueVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/ValueVisitor.cs
@@ -223,7 +223,7 @@ internal sealed class ValueVisitor : TypeDocumentValidatorVisitor
                                     inputObjectType));
                         }
                         else if (value.Value.Kind is SyntaxKind.Variable &&
-                            !IsInstanceOfType(context, new NonNullType(field.Type), value.Value))
+                            !TryIsInstanceOfType(context, new NonNullType(field.Type), value.Value))
                         {
                             context.ReportError(
                                 context.OneOfVariablesMustBeNonNull(
@@ -332,7 +332,7 @@ internal sealed class ValueVisitor : TypeDocumentValidatorVisitor
         if (context.Types.TryPeek(out var currentType) &&
             currentType is IInputType locationType)
         {
-            if (valueNode.IsNull() || IsInstanceOfType(context, locationType, valueNode))
+            if (valueNode.IsNull() || TryIsInstanceOfType(context, locationType, valueNode))
             {
                 return Skip;
             }
@@ -348,7 +348,7 @@ internal sealed class ValueVisitor : TypeDocumentValidatorVisitor
         return Skip;
     }
 
-    private bool TryCreateValueError(
+    private static bool TryCreateValueError(
         IDocumentValidatorContext context,
         IInputType locationType,
         IValueNode valueNode,
@@ -388,6 +388,23 @@ internal sealed class ValueVisitor : TypeDocumentValidatorVisitor
         }
         node = null;
         return false;
+    }
+
+    private bool TryIsInstanceOfType(
+        IDocumentValidatorContext context,
+        IInputType inputType,
+        IValueNode value)
+    {
+        try
+        {
+            return IsInstanceOfType(context, inputType, value);
+        }
+        // in the case a scalar IsInstanceOfType check is not done well an throws we will
+        // catch this here and make sure that the validation fails correctly.
+        catch
+        {
+            return false;
+        }
     }
 
     private bool IsInstanceOfType(

--- a/src/HotChocolate/Core/test/Validation.Tests/ValuesOfCorrectTypeRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/ValuesOfCorrectTypeRuleTests.cs
@@ -212,6 +212,17 @@ public class ValuesOfCorrectTypeRuleTests
     }
 
     [Fact]
+    public void OverflowInt()
+    {
+        ExpectErrors($@"
+            {{
+              arguments {{
+                intArgField(intArg: {long.MaxValue})
+              }}
+            }}");
+    }
+
+    [Fact]
     public void GoodNullToBooleanNullableValue()
     {
         ExpectValid(@"

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ValuesOfCorrectTypeRuleTests.OverflowInt.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ValuesOfCorrectTypeRuleTests.OverflowInt.snap
@@ -1,0 +1,44 @@
+﻿[
+  {
+    "Message": "The specified argument value does not match the argument type.",
+    "Code": null,
+    "Path": {
+      "Name": "intArgField",
+      "Parent": {
+        "Name": "arguments",
+        "Parent": {
+          "Parent": null,
+          "Depth": -1,
+          "IsRoot": true
+        },
+        "Depth": 0,
+        "IsRoot": false
+      },
+      "Depth": 1,
+      "IsRoot": false
+    },
+    "Locations": [
+      {
+        "Line": 4,
+        "Column": 37
+      }
+    ],
+    "Extensions": {
+      "argument": "intArg",
+      "argumentValue": "9223372036854775807",
+      "locationType": "Int",
+      "specifiedBy": "http://spec.graphql.org/October2021/#sec-Values-of-Correct-Type"
+    },
+    "Exception": null,
+    "SyntaxNode": {
+      "Kind": "IntValue",
+      "Location": {
+        "Start": 77,
+        "End": 97,
+        "Line": 4,
+        "Column": 37
+      },
+      "Value": "9223372036854775807"
+    }
+  }
+]


### PR DESCRIPTION
Fixes #4378

This ensures that value overflows or other checks within the `IsInstanceOfType` check break the validation. We will revisit that for version 14 when we rewrite the scalar type to be simpler.