### PR TITLE
Fixes Strawberry shake exception handling (#4596)

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -25,7 +25,7 @@ public class ObjectFieldDescriptor
     private ParameterInfo[] _parameterInfos = Array.Empty<ParameterInfo>();
 
     /// <summary>
-    ///  Creates a new instance of <see cref="ObjectFieldDescriptor"/>
+    /// Creates a new instance of <see cref="ObjectFieldDescriptor"/>
     /// </summary>
     protected ObjectFieldDescriptor(
         IDescriptorContext context,
@@ -38,7 +38,7 @@ public class ObjectFieldDescriptor
     }
 
     /// <summary>
-    ///  Creates a new instance of <see cref="ObjectFieldDescriptor"/>
+    /// Creates a new instance of <see cref="ObjectFieldDescriptor"/>
     /// </summary>
     protected ObjectFieldDescriptor(
         IDescriptorContext context,
@@ -76,7 +76,7 @@ public class ObjectFieldDescriptor
     }
 
     /// <summary>
-    ///  Creates a new instance of <see cref="ObjectFieldDescriptor"/>
+    /// Creates a new instance of <see cref="ObjectFieldDescriptor"/>
     /// </summary>
     protected ObjectFieldDescriptor(
         IDescriptorContext context,

--- a/src/StrawberryShake/Client/src/Core/OperationResultBuilder.cs
+++ b/src/StrawberryShake/Client/src/Core/OperationResultBuilder.cs
@@ -66,6 +66,23 @@ public abstract class OperationResultBuilder<TResultData>
             errors = list;
         }
 
+        // If we have a transport error but the response does not contain any client errors
+        // we will create a client error from the provided transport error.
+        if (response.Exception is not null && errors is not { Count: > 0 })
+        {
+            errors = new IClientError[]
+            {
+                new ClientError(
+                    response.Exception.Message,
+                    ErrorCodes.InvalidResultDataStructure,
+                    exception: response.Exception,
+                    extensions: new Dictionary<string, object?>
+                    {
+                        { nameof(response.Exception.StackTrace), response.Exception.StackTrace }
+                    })
+            };
+        }
+
         return new OperationResult<TResultData>(
             data,
             dataInfo,

--- a/src/StrawberryShake/Client/src/Core/Response.cs
+++ b/src/StrawberryShake/Client/src/Core/Response.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using StrawberryShake.Properties;
 using static StrawberryShake.Properties.Resources;
 
 namespace StrawberryShake;
@@ -38,7 +39,7 @@ public sealed class Response<TBody> : IDisposable where TBody : class
     /// Additional custom data provided by client extensions.
     /// </param>
     public Response(
-        TBody body,
+        TBody? body,
         Exception? exception,
         bool isPatch = false,
         bool hasNext = false,
@@ -61,7 +62,7 @@ public sealed class Response<TBody> : IDisposable where TBody : class
     /// <summary>
     /// The serialized response body.
     /// </summary>
-    public TBody Body { get; }
+    public TBody? Body { get; }
 
     /// <summary>
     /// The transport exception.

--- a/src/StrawberryShake/Client/src/Resources/Properties/Resources.Designer.cs
+++ b/src/StrawberryShake/Client/src/Resources/Properties/Resources.Designer.cs
@@ -272,5 +272,11 @@ namespace StrawberryShake.Properties {
                 return ResourceManager.GetString("JsonResultPatcher_PathSegmentMustBeStringOrInt", resourceCulture);
             }
         }
+        
+        internal static string ResponseEnumerator_HttpNoSuccessStatusCode {
+            get {
+                return ResourceManager.GetString("ResponseEnumerator_HttpNoSuccessStatusCode", resourceCulture);
+            }
+        }
     }
 }

--- a/src/StrawberryShake/Client/src/Resources/Properties/Resources.resx
+++ b/src/StrawberryShake/Client/src/Resources/Properties/Resources.resx
@@ -132,4 +132,7 @@
   <data name="JsonResultPatcher_PathSegmentMustBeStringOrInt" xml:space="preserve">
     <value>A path segment must be a string or an integer.</value>
   </data>
+  <data name="ResponseEnumerator_HttpNoSuccessStatusCode" xml:space="preserve">
+    <value>Response status code does not indicate success: {0} ({1}).</value>
+  </data>
 </root>

