### PR TITLE
Fix BatchDispatcher headroom detection under thread pool saturation

### DIFF
--- a/src/HotChocolate/Core/src/Fetching/BatchDispatcher.cs
+++ b/src/HotChocolate/Core/src/Fetching/BatchDispatcher.cs
@@ -232,7 +232,11 @@ public sealed partial class BatchDispatcher : IBatchDispatcher
                     Thread.Yield();
                 }
             }
+
+            return;
         }
+
+        Thread.Yield();
     }
 
     private void Send(BatchDispatchEventType type)
@@ -252,6 +256,13 @@ public sealed partial class BatchDispatcher : IBatchDispatcher
 
     private static bool ThreadPoolHasHeadroom()
     {
+#if NET8_0_OR_GREATER
+        if (ThreadPool.PendingWorkItemCount > 0)
+        {
+            return false;
+        }
+#endif
+
         ThreadPool.GetAvailableThreads(out var worker, out _);
         return worker >= 2;
     }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 
Fix BatchDispatcher spin loop starvation when pool is saturated

1. Added pending-work guard to headroom probe
2. Yield after spin window to release worker threads
3. Added regression test covering thread pool saturation

Closes #8825
