### PR TITLE
[Fusion] Used `ARGUMENT` instead of `ARG` in error codes

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryCodes.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryCodes.cs
@@ -35,8 +35,8 @@ public static class LogEntryCodes
     public const string IsInvalidFieldType = "IS_INVALID_FIELD_TYPE";
     public const string IsInvalidSyntax = "IS_INVALID_SYNTAX";
     public const string IsInvalidUsage = "IS_INVALID_USAGE";
-    public const string KeyDirectiveInFieldsArg = "KEY_DIRECTIVE_IN_FIELDS_ARG";
-    public const string KeyFieldsHasArgs = "KEY_FIELDS_HAS_ARGS";
+    public const string KeyDirectiveInFieldsArgument = "KEY_DIRECTIVE_IN_FIELDS_ARGUMENT";
+    public const string KeyFieldsHasArguments = "KEY_FIELDS_HAS_ARGUMENTS";
     public const string KeyFieldsSelectInvalidType = "KEY_FIELDS_SELECT_INVALID_TYPE";
     public const string KeyInvalidFields = "KEY_INVALID_FIELDS";
     public const string KeyInvalidFieldsType = "KEY_INVALID_FIELDS_TYPE";
@@ -49,8 +49,8 @@ public static class LogEntryCodes
     public const string OutputFieldTypesNotMergeable = "OUTPUT_FIELD_TYPES_NOT_MERGEABLE";
     public const string OverrideFromSelf = "OVERRIDE_FROM_SELF";
     public const string OverrideOnInterface = "OVERRIDE_ON_INTERFACE";
-    public const string ProvidesDirectiveInFieldsArg = "PROVIDES_DIRECTIVE_IN_FIELDS_ARG";
-    public const string ProvidesFieldsHasArgs = "PROVIDES_FIELDS_HAS_ARGS";
+    public const string ProvidesDirectiveInFieldsArgument = "PROVIDES_DIRECTIVE_IN_FIELDS_ARGUMENT";
+    public const string ProvidesFieldsHasArguments = "PROVIDES_FIELDS_HAS_ARGUMENTS";
     public const string ProvidesFieldsMissingExternal = "PROVIDES_FIELDS_MISSING_EXTERNAL";
     public const string ProvidesInvalidFields = "PROVIDES_INVALID_FIELDS";
     public const string ProvidesInvalidFieldsType = "PROVIDES_INVALID_FIELDS_TYPE";

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryHelper.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryHelper.cs
@@ -627,7 +627,7 @@ internal static class LogEntryHelper
                 type.Name,
                 schema.Name,
                 string.Join(".", fieldNamePath))
-            .SetCode(LogEntryCodes.KeyDirectiveInFieldsArg)
+            .SetCode(LogEntryCodes.KeyDirectiveInFieldsArgument)
             .SetSeverity(LogSeverity.Error)
             .SetCoordinate(type.Coordinate)
             .SetTypeSystemMember(keyDirective)
@@ -647,7 +647,7 @@ internal static class LogEntryHelper
                 type.Name,
                 schema.Name,
                 keyField.Coordinate.ToString())
-            .SetCode(LogEntryCodes.KeyFieldsHasArgs)
+            .SetCode(LogEntryCodes.KeyFieldsHasArguments)
             .SetSeverity(LogSeverity.Error)
             .SetCoordinate(type.Coordinate)
             .SetTypeSystemMember(keyDirective)
@@ -856,7 +856,7 @@ internal static class LogEntryHelper
                 coordinate.ToString(),
                 schema.Name,
                 string.Join(".", fieldNamePath))
-            .SetCode(LogEntryCodes.ProvidesDirectiveInFieldsArg)
+            .SetCode(LogEntryCodes.ProvidesDirectiveInFieldsArgument)
             .SetSeverity(LogSeverity.Error)
             .SetCoordinate(coordinate)
             .SetTypeSystemMember(providesDirective)
@@ -878,7 +878,7 @@ internal static class LogEntryHelper
                 coordinate.ToString(),
                 schema.Name,
                 providedField.Coordinate.ToString())
