### PR TITLE
Fixed incorrect parameter type in FieldSelectionMapValidator

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Utilities/Validators/FieldSelectionMapValidator.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Utilities/Validators/FieldSelectionMapValidator.cs
@@ -306,7 +306,7 @@ public sealed class FieldSelectionMapValidator(ISchemaDefinition schema)
     }
 
     protected override ISyntaxVisitorAction Leave(
-        ObjectValueSelectionNode node,
+        ObjectFieldSelectionNode node,
         FieldSelectionMapValidatorContext context)
     {
         context.InputTypes.Pop();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed incorrect parameter type in FieldSelectionMapValidator.