### PR TITLE
Fix race condition in RequestExecutor creation

### DIFF
--- a/src/HotChocolate/Core/src/Execution.Abstractions/Execution/RequestExecutorProxy.cs
+++ b/src/HotChocolate/Core/src/Execution.Abstractions/Execution/RequestExecutorProxy.cs
@@ -189,8 +189,8 @@ public class RequestExecutorProxy : IRequestExecutor, IDisposable
                     .GetExecutorAsync(_schemaName, cancellationToken)
                     .ConfigureAwait(false);
 
-                CurrentExecutor = executor;
                 OnConfigureRequestExecutor(executor, null);
+                CurrentExecutor = executor;
             }
             else
             {


### PR DESCRIPTION
If two requests come in roughly at the same time. The first request enters the lock to create the request executor.
Once the exeuctor is constructed it's being assigned to the `CurrentExecutor` property.
The second request can now already take the executor without waiting for the lock i.e. the construction to finish.
That's unfortunate, since the `OnConfigureRequestExecutor` is run after the property assignment, so the `ExecutorSession` might not yet have been associated with the executor, when the second request already tries to use the executor.

This PR fixes this, by simply moving the `OnConfigureRequestExecutor` before the `CurrentExecutor` assignment.