### PR TITLE
Fix race condition on MethodInfo.GetParameters()

### DIFF
--- a/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Members.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Members.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Reflection;
 using HotChocolate.Utilities;
 

--- a/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Members.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Members.cs
@@ -43,7 +43,8 @@ public sealed partial class ExtendedType
                     method,
                     cache));
 
-            var parameterTypes = ImmutableDictionary.CreateBuilder<ParameterInfo, IExtendedType>();
+            var parameterTypes = ImmutableDictionary.CreateBuilder<ParameterInfo, IExtendedType>(
+                ParameterInfoComparer.Instance);
 
             foreach (var parameter in parameters)
             {

--- a/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Members.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Members.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection;
 using HotChocolate.Utilities;
 
@@ -28,7 +29,10 @@ public sealed partial class ExtendedType
             };
         }
 
-        public static ExtendedMethodInfo FromMethod(MethodInfo method, TypeCache cache)
+        public static ExtendedMethodInfo FromMethod(
+            MethodInfo method,
+            ParameterInfo[] parameters,
+            TypeCache cache)
         {
             var helper = new NullableHelper(method.DeclaringType!);
             var context = helper.GetContext(method);
@@ -40,7 +44,6 @@ public sealed partial class ExtendedType
                     method,
                     cache));
 
-            var parameters = method.GetParameters();
             var parameterTypes = ImmutableDictionary.CreateBuilder<ParameterInfo, IExtendedType>();
 
             foreach (var parameter in parameters)

--- a/src/HotChocolate/Core/src/Types/Internal/ExtendedType.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ExtendedType.cs
@@ -205,12 +205,16 @@ public sealed partial class ExtendedType : IExtendedType
         return Members.FromMember(member, cache);
     }
 
-    internal static ExtendedMethodInfo FromMethod(MethodInfo method, TypeCache cache)
+    internal static ExtendedMethodInfo FromMethod(
+        MethodInfo method,
+        ParameterInfo[] parameters,
+        TypeCache cache)
     {
         ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(parameters);
         ArgumentNullException.ThrowIfNull(cache);
 
-        return Members.FromMethod(method, cache);
+        return Members.FromMethod(method, parameters, cache);
     }
 
     /// <summary>

--- a/src/HotChocolate/Core/src/Types/Internal/ParameterInfoComparer.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ParameterInfoComparer.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+
+namespace HotChocolate.Internal;
+
+internal sealed class ParameterInfoComparer : IEqualityComparer<ParameterInfo>
+{
+    public bool Equals(ParameterInfo? x, ParameterInfo? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return x.MetadataToken == y.MetadataToken
+            && x.Member.Module.MetadataToken == y.Member.Module.MetadataToken;
+    }
+
+    public int GetHashCode(ParameterInfo obj)
+    {
+        return HashCode.Combine(obj.MetadataToken, obj.Member.Module.MetadataToken);
+    }
+
+    public static readonly ParameterInfoComparer Instance = new();
+}

--- a/src/HotChocolate/Core/src/Types/Types/Attributes/SubscribeAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Attributes/SubscribeAttribute.cs
@@ -35,7 +35,7 @@ public sealed class SubscribeAttribute : ObjectFieldDescriptorAttribute
         if (MessageType is null)
         {
             var messageParameter =
-                method.GetParameters()
+                context.TypeInspector.GetParameters(method)
                     .FirstOrDefault(t => t.IsDefined(typeof(EventMessageAttribute)));
 
             if (messageParameter is null)

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
@@ -35,7 +35,7 @@ public class DefaultTypeInspector(bool ignoreRequiredAttribute = false) : Conven
     private readonly TypeCache _typeCache = new();
     private readonly ConcurrentDictionary<MethodInfo, ExtendedMethodInfo> _methods = [];
     private readonly ConcurrentDictionary<(Type, bool, bool), MemberInfo[]> _membersCache = new();
-    private readonly Dictionary<MethodInfo, ParameterInfo[]> _parametersCache = new();
+    private readonly ConcurrentDictionary<MethodInfo, ParameterInfo[]> _parametersCache = new();
 
     /// <summary>
     /// Infer type to be non-null if <see cref="RequiredAttribute"/> is found.
@@ -100,7 +100,7 @@ public class DefaultTypeInspector(bool ignoreRequiredAttribute = false) : Conven
             }
 
             parameters = method.GetParameters();
