### PR TITLE
[Fusion] Reverted changes ensuring unique schema name enum values

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -42,7 +42,7 @@ internal sealed class SourceSchemaMerger
         SourceSchemaMergerOptions? options = null)
     {
         _schemas = schemas;
-        _schemaConstantNames = CreateSchemaConstantNames(schemas);
+        _schemaConstantNames = schemas.ToFrozenDictionary(s => s.Name, s => ToConstantCase(s.Name));
         _options = options ?? new SourceSchemaMergerOptions();
         _fusionTypeDefinitions = CreateFusionTypeDefinitions();
         _fusionDirectiveDefinitions = CreateFusionDirectiveDefinitions();
@@ -98,30 +98,6 @@ internal sealed class SourceSchemaMerger
         }
 
         return mergedSchema;
-    }
-
-    private static FrozenDictionary<string, string> CreateSchemaConstantNames(
-        ImmutableSortedSet<MutableSchemaDefinition> schemas)
-    {
-        var schemaConstantNames = new Dictionary<string, string>();
-        var counters = new Dictionary<string, int>();
-
-        foreach (var schema in schemas)
-        {
-            var constantName = ToConstantCase(schema.Name);
-
-            if (schemaConstantNames.ContainsValue(constantName))
-            {
-                var counterValue = counters.GetValueOrDefault(constantName, 0);
-                counters[constantName] = ++counterValue;
-
-                constantName += $"_{counterValue}";
-            }
-
-            schemaConstantNames[schema.Name] = constantName;
-        }
-
-        return schemaConstantNames.ToFrozenDictionary();
     }
 
     private void MergeDirectiveDefinitions(MutableSchemaDefinition mergedSchema)

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMergerTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMergerTests.cs
@@ -113,31 +113,6 @@ public sealed class SourceSchemaMergerTests
     }
 
     [Fact]
-    public void Merge_ConflictingSchemaNames_UsesUniqueSchemaEnumValues()
-    {
-        // arrange
-        IEnumerable<MutableSchemaDefinition> schemas =
-        [
-            new() { Name = "Example.Name" },
-            new() { Name = "Example-Name" },
-            new() { Name = "Example_Name" },
-            new() { Name = "AnotherName" },
-            new() { Name = "AnotherNAME" }
-        ];
-
-        var merger = new SourceSchemaMerger(
-            schemas.ToImmutableSortedSet(
-                new SchemaByNameComparer<MutableSchemaDefinition>()));
-
-        // act
-        var result = merger.Merge();
-
-        // assert
-        Assert.True(result.IsSuccess);
-        result.Value.Types["fusion__Schema"].ToString().MatchSnapshot(extension: ".graphql");
-    }
-
-    [Fact]
     public void Merge_WithRequireInputObject_RetainsInputObjectType()
     {
         // arrange

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/__snapshots__/SourceSchemaMergerTests.Merge_ConflictingSchemaNames_UsesUniqueSchemaEnumValues.graphql
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/__snapshots__/SourceSchemaMergerTests.Merge_ConflictingSchemaNames_UsesUniqueSchemaEnumValues.graphql
@@ -1,8 +1,0 @@
-"The fusion__Schema enum is a generated type used within an execution schema document to refer to a source schema in a type-safe manner."
-enum fusion__Schema {
-  ANOTHER_NAME @fusion__schema_metadata(name: "AnotherNAME")
-  ANOTHER_NAME_1 @fusion__schema_metadata(name: "AnotherName")
-  EXAMPLE_NAME @fusion__schema_metadata(name: "Example-Name")
-  EXAMPLE_NAME_1 @fusion__schema_metadata(name: "Example.Name")
-  EXAMPLE_NAME_2 @fusion__schema_metadata(name: "Example_Name")
-}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Reverted changes ensuring unique schema name enum values.

---

Reverts the main changes in #8940, as similar names will instead result in an error.