### PR TITLE
Pin .NET 10 version in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.x
+          dotnet-version: 10.0.100-rc.1.25451.107
 
       - name: Generate Test Matrix
         run: dotnet run --project ./.build -- GenerateMatrix
@@ -181,7 +181,7 @@ jobs:
           dotnet-version: |
             8.x
             9.x
-            10.x
+            10.0.100-rc.1.25451.107
 
       - name: Run Build
         id: run-build
@@ -252,7 +252,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: graphql-platform
-          files: './output/download/coverage-*/*/coverage.opencover.xml'
+          files: "./output/download/coverage-*/*/coverage.opencover.xml"
           disable_search: true
           flags: unittests
           fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
       - main
       - main-version-*
     paths:
-      - 'src/**'
+      - "src/**"
 
 concurrency:
   group: main-coverage
@@ -32,7 +32,7 @@ jobs:
           dotnet-version: |
             8.x
             9.x
-            10.x
+            10.0.100-rc.1.25451.107
 
       - name: Generate Test Matrix
         run: dotnet run --project ./.build -- GenerateMatrix
@@ -64,7 +64,7 @@ jobs:
           dotnet-version: |
             8.x
             9.x
-            10.x
+            10.0.100-rc.1.25451.107
 
       - name: Run Build
         id: run-build
@@ -137,7 +137,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: graphql-platform
-          files: './output/download/coverage-*/*/coverage.opencover.xml'
+          files: "./output/download/coverage-*/*/coverage.opencover.xml"
           disable_search: true
           flags: unittests
           fail_ci_if_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           dotnet-version: |
             8.x
             9.x
-            10.x
+            10.0.100-rc.1.25451.107
 
       - name: 🏷 Get the version from tag
         run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
@@ -104,7 +104,7 @@ jobs:
       - name: 🛠 Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.x
+          dotnet-version: 10.0.100-rc.1.25451.107
 
       - name: 🏷 Get the version from tag (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
Our release builds are currently failing since .NET 10 rc.2 is installed on them, but the repository version is fixed to rc.1.
We can't upgrade the repository to rc.2, since [Npgsql.EntityFrameworkCore.PostgreSQL](https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL) hasn't been published as rc.2 yet, so I'm just pinning the GitHub Action .NET 10 version to `10.0.100-rc.1.25451.107` for now.