-            _parametersCache[method] = parameters;
+            _parametersCache.TryAdd(method, parameters);
 
             return parameters;
         }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/ITypeInspector.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/ITypeInspector.cs
@@ -35,6 +35,17 @@ public interface ITypeInspector : IConvention
         bool allowObject = false);
 
     /// <summary>
+    /// Gets the parameters of <paramref name="method"/> in a thread-safe manner.
+    /// </summary>
+    /// <param name="method">
+    /// The method to get the parameters from.
+    /// </param>
+    /// <returns>
+    /// The parameters of the <paramref name="method"/>.
+    /// </returns>
+    ParameterInfo[] GetParameters(MethodInfo method);
+
+    /// <summary>
     /// Defines if a member shall be ignored. This method interprets ignore attributes.
     /// </summary>
     /// <param name="member">

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -52,7 +52,7 @@ public class InterfaceFieldDescriptor
 
         if (member is MethodInfo m)
         {
-            _parameterInfos = m.GetParameters();
+            _parameterInfos = context.TypeInspector.GetParameters(m);
             Parameters = _parameterInfos.ToDictionary(t => t.Name!, StringComparer.Ordinal);
         }
     }
@@ -241,7 +241,7 @@ public class InterfaceFieldDescriptor
 
             if (propertyOrMethod is MethodInfo m)
             {
-                _parameterInfos = m.GetParameters();
+                _parameterInfos = Context.TypeInspector.GetParameters(m);
                 Parameters = _parameterInfos.ToDictionary(t => t.Name!, StringComparer.Ordinal);
             }
 

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -62,7 +62,7 @@ public class ObjectFieldDescriptor
 
         if (member is MethodInfo m)
         {
-            _parameterInfos = m.GetParameters();
+            _parameterInfos = context.TypeInspector.GetParameters(m);
             Parameters = _parameterInfos.ToDictionary(t => t.Name!, StringComparer.Ordinal);
             Configuration.ResultType = m.ReturnType;
         }