-            .SetCode(LogEntryCodes.ProvidesFieldsHasArgs)
+            .SetCode(LogEntryCodes.ProvidesFieldsHasArguments)
             .SetSeverity(LogSeverity.Error)
             .SetCoordinate(coordinate)
             .SetTypeSystemMember(providesDirective)

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/KeyDirectiveInFieldsArgumentRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/KeyDirectiveInFieldsArgumentRuleTests.cs
@@ -40,7 +40,7 @@ public sealed class KeyDirectiveInFieldsArgumentRuleTests : RuleTestBase
                 """
                 {
                     "message": "A @key directive on type 'User' in schema 'A' references field 'name', which must not include directive applications.",
-                    "code": "KEY_DIRECTIVE_IN_FIELDS_ARG",
+                    "code": "KEY_DIRECTIVE_IN_FIELDS_ARGUMENT",
                     "severity": "Error",
                     "coordinate": "User",
                     "member": "key",
@@ -76,7 +76,7 @@ public sealed class KeyDirectiveInFieldsArgumentRuleTests : RuleTestBase
                 """
                 {
                     "message": "A @key directive on type 'User' in schema 'A' references field 'name.firstName', which must not include directive applications.",
-                    "code": "KEY_DIRECTIVE_IN_FIELDS_ARG",
+                    "code": "KEY_DIRECTIVE_IN_FIELDS_ARGUMENT",
                     "severity": "Error",
                     "coordinate": "User",
                     "member": "key",
@@ -106,7 +106,7 @@ public sealed class KeyDirectiveInFieldsArgumentRuleTests : RuleTestBase
                 """
                 {
                     "message": "A @key directive on type 'User' in schema 'A' references field 'id', which must not include directive applications.",
-                    "code": "KEY_DIRECTIVE_IN_FIELDS_ARG",
+                    "code": "KEY_DIRECTIVE_IN_FIELDS_ARGUMENT",
                     "severity": "Error",
                     "coordinate": "User",
                     "member": "key",
@@ -117,7 +117,7 @@ public sealed class KeyDirectiveInFieldsArgumentRuleTests : RuleTestBase
                 """
                 {
                     "message": "A @key directive on type 'User' in schema 'A' references field 'name', which must not include directive applications.",
-                    "code": "KEY_DIRECTIVE_IN_FIELDS_ARG",
+                    "code": "KEY_DIRECTIVE_IN_FIELDS_ARGUMENT",
                     "severity": "Error",
                     "coordinate": "User",
                     "member": "key",

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/KeyFieldsHasArgumentsRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/KeyFieldsHasArgumentsRuleTests.cs
@@ -39,7 +39,7 @@ public sealed class KeyFieldsHasArgumentsRuleTests : RuleTestBase
                 """
                 {
                     "message": "A @key directive on type 'User' in schema 'A' references field 'User.tags', which must not have arguments.",
-                    "code": "KEY_FIELDS_HAS_ARGS",
+                    "code": "KEY_FIELDS_HAS_ARGUMENTS",
                     "severity": "Error",
                     "coordinate": "User",
                     "member": "key",
@@ -71,7 +71,7 @@ public sealed class KeyFieldsHasArgumentsRuleTests : RuleTestBase
                 """
                 {
                     "message": "A @key directive on type 'User' in schema 'A' references field 'UserInfo.tags', which must not have arguments.",
-                    "code": "KEY_FIELDS_HAS_ARGS",
+                    "code": "KEY_FIELDS_HAS_ARGUMENTS",
                     "severity": "Error",
                     "coordinate": "User",
                     "member": "key",
@@ -99,7 +99,7 @@ public sealed class KeyFieldsHasArgumentsRuleTests : RuleTestBase
                 """
                 {
                     "message": "A @key directive on type 'User' in schema 'A' references field 'User.id', which must not have arguments.",
-                    "code": "KEY_FIELDS_HAS_ARGS",
+                    "code": "KEY_FIELDS_HAS_ARGUMENTS",
                     "severity": "Error",
                     "coordinate": "User",
                     "member": "key",
@@ -110,7 +110,7 @@ public sealed class KeyFieldsHasArgumentsRuleTests : RuleTestBase
                 """
                 {
                     "message": "A @key directive on type 'User' in schema 'A' references field 'User.tags', which must not have arguments.",
-                    "code": "KEY_FIELDS_HAS_ARGS",
+                    "code": "KEY_FIELDS_HAS_ARGUMENTS",
                     "severity": "Error",
                     "coordinate": "User",
                     "member": "key",

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/ProvidesDirectiveInFieldsArgumentRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/ProvidesDirectiveInFieldsArgumentRuleTests.cs
@@ -52,7 +52,7 @@ public sealed class ProvidesDirectiveInFieldsArgumentRuleTests : RuleTestBase
                 """
                 {
                     "message": "The @provides directive on field 'User.profile' in schema 'A' references field 'name', which must not include directive applications.",
-                    "code": "PROVIDES_DIRECTIVE_IN_FIELDS_ARG",
+                    "code": "PROVIDES_DIRECTIVE_IN_FIELDS_ARGUMENT",
                     "severity": "Error",
                     "coordinate": "User.profile",
                     "member": "provides",
@@ -92,7 +92,7 @@ public sealed class ProvidesDirectiveInFieldsArgumentRuleTests : RuleTestBase
                 """
                 {
                     "message": "The @provides directive on field 'User.profile' in schema 'A' references field 'info.name', which must not include directive applications.",
-                    "code": "PROVIDES_DIRECTIVE_IN_FIELDS_ARG",
+                    "code": "PROVIDES_DIRECTIVE_IN_FIELDS_ARGUMENT",
                     "severity": "Error",
                     "coordinate": "User.profile",
                     "member": "provides",
@@ -128,7 +128,7 @@ public sealed class ProvidesDirectiveInFieldsArgumentRuleTests : RuleTestBase
                 """
                 {
                     "message": "The @provides directive on field 'User.profile' in schema 'A' references field 'id', which must not include directive applications.",
-                    "code": "PROVIDES_DIRECTIVE_IN_FIELDS_ARG",
+                    "code": "PROVIDES_DIRECTIVE_IN_FIELDS_ARGUMENT",
                     "severity": "Error",
                     "coordinate": "User.profile",
                     "member": "provides",
@@ -139,7 +139,7 @@ public sealed class ProvidesDirectiveInFieldsArgumentRuleTests : RuleTestBase
                 """
                 {
                     "message": "The @provides directive on field 'User.profile' in schema 'A' references field 'name', which must not include directive applications.",
-                    "code": "PROVIDES_DIRECTIVE_IN_FIELDS_ARG",
+                    "code": "PROVIDES_DIRECTIVE_IN_FIELDS_ARGUMENT",
                     "severity": "Error",
                     "coordinate": "User.profile",
                     "member": "provides",

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/ProvidesFieldsHasArgumentsRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/ProvidesFieldsHasArgumentsRuleTests.cs
@@ -53,7 +53,7 @@ public sealed class ProvidesFieldsHasArgumentsRuleTests : RuleTestBase
                 """
                 {
                     "message": "The @provides directive on field 'Article.author' in schema 'A' references field 'User.tags', which must not have arguments.",
-                    "code": "PROVIDES_FIELDS_HAS_ARGS",
+                    "code": "PROVIDES_FIELDS_HAS_ARGUMENTS",
                     "severity": "Error",
                     "coordinate": "Article.author",
                     "member": "provides",
@@ -95,7 +95,7 @@ public sealed class ProvidesFieldsHasArgumentsRuleTests : RuleTestBase
                 """
                 {
                     "message": "The @provides directive on field 'Article.author' in schema 'A' references field 'UserInfo.tags', which must not have arguments.",
-                    "code": "PROVIDES_FIELDS_HAS_ARGS",
+                    "code": "PROVIDES_FIELDS_HAS_ARGUMENTS",
                     "severity": "Error",
                     "coordinate": "Article.author",
                     "member": "provides",


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Used `ARGUMENT` instead of `ARG` in error codes.