### PR TITLE
Fixed Persisted query opt-in by MSBuild prop

### DIFF
--- a/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
+++ b/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
@@ -29,7 +29,7 @@
       <GenCommand>dotnet &quot;$(GenTool)&quot; generate &quot;$(MSBuildProjectDirectory)&quot;</GenCommand>
       <GenCommand>$(GenCommand) -o $(GraphQLCodeGenerationRoot)</GenCommand>
       <GenCommand Condition="'$(RootNamespace)' != ''">$(GenCommand) -n $(RootNamespace)</GenCommand>
-      <GenCommand Condition="'$(GraphQLPersistedQueryOutput)' != ''">$(GenCommand) -q $(GraphQLQueryGenerationRoot)</GenCommand>
+      <GenCommand Condition="'$(GraphQLPersistedQueryOutput)' != ''">$(GenCommand) -q $(GraphQLPersistedQueryOutput)</GenCommand>
       <GenCommand Condition="'$(GraphQLRequestHash)' != ''">$(GenCommand) -a $(GraphQLRequestHash)</GenCommand>
       <GenCommand Condition="'$(GraphQLStrictSchemaValidation)' != 'enable'">$(GenCommand) -s</GenCommand>
       <GenCommand Condition="'$(GraphQLClientStore)' != 'enable'">$(GenCommand) -t</GenCommand>


### PR DESCRIPTION
Since upgrading to v13, Debug builds are always using persisted queries, even if you setup your project with the following to attempt to only opt-in say a Release build.
```xml
<StrawberryShake_PersistedQueryDirectory Condition="'$(Configuration)' != 'Debug'">$(MSBuildProjectDirectory)\..\$(MSBuildProjectName)PersistedQueries</StrawberryShake_PersistedQueryDirectory>`
```

I believe this is just a copy-paste error here. 

Relates to code here in the CLI.
https://github.com/ChilliCream/hotchocolate/blob/bbbaa34048a27bf8a5938405de38ececc5202fbe/src/StrawberryShake/Tooling/src/dotnet-graphql/GenerateCommand.cs#L73-L76

The idea of the string.IsNullOrEmpty is to allow opt-in via the MSBuild prop.