### PR TITLE
Re-add RequestExecutorSetup.SchemaBuilder

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Warmup/RequestExecutorWarmupService.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Warmup/RequestExecutorWarmupService.cs
@@ -14,7 +14,7 @@ internal sealed class RequestExecutorWarmupService(
         foreach (var schemaName in provider.SchemaNames)
         {
             var setup = await executorOptionsMonitor.GetAsync(schemaName, cancellationToken);
-            var options = RequestExecutorManager.CreateSchemaOptions(setup);
+            var options = CreateSchemaOptions(setup);
 
             if (!options.LazyInitialization)
             {
@@ -31,5 +31,17 @@ internal sealed class RequestExecutorWarmupService(
     private async Task WarmupAsync(string schemaName, CancellationToken cancellationToken)
     {
         await provider.GetExecutorAsync(schemaName, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static SchemaOptions CreateSchemaOptions(RequestExecutorSetup setup)
+    {
+        var options = new SchemaOptions();
+
+        foreach (var configure in setup.SchemaOptionModifiers)
+        {
+            configure(options);
+        }
+
+        return options;
     }
 }

--- a/src/HotChocolate/Core/src/Execution/Configuration/RequestExecutorSetup.cs
+++ b/src/HotChocolate/Core/src/Execution/Configuration/RequestExecutorSetup.cs
@@ -25,6 +25,11 @@ public sealed class RequestExecutorSetup
     public Schema? Schema { get; set; }
 
     /// <summary>
+    /// Gets or sets the schema builder that is used to create the schema.
+    /// </summary>
+    public ISchemaBuilder? SchemaBuilder { get; set; }
+
+    /// <summary>
     /// Gets or sets the request executor options.
     /// </summary>
     public RequestExecutorOptions? RequestExecutorOptions { get; set; }
@@ -110,6 +115,7 @@ public sealed class RequestExecutorSetup
     public void CopyTo(RequestExecutorSetup options)
     {
         options.Schema = Schema;
+        options.SchemaBuilder = SchemaBuilder;
         options.RequestExecutorOptions = RequestExecutorOptions;
         options._onConfigureSchemaBuilderHooks.AddRange(_onConfigureSchemaBuilderHooks);
         options._onConfigureRequestExecutorOptionsHooks.AddRange(_onConfigureRequestExecutorOptionsHooks);

--- a/src/HotChocolate/Core/src/Execution/DependencyInjection/SchemaRequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution/DependencyInjection/SchemaRequestExecutorBuilderExtensions.cs
@@ -28,7 +28,13 @@ public static partial class SchemaRequestExecutorBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configure);
 
-        return builder.Configure(setup => setup.SchemaOptionModifiers.Add(configure));
+        // We configure the options using the internal SchemaBuilder,
+        // but we also register the modification through the SchemaOptionModifiers,
+        // so we're able to build the schema options without having to construct
+        // the schema.
+        return builder
+            .ConfigureSchema(b => b.ModifyOptions(configure))
+            .Configure(setup => setup.SchemaOptionModifiers.Add(configure));
     }
 
     /// <summary>

--- a/src/HotChocolate/Core/src/Execution/RequestExecutorManager.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutorManager.cs
@@ -155,12 +155,9 @@ internal sealed partial class RequestExecutorManager
             await _optionsMonitor.GetAsync(schemaName, cancellationToken)
                 .ConfigureAwait(false);
 
-        var options = CreateSchemaOptions(setup);
-        var schemaBuilder = SchemaBuilder.New(options);
-
         var context = new ConfigurationContext(
             schemaName,
-            schemaBuilder,
+            setup.SchemaBuilder ?? SchemaBuilder.New(),
             _applicationServices);
 
         var typeModuleChangeMonitor = new TypeModuleChangeMonitor(this, context.SchemaName);
@@ -247,18 +244,6 @@ internal sealed partial class RequestExecutorManager
             await Task.Delay(registeredExecutor.EvictionTimeout).ConfigureAwait(false);
             await registeredExecutor.DisposeAsync().ConfigureAwait(false);
         }
-    }
-
-    internal static SchemaOptions CreateSchemaOptions(RequestExecutorSetup setup)
-    {
-        var options = new SchemaOptions();
-
-        foreach (var configure in setup.SchemaOptionModifiers)
-        {
-            configure(options);
-        }
-
-        return options;
     }
 
     private async Task<ServiceProvider> CreateSchemaServicesAsync(

--- a/src/HotChocolate/Core/src/Types/SchemaBuilder.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaBuilder.cs
@@ -22,15 +22,13 @@ public partial class SchemaBuilder : ISchemaBuilder
     private readonly List<CreateRef> _types = [];
     private readonly Dictionary<OperationType, CreateRef> _operations = [];
 
-    private readonly SchemaOptions _options;
+    private readonly SchemaOptions _options = new();
     private IsOfTypeFallback? _isOfType;
     private IServiceProvider? _services;
     private CreateRef? _schema;
 
-    private SchemaBuilder(SchemaOptions options)
+    private SchemaBuilder()
     {
-        _options = options;
-
         var typeInterceptors = new TypeInterceptorCollection();
 
         typeInterceptors.TryAdd(new IntrospectionTypeInterceptor());
@@ -240,7 +238,5 @@ public partial class SchemaBuilder : ISchemaBuilder
     /// <returns>
     /// Returns a new instance of <see cref="SchemaBuilder"/>.
     /// </returns>
-    public static SchemaBuilder New() => new(new SchemaOptions());
-
-    internal static SchemaBuilder New(SchemaOptions options) => new(options);
+    public static SchemaBuilder New() => new();
 }


### PR DESCRIPTION
I removed this in https://github.com/ChilliCream/graphql-platform/pull/8758, since there were no references and it felt like a really obscure option... Turns out we're using it in Nitro, so I'm re-adding it.