### PR TITLE
Fix description of delegate resolver $arguments variable

### DIFF
--- a/website/src/docs/hotchocolate/v13/distributed-schema/schema-configuration.md
+++ b/website/src/docs/hotchocolate/v13/distributed-schema/schema-configuration.md
@@ -324,7 +324,7 @@ extend type Product {
 @delegate(path: "inventoryInfo(upc: $arguments:sku).isInStock")
 ```
 
-With the `$fields` variable you can access fields of the type you extend.
+With the `$arguments` variable you can access the arguments of the Gateway resolver
 
 ```sdl
 extend type Query {


### PR DESCRIPTION
It looks like this was copy/pasted from the $fields variable above and didn't really make sense.

I have amended the description in the $arguments section to be about this variable