### PR TITLE
Updated the spec URL for GraphQL custom scalars

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -5,6 +5,7 @@ accessibilities
 agrc
 Alderaan
 Andi
+andimarek
 ASPDEPR004
 ASPDEPR008
 aspnetcore

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/DateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/DateTimeType.cs
@@ -9,14 +9,13 @@ namespace HotChocolate.Types;
 /// <summary>
 /// This GraphQL Scalar represents an exact point in time.
 /// This point in time is specified by having an offset to UTC and does not use time zone.
-///
-/// https://www.graphql-scalars.com/date-time/
 /// </summary>
+/// <seealso href="https://scalars.graphql.org/andimarek/date-time.html">Specification</seealso>
 public class DateTimeType : ScalarType<DateTimeOffset, StringValueNode>
 {
     private const string UtcFormat = "yyyy-MM-ddTHH\\:mm\\:ss.fffZ";
     private const string LocalFormat = "yyyy-MM-ddTHH\\:mm\\:ss.fffzzz";
-    private const string SpecifiedByUri = "https://www.graphql-scalars.com/date-time";
+    private const string SpecifiedByUri = "https://scalars.graphql.org/andimarek/date-time.html";
 
     private static readonly Regex s_dateTimeScalarRegex = new(
         @"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{1,7})?(Z|[+-][0-9]{2}:[0-9]{2})$",
@@ -196,7 +195,7 @@ public class DateTimeType : ScalarType<DateTimeOffset, StringValueNode>
         }
 
         // No "Unknown Local Offset Convention".
-        // https://www.graphql-scalars.com/date-time/#no-unknown-local-offset-convention
+        // https://scalars.graphql.org/andimarek/date-time.html#sec-Overview.No-Unknown-Local-Offset-Convention-
         if (serialized.EndsWith("-00:00"))
         {
             value = null;

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.Query_Specified_By.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.Query_Specified_By.snap
@@ -1,7 +1,7 @@
 {
   "data": {
     "__type": {
-      "specifiedByURL": "https://www.graphql-scalars.com/date-time"
+      "specifiedByURL": "https://scalars.graphql.org/andimarek/date-time.html"
     }
   }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscoveryTests.InferDateTime.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscoveryTests.InferDateTime.snap
@@ -11,4 +11,4 @@ type QueryWithDateTime {
 directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscoveryTests.InferDateTimeFromModel.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscoveryTests.InferDateTimeFromModel.snap
@@ -52,4 +52,4 @@ directive @specifiedBy("The specifiedBy URL points to a human-readable specifica
 scalar Date
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscoveryTests.TypeDiscovery_Should_InferStructs.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/__snapshots__/TypeDiscoveryTests.TypeDiscovery_Should_InferStructs.snap
@@ -22,6 +22,6 @@ type QueryTypeWithStruct {
 directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")
 
 scalar UUID @specifiedBy(url: "https:\/\/tools.ietf.org\/html\/rfc4122")

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/SpecifiedByDirectiveTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/SpecifiedByDirectiveTypeTests.cs
@@ -58,7 +58,7 @@ public static class SpecifiedByDirectiveTypeTests
                     directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
 
                     "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-                    scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+                    scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")
                     """)
                 .UseField(next => next)
                 .BuildSchemaAsync();

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/SpecifiedByDirectiveTypeTests.EnsureSpecifiedByDirectiveExistsInSdl.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/SpecifiedByDirectiveTypeTests.EnsureSpecifiedByDirectiveExistsInSdl.graphql
@@ -10,4 +10,4 @@ type Query1 {
 directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
@@ -432,7 +432,7 @@ public class DateTimeTypeTests
     {
         return new TheoryData<string, DateTimeOffset>
         {
-            // https://www.graphql-scalars.com/date-time/#test-cases (valid strings)
+            // https://scalars.graphql.org/andimarek/date-time.html#sec-Overview.Examples (valid examples)
             {
                 // A DateTime with UTC offset (+00:00).
                 "2011-08-30T13:22:53.108Z",
@@ -476,7 +476,7 @@ public class DateTimeTypeTests
     {
         return
         [
-            // https://www.graphql-scalars.com/date-time/#test-cases (invalid strings)
+            // https://scalars.graphql.org/andimarek/date-time.html#sec-Overview.Examples (invalid examples)
             // The minutes of the offset are missing.
             "2011-08-30T13:22:53.108-03",
             // Too many digits for fractions of a second. Exactly three expected.

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/CodeFirstTests.Change_DefaultBinding_For_DateTime.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/CodeFirstTests.Change_DefaultBinding_For_DateTime.snap
@@ -18,4 +18,4 @@ directive @specifiedBy("The specifiedBy URL points to a human-readable specifica
 scalar Date
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")

--- a/src/HotChocolate/ModelContextProtocol/src/HotChocolate.ModelContextProtocol/Extensions/TypeExtensions.cs
+++ b/src/HotChocolate/ModelContextProtocol/src/HotChocolate.ModelContextProtocol/Extensions/TypeExtensions.cs
@@ -183,7 +183,7 @@ internal static class TypeExtensions
                 // e.g. dmFsdWU= (Base64-encoded string)
                 => @"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$",
             DateTimeType
-                // e.g. 2011-08-30T13:22:53.108Z (https://www.graphql-scalars.com/date-time/)
+                // e.g. 2011-08-30T13:22:53.108Z (https://scalars.graphql.org/andimarek/date-time.html)
                 =>
                     @"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}"
                     + @"(?:\.\d{1,7})?(?:[Zz]|[+-]\d{2}:\d{2})$",

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/__snapshots__/MongoDbFilterVisitorComparableTests.Create_Implicit_Operation.graphql
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/__snapshots__/MongoDbFilterVisitorComparableTests.Create_Implicit_Operation.graphql
@@ -143,7 +143,7 @@ input FooFilterInput {
 directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")
 
 "The `Decimal` scalar type represents a decimal floating-point number."
 scalar Decimal

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/__snapshots__/MongoDbFilterVisitorComparableTests.Create_Implicit_Operation_Normalized.graphql
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/__snapshots__/MongoDbFilterVisitorComparableTests.Create_Implicit_Operation_Normalized.graphql
@@ -128,7 +128,7 @@ input UuidOperationFilterInput {
 directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")
 
 "The `Decimal` scalar type represents a decimal floating-point number."
 scalar Decimal

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/schema.graphql
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/schema.graphql
@@ -3531,7 +3531,7 @@ directive @defer("Deferred when true." if: Boolean "If this argument label has a
 scalar Any
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")
 
 "The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
 scalar Long

--- a/src/StrawberryShake/Client/src/Core/ThrowHelper.cs
+++ b/src/StrawberryShake/Client/src/Core/ThrowHelper.cs
@@ -19,7 +19,7 @@ internal static class ThrowHelper
         string serializedValue) =>
         new(new ClientError(
             "The serialized format for DateTime must be `yyyy-MM-ddTHH\\:mm\\:ss.fffzzz`. "
-            + "For more information read: `https://www.graphql-scalars.com/date-time`.",
+            + "For more information read: `https://scalars.graphql.org/andimarek/date-time.html`.",
             extensions: new Dictionary<string, object?>
             {
                     { "serializedValue", serializedValue }

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/__resources__/PaymentSchema.graphql
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/__resources__/PaymentSchema.graphql
@@ -7676,7 +7676,7 @@ directive @stream("Streamed when true." if: Boolean "The initial elements that s
 scalar Date
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https:\/\/scalars.graphql.org\/andimarek\/date-time.html")
 
 "The `Decimal` scalar type represents a decimal floating-point number."
 scalar Decimal

--- a/website/src/docs/hotchocolate/v16/defining-a-schema/scalars.md
+++ b/website/src/docs/hotchocolate/v16/defining-a-schema/scalars.md
@@ -170,7 +170,7 @@ Notice how our code uses `int` for the `Id`, but in a request / response it woul
 
 # GraphQL Community Scalars
 
-The website <https://www.graphql-scalars.com/> hosts specifications for GraphQL scalars defined by the community. The community scalars use the `@specifiedBy` directive to point to the spec that is implemented.
+The website <https://scalars.graphql.org/> hosts specifications for GraphQL scalars defined by the community. The community scalars use the `@specifiedBy` directive to point to the spec that is implemented.
 
 ```sdl
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
@@ -183,7 +183,7 @@ A custom GraphQL scalar which represents an exact point in time. This point in t
 The DateTime scalar is based on [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339).
 
 ```sdl
-scalar DateTime @specifiedBy(url: "https://www.graphql-scalars.com/date-time/")
+scalar DateTime @specifiedBy(url: "https://scalars.graphql.org/andimarek/date-time.html")
 ```
 
 > Note: The Hot Chocolate implementation diverges slightly from the DateTime Scalar specification, and allows fractional seconds of 0-7 digits, as opposed to exactly 3.


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated the spec URL for GraphQL custom scalars.