### PR TITLE
Properly highlight diff code-blocks on website

### DIFF
--- a/website/gatsby-browser.js
+++ b/website/gatsby-browser.js
@@ -8,3 +8,4 @@ require("prismjs/components/prism-graphql");
 require("prismjs/components/prism-json");
 require("prismjs/components/prism-bash");
 require("prismjs/components/prism-sql");
+require("prismjs/components/prism-diff");


### PR DESCRIPTION
**Before**
<img width="1350" height="420" alt="CleanShot 2025-10-11 at 20 27 52@2x" src="https://github.com/user-attachments/assets/a1d5b9a0-d10c-4794-a99b-daeb2c2691b6" />

**After**
<img width="1356" height="412" alt="CleanShot 2025-10-11 at 20 27 33@2x" src="https://github.com/user-attachments/assets/30cf1711-156e-4ca9-9d6a-422a7e2f648a" />