--- a/src/StrawberryShake/Client/src/Transport.Http/ResponseHelper.cs
+++ b/src/StrawberryShake/Client/src/Transport.Http/ResponseHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.IO;
+using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ internal static class ResponseHelper
 {
     public static async Task<Response<JsonDocument>> TryParseResponse(
         this Stream stream,
+        Exception? transportError,
         CancellationToken cancellationToken)
     {
         try
@@ -35,14 +37,15 @@ internal static class ResponseHelper
                     hasNext = true;
                 }
 
-                return new Response<JsonDocument>(document, null, isPatch, hasNext);
+                return new Response<JsonDocument>(document, transportError, isPatch, hasNext);
             }
 
-            return new Response<JsonDocument>(document, null);
+            return new Response<JsonDocument>(document, transportError);
         }
         catch (Exception ex)
         {
-            return new Response<JsonDocument>(CreateBodyFromException(ex), ex);
+            var error = transportError ?? ex;
+            return new Response<JsonDocument>(CreateBodyFromException(error), error);
         }
     }
 

--- a/src/StrawberryShake/Client/test/Transport.WebSocket.Tests/TestHelper/TestServerHelper.cs
+++ b/src/StrawberryShake/Client/test/Transport.WebSocket.Tests/TestHelper/TestServerHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using HotChocolate;
+using HotChocolate.Execution;
 using HotChocolate.Execution.Configuration;
 using HotChocolate.StarWars;
 using Microsoft.AspNetCore.Builder;
@@ -6,6 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using static HotChocolate.WellKnownContextData;
 
 namespace StrawberryShake.Transport.WebSockets;
 
@@ -24,55 +27,93 @@ public static class TestServerHelper
                 var host = new WebHostBuilder()
                     .UseConfiguration(config)
                     .UseKestrel()
-                    .ConfigureServices(services =>
-                    {
-                        var builder = services.AddRouting().AddGraphQLServer();
+                    .ConfigureServices(
+                        services =>
+                        {
+                            var builder = services.AddRouting().AddGraphQLServer();
 
-                        configure(builder);
+                            configure(builder);
 
-                        builder
-                            .AddStarWarsTypes()
-                            .AddExportDirectiveType()
-                            .AddStarWarsRepositories()
-                            .AddInMemorySubscriptions()
-                            .ModifyOptions(
-                                o =>
-                                {
-                                    o.EnableDefer = true;
-                                    o.EnableStream = true;
-                                });
-                    })
-                    .Configure(app =>
-                        app.Use(async (ct, next) =>
-                            {
-                                try
-                                {
-                                    // Kestrel does not return proper error responses:
-                                    // https://github.com/aspnet/KestrelHttpServer/issues/43
-                                    await next();
-                                }
-                                catch (Exception ex)
-                                {
-                                    if (ct.Response.HasStarted)
+                            builder
+                                .AddStarWarsTypes()
+                                .AddExportDirectiveType()
+                                .AddStarWarsRepositories()
+                                .AddInMemorySubscriptions()
+                                .ModifyOptions(
+                                    o =>
                                     {
-                                        throw;
-                                    }
+                                        o.EnableDefer = true;
+                                        o.EnableStream = true;
+                                    })
+                                .UseDefaultPipeline()
+                                .UseRequest(
+                                    next => async context =>
+                                    {
+                                        if (context.ContextData.TryGetValue(
+                                                nameof(HttpContext),
+                                                out var value) &&
+                                            value is HttpContext httpContext &&
+                                            context.Result is IQueryResult result)
+                                        {
+                                            var headers = httpContext.Request.Headers;
+                                            if (headers.ContainsKey("sendErrorStatusCode"))
+                                            {
+                                                context.Result = result =
+                                                    QueryResultBuilder
+                                                        .FromResult(result)
+                                                        .SetContextData(HttpStatusCode, 403)
+                                                        .Create();
+                                            }
 
-                                    ct.Response.StatusCode = 500;
-                                    ct.Response.Headers.Clear();
-                                    await ct.Response.WriteAsync(ex.ToString());
-                                }
-                            })
-                            .UseWebSockets()
-                            .UseRouting()
-                            .UseEndpoints(e => e.MapGraphQL()))
+                                            if (headers.ContainsKey("sendError"))
+                                            {
+                                                context.Result =
+                                                    QueryResultBuilder
+                                                        .FromResult(result)
+                                                        .AddError(new Error("Some error!"))
+                                                        .Create();
+                                            }
+                                        }
+
+                                        await next(context);
+                                    });
+                        })
+                    .Configure(
+                        app =>
+                            app.Use(
+                                    async (ct, next) =>
+                                    {
+                                        try
+                                        {
+                                            // Kestrel does not return proper error responses:
+                                            // https://github.com/aspnet/KestrelHttpServer/issues/43
+                                            await next();
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            if (ct.Response.HasStarted)
+                                            {
+                                                throw;
+                                            }
+
+                                            ct.Response.StatusCode = 500;
+                                            ct.Response.Headers.Clear();
+                                            await ct.Response.WriteAsync(ex.ToString());
+                                        }
+                                    })
+                                .UseWebSockets()
+                                .UseRouting()
+                                .UseEndpoints(e => e.MapGraphQL()))
                     .Build();
 
                 host.Start();
 
                 return host;
             }
