### PR TITLE
[Fusion] Removed temporary comments from TypeDefinitionExtensions

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Extensions/TypeDefinitionExtensions.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Extensions/TypeDefinitionExtensions.cs
@@ -1,5 +1,6 @@
 using HotChocolate.Types;
 using HotChocolate.Types.Mutable;
+using static HotChocolate.Fusion.Properties.CompositionResources;
 using static HotChocolate.Fusion.WellKnownArgumentNames;
 using static HotChocolate.Fusion.WellKnownDirectiveNames;
 
@@ -7,7 +8,6 @@ namespace HotChocolate.Fusion.Extensions;
 
 internal static class TypeDefinitionExtensions
 {
-    // todo put all of this data in the execution schema.
     public static IEnumerable<MutableObjectTypeDefinition> GetPossibleTypes(
         this ITypeDefinition type,
         string schemaName,
@@ -16,7 +16,7 @@ internal static class TypeDefinitionExtensions
         if (type.Kind is not TypeKind.Object and not TypeKind.Interface and not TypeKind.Union)
         {
             throw new ArgumentException(
-                "The specified type is not an abstract type.", // tmp not very accurate message + loc
+                TypeDefinitionExtensions_TheSpecifiedTypeIsNotAnAbstractType,
                 nameof(type));
         }
 

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Properties/CompositionResources.Designer.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Properties/CompositionResources.Designer.cs
@@ -1248,6 +1248,15 @@ namespace HotChocolate.Fusion.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The specified type is not an abstract type..
+        /// </summary>
+        internal static string TypeDefinitionExtensions_TheSpecifiedTypeIsNotAnAbstractType {
+            get {
+                return ResourceManager.GetString("TypeDefinitionExtensions_TheSpecifiedTypeIsNotAnAbstractType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; is missing..
         /// </summary>
         internal static string TypeDefinitionInvalidRule_ArgumentMissing {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Properties/CompositionResources.resx
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Properties/CompositionResources.resx
@@ -414,6 +414,9 @@
   <data name="ShareableMutableDirectiveDefinition_Description" xml:space="preserve">
     <value>The @shareable directive allows multiple source schemas to define the same field, ensuring that this decision is both intentional and coordinated by requiring fields to be explicitly marked.</value>
   </data>
+  <data name="TypeDefinitionExtensions_TheSpecifiedTypeIsNotAnAbstractType" xml:space="preserve">
+    <value>The specified type is not an abstract type.</value>
+  </data>
   <data name="TypeDefinitionInvalidRule_ArgumentMissing" xml:space="preserve">
     <value>The argument '{0}' is missing.</value>
   </data>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Removed temporary comments from TypeDefinitionExtensions.