@@ -172,7 +172,7 @@ public class ObjectFieldDescriptor
 
                 if (subscribeMember is MethodInfo subscribeMethod)
                 {
-                    var subscribeParameters = subscribeMethod.GetParameters();
+                    var subscribeParameters = Context.TypeInspector.GetParameters(subscribeMethod);
                     var parameterLength = _parameterInfos.Length + subscribeParameters.Length;
                     var parameters = new ParameterInfo[parameterLength];
 
@@ -397,7 +397,7 @@ public class ObjectFieldDescriptor
 
             if (propertyOrMethod is MethodInfo m)
             {
-                _parameterInfos = m.GetParameters();
+                _parameterInfos = Context.TypeInspector.GetParameters(m);
                 Parameters = _parameterInfos.ToDictionary(t => t.Name!, StringComparer.Ordinal);
             }
 

--- a/src/HotChocolate/Core/src/Types/Types/Interceptors/ResolverTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Interceptors/ResolverTypeInterceptor.cs
@@ -401,7 +401,8 @@ internal sealed class ResolverTypeInterceptor : TypeInterceptor
     {
         if (member is MethodInfo method)
         {
-            foreach (var parameter in _resolverCompiler.GetArgumentParameters(method.GetParameters()))
+            var parameters = _context.TypeInspector.GetParameters(method);
+            foreach (var parameter in _resolverCompiler.GetArgumentParameters(parameters))
             {
                 _parameters[parameter.Name!] = parameter;
             }

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/ResolverCompilerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/ResolverCompilerTests.cs
@@ -22,11 +22,12 @@ public class ResolverCompilerTests
     public async Task Compile_TaskObjMethod_NoParams_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ObjectTaskResolver))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -40,11 +41,12 @@ public class ResolverCompilerTests
     public async Task Compile_TaskStringMethod_NoParams_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringTaskResolver))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -58,11 +60,12 @@ public class ResolverCompilerTests
     public async Task Compile_TaskStringMethod_WithParams_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringTaskResolverWithArg))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -77,11 +80,12 @@ public class ResolverCompilerTests
     public async Task Compile_ObjMethod_NoParams_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ObjectResolver))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -95,11 +99,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringMethod_NoParams_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringResolver))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -113,11 +118,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringMethod_WithParams_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringResolverWithArg))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -132,11 +138,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringValueNodeMethod_WithParams_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringValueNodeResolverWithArg))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -152,11 +159,12 @@ public class ResolverCompilerTests
     public async Task Compile_OptionalStringMethod_WithParams_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.OptionalStringResolverWithArg))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -172,11 +180,12 @@ public class ResolverCompilerTests
     public async Task Compile_ObjTaskProperty_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetProperty("ObjectTaskStringProp")!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -190,11 +199,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringTaskProperty_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetProperty("StringTaskResolverProp")!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -208,11 +218,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringProperty_SourceResolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetProperty("StringProp")!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -226,11 +237,12 @@ public class ResolverCompilerTests
     public async Task Compile_TaskObjMethod_NoParams_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ObjectTaskResolver))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -245,11 +257,12 @@ public class ResolverCompilerTests
     public async Task Compile_TaskStringMethod_NoParams_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringTaskResolver))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -264,11 +277,12 @@ public class ResolverCompilerTests
     public async Task Compile_TaskStringMethod_WithParams_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringTaskResolverWithArg))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -284,11 +298,12 @@ public class ResolverCompilerTests
     public async Task Compile_ObjMethod_NoParams_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ObjectResolver))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -303,11 +318,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringMethod_NoParams_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringResolver))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -322,11 +338,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringMethod_WithParams_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.StringResolverWithArg))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -342,11 +359,12 @@ public class ResolverCompilerTests
     public async Task Compile_ObjTaskProperty_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetProperty("ObjectTaskStringProp")!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -361,11 +379,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringTaskProperty_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetProperty("StringTaskResolverProp")!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -380,11 +399,12 @@ public class ResolverCompilerTests
     public async Task Compile_StringProperty_Resolver()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetProperty("StringProp")!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver =
             compiler.CompileResolve(member, typeof(Entity), type).Resolver!;
 
@@ -399,11 +419,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_CancellationToken()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithCancellationToken))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -418,11 +439,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_ResolverContext()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithResolverContext))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -436,11 +458,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_FieldSelection()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithFieldSelection))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -458,11 +481,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_Selection()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithSelection))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
         var pure = compiler.CompileResolve(member, type).PureResolver!;
 
@@ -484,11 +508,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_FieldSyntax()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithFieldSyntax))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
         var pure = compiler.CompileResolve(member, type).PureResolver!;
 
@@ -519,11 +544,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_ObjectType()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithObjectType))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -544,11 +570,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_Operation()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithOperationDefinition))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -578,11 +605,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_ObjectField()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithObjectField))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -608,11 +636,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_IOutputField()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithOutputField))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -638,11 +667,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_Document()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithDocument))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -661,11 +691,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_Schema()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithSchema))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -685,11 +716,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_Service()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.ResolverWithService))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -706,12 +738,13 @@ public class ResolverCompilerTests
     public async Task Compile_GetGlobalState_With_Key()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetGlobalStateWithKey))!;
         var contextData = new Dictionary<string, object?> { { "foo", "bar" } };
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -726,12 +759,13 @@ public class ResolverCompilerTests
     public async Task Compile_GetGlobalState()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetGlobalState))!;
         var contextData = new Dictionary<string, object?> { { "foo", "bar" } };
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -746,12 +780,13 @@ public class ResolverCompilerTests
     public async Task Compile_GetGlobalState_State_Does_Not_Exist()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetGlobalState))!;
         var contextData = new Dictionary<string, object?>();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -766,12 +801,13 @@ public class ResolverCompilerTests
     public async Task Compile_GetGlobalState_With_Default_Abc()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetGlobalStateWithDefaultAbc))!;
         var contextData = new Dictionary<string, object?>();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -786,12 +822,13 @@ public class ResolverCompilerTests
     public async Task Compile_GetGlobalState_With_Default()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetGlobalStateWithDefault))!;
         var contextData = new Dictionary<string, object?>();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -806,12 +843,13 @@ public class ResolverCompilerTests
     public async Task Compile_GetGlobalState_Nullable()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetGlobalStateNullable))!;
         var contextData = new Dictionary<string, object?>();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -826,12 +864,13 @@ public class ResolverCompilerTests
     public async Task Compile_SetGlobalState()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.SetGlobalState))!;
         var contextData = new Dictionary<string, object?>();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -848,13 +887,14 @@ public class ResolverCompilerTests
     public async Task Compile_SetGlobalState_Generic()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.SetGlobalStateGeneric))!;
 
         var contextData = new Dictionary<string, object?>();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -871,13 +911,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetScopedState_With_Key()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetScopedStateWithKey))!;
         var contextData = new Dictionary<string, object?> { { "foo", "bar" } }
             .ToImmutableDictionary();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -892,6 +933,7 @@ public class ResolverCompilerTests
     public async Task Compile_GetScopedState()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetScopedState))!;
 
