### PR TITLE
[Fusion] Properly format multiline compose output

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.CommandLine/Commands/ComposeCommand.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.CommandLine/Commands/ComposeCommand.cs
@@ -616,7 +616,7 @@ internal sealed class ComposeCommand : Command
 
     /// <summary>
     /// Since we're prefixing the message with an emoji and space before printing,
-    /// we need to also indent each line of a multiline message by two spaces to fix the alignment.
+    /// we need to also indent each line of a multiline message by three spaces to fix the alignment.
     /// </summary>
     private static string FormatMultilineMessage(string message)
     {


### PR DESCRIPTION
I found long lists of errors a bit hard to scan, since the hierarchy was slightly interrupted by the second line not being aligned below the first line's text.
Thought about also covering the `[ERR] ` with indentation, but it got a bit too spaced out for my taste...

**Before**
<img width="1488" height="346" alt="CleanShot 2025-08-18 at 13 55 07@2x" src="https://github.com/user-attachments/assets/b7c7ab67-6258-4da6-a3a2-104a99716d49" />

**After**
<img width="1526" height="342" alt="CleanShot 2025-08-18 at 14 58 06@2x" src="https://github.com/user-attachments/assets/09d268c0-d243-4872-a291-84464730f4a4" />
