### PR TITLE
Website: Fix `yarn develop` script in `package.json`

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "gatsby build",
-    "develop": "NODE_OPTIONS=--no-experimental-fetch && gatsby develop --verbose --host 0.0.0.0",
+    "develop": "gatsby develop --verbose --host 0.0.0.0",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "yarn develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
Removed `NODE_OPTIONS=--no-experimental-fetch`

It was removed since nodejs version 23: https://github.com/nodejs/node/commit/311504125f

Closes #8959