@@ -899,7 +941,7 @@ public class ResolverCompilerTests
             .ToImmutableDictionary();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -914,13 +956,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetScopedState_State_Does_Not_Exist()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetScopedState))!;
         var contextData =
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -935,6 +978,7 @@ public class ResolverCompilerTests
     public async Task Compile_GetScopedState_With_Default_Abc()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetScopedStateWithDefaultAbc))!;
 
@@ -942,7 +986,7 @@ public class ResolverCompilerTests
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -957,6 +1001,7 @@ public class ResolverCompilerTests
     public async Task Compile_GetScopedState_With_Default()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetScopedStateWithDefault))!;
 
@@ -964,7 +1009,7 @@ public class ResolverCompilerTests
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -979,6 +1024,7 @@ public class ResolverCompilerTests
     public async Task Compile_GetScopedState_Nullable()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetScopedStateNullable))!;
 
@@ -986,7 +1032,7 @@ public class ResolverCompilerTests
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1001,6 +1047,7 @@ public class ResolverCompilerTests
     public async Task Compile_SetScopedState()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.SetScopedState))!;
 
@@ -1008,7 +1055,7 @@ public class ResolverCompilerTests
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1027,6 +1074,7 @@ public class ResolverCompilerTests
     public async Task Compile_SetScopedState_Generic()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.SetScopedStateGeneric))!;
 
@@ -1034,7 +1082,7 @@ public class ResolverCompilerTests
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1053,13 +1101,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetLocalState_With_Key()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetLocalStateWithKey))!;
         var contextData = new Dictionary<string, object?> { { "foo", "bar" } }
             .ToImmutableDictionary();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1074,13 +1123,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetLocalState()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetLocalState))!;
         var contextData = new Dictionary<string, object?> { { "foo", "bar" } }
             .ToImmutableDictionary();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1095,13 +1145,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetLocalState_State_Does_Not_Exist()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetLocalState))!;
         var contextData =
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1116,13 +1167,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetLocalState_With_Default_Abc()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetLocalStateWithDefaultAbc))!;
         var contextData =
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1137,13 +1189,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetLocalState_With_Default()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetLocalStateWithDefault))!;
         var contextData =
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1158,6 +1211,7 @@ public class ResolverCompilerTests
     public async Task Compile_SetLocalState()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.SetLocalState))!;
 
@@ -1165,7 +1219,7 @@ public class ResolverCompilerTests
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1184,6 +1238,7 @@ public class ResolverCompilerTests
     public async Task Compile_SetLocalState_Generic()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.SetLocalStateGeneric))!;
 
@@ -1191,7 +1246,7 @@ public class ResolverCompilerTests
             ImmutableDictionary<string, object?>.Empty;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1210,6 +1265,7 @@ public class ResolverCompilerTests
     public async Task Compile_GetClaimsPrincipal()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetClaimsPrincipal))!;
 
