### PR TITLE
[Fusion] Allow to override source schema name of Aspire resource

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/CompositionHelper.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/CompositionHelper.cs
@@ -74,11 +74,11 @@ internal static class CompositionHelper
             });
         }
 
-        foreach (var schema in sourceSchemas)
+        foreach (var schema in newSourceSchemas)
         {
             if (!sourceSchemaNames.Add(schema.Name))
             {
-                sourceSchemaMap[schema.Name] = new SourceSchemaInfo
+                sourceSchemas[schema.Name] = new SourceSchemaInfo
                 {
                     Name = schema.Name,
                     Schema = schema.Schema,

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/GraphQLResourceBuilderExtensions.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/GraphQLResourceBuilderExtensions.cs
@@ -13,16 +13,19 @@ public static class GraphQLResourceBuilderExtensions
     /// <param name="builder">The resource builder</param>
     /// <param name="path">The GraphQL endpoint path (defaults to "/graphql/schema.graphql")</param>
     /// <param name="endpointName">The endpoint name to use (defaults to "http")</param>
+    /// <param name="sourceSchemaName">The source schema name (defaults to the resource name)</param>
     /// <returns>The resource builder for chaining</returns>
     public static IResourceBuilder<T> WithGraphQLSchemaEndpoint<T>(
         this IResourceBuilder<T> builder,
         string path = "/graphql/schema.graphql",
-        string endpointName = "http")
+        string endpointName = "http",
+        string? sourceSchemaName = null)
         where T : IResourceWithEndpoints
     {
         builder.WithAnnotation(
             new GraphQLSourceSchemaAnnotation
             {
+                SourceSchemaName = sourceSchemaName,
                 EndpointName = endpointName,
                 SchemaPath = path,
                 Location = SourceSchemaLocationType.SchemaEndpoint
@@ -36,15 +39,18 @@ public static class GraphQLResourceBuilderExtensions
     /// </summary>
     /// <param name="builder">The resource builder</param>
     /// <param name="fileName">The schema file name (defaults to "schema.graphql")</param>
+    /// <param name="sourceSchemaName">The source schema name (defaults to the resource name)</param>
     /// <returns>The resource builder for chaining</returns>
     public static IResourceBuilder<T> WithGraphQLSchemaFile<T>(
         this IResourceBuilder<T> builder,
-        string fileName = "schema.graphqls")
+        string fileName = "schema.graphqls",
+        string? sourceSchemaName = null)
         where T : IResourceWithEndpoints
     {
         builder.WithAnnotation(
             new GraphQLSourceSchemaAnnotation
             {
+                SourceSchemaName = sourceSchemaName,
                 SchemaPath = fileName,
                 Location = SourceSchemaLocationType.ProjectDirectory
             });
@@ -73,6 +79,12 @@ public static class GraphQLResourceBuilderExtensions
             });
 
         return builder;
+    }
+
+    internal static string? GetGraphQLSourceSchemaName(this IResource resource)
+    {
+        var annotation = resource.Annotations.OfType<GraphQLSourceSchemaAnnotation>().FirstOrDefault();
+        return annotation?.SourceSchemaName;
     }
 
     internal static string? GetGraphQLSchemaUrl(this IResourceWithEndpoints resource, string? endpointName = null)

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/GraphQLSourceSchemaAnnotation.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/GraphQLSourceSchemaAnnotation.cs
@@ -4,8 +4,13 @@ namespace HotChocolate.Fusion.Aspire;
 
 internal sealed class GraphQLSourceSchemaAnnotation : IResourceAnnotation
 {
+    public string? SourceSchemaName { get; init; }
+
     public string? EndpointName { get; init; }
 
+    /// <summary>
+    /// The path or download URL of a GraphQL schema document.
+    /// </summary>
     public string? SchemaPath { get; init; }
 
     public required SourceSchemaLocationType Location { get; init; }

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/SchemaComposition.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/SchemaComposition.cs
@@ -121,7 +121,7 @@ internal sealed class SchemaComposition(
             if (!referencedResource.HasGraphQLSchema())
             {
                 logger.LogDebug(
-                    "Resource {ResourceName} does not have GraphQL schema, skipping",
+                    "Resource {ResourceName} does not have a GraphQL schema, skipping",
                     referencedResource.Name);
                 continue;
             }
@@ -208,6 +208,8 @@ internal sealed class SchemaComposition(
         IResourceWithEndpoints resource,
         CancellationToken cancellationToken)
     {
+        var sourceSchemaName = resource.GetGraphQLSourceSchemaName() ?? resource.Name;
+
         var schemaUrl = resource.GetGraphQLSchemaUrl();
         if (schemaUrl == null)
         {
@@ -232,7 +234,7 @@ internal sealed class SchemaComposition(
 
         return new SourceSchemaInfo
         {
-            Name = resource.Name,
+            Name = sourceSchemaName,
             ResourceName = resource.Name,
             HttpEndpointUrl = new Uri(schemaUrl),
             Schema = new SourceSchemaText(resource.Name, schemaText),


### PR DESCRIPTION
Currently the Aspire composition always uses the name of the resource as the source schema name.
This is problematic when you have configured other source schema names and client configuration based on those names.

This PR allows to override the source schema name when using Aspire.