### PR TITLE
[Fusion] Include quotes for extension root string values

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Text/Json/SourceResultDocument.Text.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Text/Json/SourceResultDocument.Text.cs
@@ -166,7 +166,7 @@ public sealed partial class SourceResultDocument
         return ReadRawValue(start, endRow.Location - start + endRowLength);
     }
 
-    internal ReadOnlyMemory<byte> GetRawValueAsMemory(Cursor cursor)
+    internal ReadOnlyMemory<byte> GetRawValueAsMemory(Cursor cursor, bool includeQuotes)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -174,6 +174,13 @@ public sealed partial class SourceResultDocument
 
         if (row.IsSimpleValue)
         {
+            if (includeQuotes && row.TokenType == JsonTokenType.String)
+            {
+                // Start one character earlier than the value (the open quote)
+                // End one character after the value (the close quote)
+                return ReadRawValueAsMemory(row.Location - 1, row.SizeOrLength + 2);
+            }
+
             return ReadRawValueAsMemory(row.Location, row.SizeOrLength);
         }
 

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Text/Json/SourceResultElement.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Text/Json/SourceResultElement.cs
@@ -471,7 +471,7 @@ public readonly partial struct SourceResultElement
     public ReadOnlyMemory<byte> GetRawValueAsMemory()
     {
         CheckValidInstance();
-        return _parent.GetRawValueAsMemory(_cursor);
+        return _parent.GetRawValueAsMemory(_cursor, includeQuotes: true);
     }
 
     internal ReadOnlySpan<byte> ValueSpan

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/SourceSchemaErrorTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/SourceSchemaErrorTests.cs
@@ -1046,6 +1046,7 @@ public class SourceSchemaErrorTests : FusionTestBase
                 throw new GraphQLException(
                     ErrorBuilder.New()
                         .SetMessage("Something went wrong")
+                        .SetCode("SOME_ERROR")
                         .SetPath(context.Path)
                         .SetException(new Exception("Some exception"))
                         .Build());

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/SourceSchemaErrorTests.Error_Extensions_From_Source_Schema_Are_Properly_Forwarded.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/SourceSchemaErrorTests.Error_Extensions_From_Source_Schema_Are_Properly_Forwarded.yaml
@@ -14,6 +14,7 @@ response:
             "someField"
           ],
           "extensions": {
+            "code": "SOME_ERROR",
             "exception": {
               "message": "Some exception",
               "stackTrace": null
@@ -55,6 +56,7 @@ sourceSchemas:
                       "someField"
                     ],
                     "extensions": {
+                      "code": "SOME_ERROR",
                       "exception": {
                         "message": "Some exception",
                         "stackTrace": null


### PR DESCRIPTION
Previously string values would be serialized without quotes, leading to JSON parsing issues.