@@ -1219,7 +1275,7 @@ public class ResolverCompilerTests
         };
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1234,13 +1290,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetClaimsPrincipal_ClaimsNotExists()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetClaimsPrincipal))!;
 
         var contextData = new Dictionary<string, object?>();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1256,13 +1313,14 @@ public class ResolverCompilerTests
     public async Task Compile_GetNullableClaimsPrincipal_ClaimsNotExists()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetNullableClaimsPrincipal))!;
 
         var contextData = new Dictionary<string, object?>();
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert
@@ -1278,11 +1336,12 @@ public class ResolverCompilerTests
     public async Task Compile_Arguments_Path()
     {
         // arrange
+        var typeInspector = new DefaultTypeInspector();
         var type = typeof(Resolvers);
         MemberInfo member = type.GetMethod(nameof(Resolvers.GetPath))!;
 
         // act
-        var compiler = new DefaultResolverCompiler(EmptyServiceProvider.Instance, _empty);
+        var compiler = new DefaultResolverCompiler(typeInspector, EmptyServiceProvider.Instance, _empty);
         var resolver = compiler.CompileResolve(member, type).Resolver!;
 
         // assert

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/FilterInputTypeTest.FilterInputType_Should_ThrowException_WhenNoConventionIsRegistered.snap
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/FilterInputTypeTest.FilterInputType_Should_ThrowException_WhenNoConventionIsRegistered.snap
@@ -6,7 +6,7 @@ For more details look at the `Errors` property.
  (HotChocolate.Types.ObjectType)
 
    at HotChocolate.Data.FilterDescriptorContextExtensions.<>c__DisplayClass1_0.<GetFilterConvention>b__0() in FilterDescriptorContextExtensions.cs:line 19
-   at HotChocolate.Types.Descriptors.DescriptorContext.GetConventionOrDefault[T](Func`1 factory, String scope) in DescriptorContext.cs:line 165
+   at HotChocolate.Types.Descriptors.DescriptorContext.GetConventionOrDefault[T](Func`1 factory, String scope) in DescriptorContext.cs:line 158
    at HotChocolate.Data.FilterDescriptorContextExtensions.GetFilterConvention(IDescriptorContext context, String scope) in FilterDescriptorContextExtensions.cs:line 18
    at HotChocolate.Types.FilterObjectFieldDescriptorExtensions.<>c__DisplayClass5_0.<UseFiltering>b__1(IDescriptorContext c, ObjectFieldConfiguration definition) in FilterObjectFieldDescriptorExtensions.cs:line 128
    at HotChocolate.Types.Descriptors.DescriptorBase`1.<>c__DisplayClass21_0.<OnBeforeCreate>b__0(IDescriptorContext c, ITypeSystemConfiguration d) in DescriptorBase~1.cs:line 97

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/FilterInputTypeTest.FilterInputType_Should_ThrowException_WhenNoConventionIsRegisteredDefault.snap
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/FilterInputTypeTest.FilterInputType_Should_ThrowException_WhenNoConventionIsRegisteredDefault.snap
@@ -6,7 +6,7 @@ For more details look at the `Errors` property.
  (HotChocolate.Types.ObjectType)
 
    at HotChocolate.Data.FilterDescriptorContextExtensions.<>c__DisplayClass1_0.<GetFilterConvention>b__0() in FilterDescriptorContextExtensions.cs:line 19
-   at HotChocolate.Types.Descriptors.DescriptorContext.GetConventionOrDefault[T](Func`1 factory, String scope) in DescriptorContext.cs:line 165
+   at HotChocolate.Types.Descriptors.DescriptorContext.GetConventionOrDefault[T](Func`1 factory, String scope) in DescriptorContext.cs:line 158
    at HotChocolate.Data.FilterDescriptorContextExtensions.GetFilterConvention(IDescriptorContext context, String scope) in FilterDescriptorContextExtensions.cs:line 18
    at HotChocolate.Types.FilterObjectFieldDescriptorExtensions.<>c__DisplayClass5_0.<UseFiltering>b__1(IDescriptorContext c, ObjectFieldConfiguration definition) in FilterObjectFieldDescriptorExtensions.cs:line 128
    at HotChocolate.Types.Descriptors.DescriptorBase`1.<>c__DisplayClass21_0.<OnBeforeCreate>b__0(IDescriptorContext c, ITypeSystemConfiguration d) in DescriptorBase~1.cs:line 97

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/SortInputTypeTests.SortInputType_Should_ThrowException_WhenNoConventionIsRegistered.snap
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/SortInputTypeTests.SortInputType_Should_ThrowException_WhenNoConventionIsRegistered.snap
@@ -6,7 +6,7 @@ For more details look at the `Errors` property.
  (HotChocolate.Types.ObjectType)
 
    at HotChocolate.Data.SortDescriptorContextExtensions.<>c__DisplayClass1_0.<GetSortConvention>b__0() in SortDescriptorContextExtensions.cs:line 20
-   at HotChocolate.Types.Descriptors.DescriptorContext.GetConventionOrDefault[T](Func`1 factory, String scope) in DescriptorContext.cs:line 165
+   at HotChocolate.Types.Descriptors.DescriptorContext.GetConventionOrDefault[T](Func`1 factory, String scope) in DescriptorContext.cs:line 158
    at HotChocolate.Data.SortDescriptorContextExtensions.GetSortConvention(IDescriptorContext context, String scope) in SortDescriptorContextExtensions.cs:line 19
    at HotChocolate.Types.SortingObjectFieldDescriptorExtensions.<>c__DisplayClass5_0.<UseSortingInternal>b__1(IDescriptorContext c, ObjectFieldConfiguration definition) in SortingObjectFieldDescriptorExtensions.cs:line 130
    at HotChocolate.Types.Descriptors.DescriptorBase`1.<>c__DisplayClass21_0.<OnBeforeCreate>b__0(IDescriptorContext c, ITypeSystemConfiguration d) in DescriptorBase~1.cs:line 97

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/SortInputTypeTests.SortInputType_Should_ThrowException_WhenNoConventionIsRegisteredDefault.snap
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/SortInputTypeTests.SortInputType_Should_ThrowException_WhenNoConventionIsRegisteredDefault.snap
@@ -6,7 +6,7 @@ For more details look at the `Errors` property.
  (HotChocolate.Types.ObjectType)
 
    at HotChocolate.Data.SortDescriptorContextExtensions.<>c__DisplayClass1_0.<GetSortConvention>b__0() in SortDescriptorContextExtensions.cs:line 20
-   at HotChocolate.Types.Descriptors.DescriptorContext.GetConventionOrDefault[T](Func`1 factory, String scope) in DescriptorContext.cs:line 165
+   at HotChocolate.Types.Descriptors.DescriptorContext.GetConventionOrDefault[T](Func`1 factory, String scope) in DescriptorContext.cs:line 158
    at HotChocolate.Data.SortDescriptorContextExtensions.GetSortConvention(IDescriptorContext context, String scope) in SortDescriptorContextExtensions.cs:line 19
    at HotChocolate.Types.SortingObjectFieldDescriptorExtensions.<>c__DisplayClass5_0.<UseSortingInternal>b__1(IDescriptorContext c, ObjectFieldConfiguration definition) in SortingObjectFieldDescriptorExtensions.cs:line 130
    at HotChocolate.Types.Descriptors.DescriptorBase`1.<>c__DisplayClass21_0.<OnBeforeCreate>b__0(IDescriptorContext c, ITypeSystemConfiguration d) in DescriptorBase~1.cs:line 97


### PR DESCRIPTION
Fixes #8433

`RuntimeMethodInfo.GetParameters` is [not thread-safe](https://source.dot.net/#System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs,f1e3caae285df850,references), but we request parameters in a variety of places during type initialization. Because of this we could end up with two different `ParameterInfo` instances for the same parameter, which leads to the missing dictionary key error reported in the linked issue.

This PR addresses this issue by adding a new thread-safe `ITypeInspector.GetParameters()` that also caches the parameter instances, similar to `GetMembers`.
After Feedback from Michael I also added a `ParameterInfoComparer` that ensures that this also works if we ever decide to make the `ExtendedMethodInfo` public and there's a race condition between us and the developer calling `GetParameters`.