### PR TITLE
[Fusion] Raise RequestExecutorEvent synchronously

### DIFF
--- a/src/HotChocolate/Core/src/Execution/RequestExecutorManager.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutorManager.cs
@@ -640,7 +640,11 @@ internal sealed partial class RequestExecutorManager
 
     private sealed class EventObservable : IObservable<RequestExecutorEvent>, IDisposable
     {
+#if NET9_0_OR_GREATER
+        private readonly Lock _sync = new();
+#else
         private readonly object _sync = new();
+#endif
         private readonly List<Subscription> _subscriptions = [];
         private bool _disposed;
 

--- a/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorProxyTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorProxyTests.cs
@@ -41,14 +41,8 @@ public class RequestExecutorProxyTests
                 .Services
                 .BuildServiceProvider()
                 .GetRequiredService<RequestExecutorManager>();
-        var updated = false;
-
         var proxy = new TestProxy(manager, manager, ISchemaDefinition.DefaultName);
-        proxy.ExecutorUpdated += () =>
-        {
-            updated = true;
-            executorUpdatedResetEvent.Set();
-        };
+        proxy.ExecutorUpdated += () => executorUpdatedResetEvent.Set();
 
         // act
         var a = await proxy.GetExecutorAsync(CancellationToken.None);
@@ -58,7 +52,6 @@ public class RequestExecutorProxyTests
 
         // assert
         Assert.NotSame(a, b);
-        Assert.True(updated);
     }
 
     private class TestProxy(

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Execution/FusionRequestExecutorProxyTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Execution/FusionRequestExecutorProxyTests.cs
@@ -54,17 +54,12 @@ public class FusionRequestExecutorProxyTests : FusionTestBase
                 .Services
                 .BuildServiceProvider()
                 .GetRequiredService<FusionRequestExecutorManager>();
-        var updated = false;
 
         var proxy = new TestProxy(manager, manager, ISchemaDefinition.DefaultName);
-        proxy.ExecutorUpdated += () =>
-        {
-            updated = true;
-            executorUpdatedResetEvent.Set();
-        };
+        proxy.ExecutorUpdated += () => executorUpdatedResetEvent.Set();
 
         // act
-        var a = await proxy.GetExecutorAsync(CancellationToken.None);
+        var a = await proxy.GetExecutorAsync(cts.Token);
 
         configProvider.UpdateConfiguration(
             CreateFusionConfiguration(
@@ -75,11 +70,10 @@ public class FusionRequestExecutorProxyTests : FusionTestBase
                 """));
 
         executorUpdatedResetEvent.Wait(cts.Token);
-        var b = await proxy.GetExecutorAsync(CancellationToken.None);
+        var b = await proxy.GetExecutorAsync(cts.Token);
 
         // assert
         Assert.NotSame(a, b);
-        Assert.True(updated);
     }
 
     private class TestProxy(


### PR DESCRIPTION
We were raising executor events to the observers through a channel. This means the events aren't guaranteed to be observed at the time they're raised, since there could be a delay between enqueueing and processing. This lead to a flaky test and could cause other subtle issues at runtime.

This PR aligns the eventing implementation to the Core RequestExecutorManager.