-            catch { }
+            catch
+            {
+                // we ignore any errors here and try the next port
+            }
         }
 
         throw new InvalidOperationException("Not port found");

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsGetFriendsTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsGetFriendsTest.cs
@@ -77,5 +77,94 @@ namespace StrawberryShake.CodeGeneration.CSharp.Integration.StarWarsGetFriends
                     "Response status code does not indicate success: 404 (Not Found).",
                     error.Message));
         }
+
+        [Fact]
+        public async Task Execute_StarWarsGetFriends_Test_403_And_Success_Content_1()
+        {
+            // arrange
+            var ct = new CancellationTokenSource(20_000).Token;
+            using var host = TestServerHelper.CreateServer(
+                _ => { },
+                out var port);
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection
+                .AddStarWarsGetFriendsClient()
+                .ConfigureHttpClient(
+                    c =>
+                    {
+                        c.BaseAddress = new Uri("http://localhost:" + port + "/graphql");
+                        c.DefaultRequestHeaders.Add("sendErrorStatusCode", "1");
+                        c.DefaultRequestHeaders.Add("sendError", "1");
+                    })
+                .ConfigureWebSocketClient(
+                    c => c.Uri = new Uri("ws://localhost:" + port + "/graphql"));
+
+            IServiceProvider services = serviceCollection.BuildServiceProvider();
+            var client =
+                services.GetRequiredService<IStarWarsGetFriendsClient>();
+
+            // act
+            var result = await client.GetHero.ExecuteAsync(ct);
+
+            // assert
+            Assert.Equal("R2-D2", result.Data?.Hero?.Name);
+            Assert.Collection(
+                result.Data!.Hero!.Friends!.Nodes!,
+                item => Assert.Equal("Luke Skywalker", item?.Name),
+                item => Assert.Equal("Han Solo", item?.Name),
+                item => Assert.Equal("Leia Organa", item?.Name));
+            Assert.NotNull(result.Errors);
+            Assert.Collection(result.Errors,
+                error => Assert.Equal(
+                    "Some error!",
+                    error.Message));
+        }
+
+        [Fact]
+        public async Task Execute_StarWarsGetFriends_Test_403_And_Success_Content_2()
+        {
+            // arrange
+            var ct = new CancellationTokenSource(20_000).Token;
+            using var host = TestServerHelper.CreateServer(
+                _ => { },
+                out var port);
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection
+                .AddStarWarsGetFriendsClient()
+                .ConfigureHttpClient(
+                    c =>
+                    {
+                        c.BaseAddress = new Uri("http://localhost:" + port + "/graphql");
+                        c.DefaultRequestHeaders.Add("sendErrorStatusCode", "1");
+                    })
+                .ConfigureWebSocketClient(
+                    c => c.Uri = new Uri("ws://localhost:" + port + "/graphql"));
+
+            IServiceProvider services = serviceCollection.BuildServiceProvider();
+            var client =
+                services.GetRequiredService<IStarWarsGetFriendsClient>();
+
+            // act
+            var result = await client.GetHero.ExecuteAsync(ct);
+
+            // assert
+            Assert.Equal("R2-D2", result.Data?.Hero?.Name);
+            Assert.Collection(
+                result.Data!.Hero!.Friends!.Nodes!,
+                item => Assert.Equal("Luke Skywalker", item?.Name),
+                item => Assert.Equal("Han Solo", item?.Name),
+                item => Assert.Equal("Leia Organa", item?.Name));
+            Assert.NotNull(result.Errors);
+            Assert.Collection(result.Errors,
+                error =>
+                {
+                    Assert.Equal(
+                        "Response status code does not indicate success: 403 (Forbidden).",
+                        error.Message);
+                    Assert.IsType<HttpRequestException>(error.Exception);
+                });
+        }
     }
 }


### PR DESCRIPTION
Pass through GraphQL errors correctly on unsuccessful HTTP response codes. 

- Attempt to parse json on any response, which will allow errors to be correctly passed through. 
- If json parsing fails, we'll ensure the status code as before

Closes #4596 
