### PR TITLE
Corrected `IsAotCompliant` to `IsAotCompatible`

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/HotChocolate.Fusion.Aspire.csproj
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Aspire/HotChocolate.Fusion.Aspire.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>HotChocolate.Fusion.Aspire</AssemblyName>
     <RootNamespace>HotChocolate.Fusion.Aspire</RootNamespace>
     <TargetFrameworks>net10.0; net9.0</TargetFrameworks>
-    <IsAotCompliant>false</IsAotCompliant>
+    <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Utilities/src/Utilities.Base36/HotChocolate.Utilities.Base36.csproj
+++ b/src/HotChocolate/Utilities/src/Utilities.Base36/HotChocolate.Utilities.Base36.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsAotCompliant>true</IsAotCompliant>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/HotChocolate/Utilities/src/Utilities.Buffers/HotChocolate.Utilities.Buffers.csproj
+++ b/src/HotChocolate/Utilities/src/Utilities.Buffers/HotChocolate.Utilities.Buffers.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsAotCompliant>true</IsAotCompliant>
+    <IsAotCompatible>true</IsAotCompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/HotChocolate/Utilities/src/Utilities.DependencyInjection/HotChocolate.Utilities.DependencyInjection.csproj
+++ b/src/HotChocolate/Utilities/src/Utilities.DependencyInjection/HotChocolate.Utilities.DependencyInjection.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsAotCompliant>true</IsAotCompliant>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/HotChocolate.Utilities.Introspection.csproj
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/HotChocolate.Utilities.Introspection.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsAotCompliant>true</IsAotCompliant>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Utilities/src/Utilities.Tasks/HotChocolate.Utilities.Tasks.csproj
+++ b/src/HotChocolate/Utilities/src/Utilities.Tasks/HotChocolate.Utilities.Tasks.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsAotCompliant>true</IsAotCompliant>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Corrected `IsAotCompliant` to `IsAotCompatible`.