### PR TITLE
Prefer comparing to interfaces

### DIFF
--- a/src/HotChocolate/Core/src/Execution.Abstractions/Execution/Extensions/CoreExecutionResultExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution.Abstractions/Execution/Extensions/CoreExecutionResultExtensions.cs
@@ -78,7 +78,7 @@ public static class CoreExecutionResultExtensions
     /// <summary>
     /// Expects a single GraphQL operation result.
     /// </summary>
-    public static OperationResult ExpectOperationResult(this IExecutionResult result)
+    public static IOperationResult ExpectOperationResult(this IExecutionResult result)
     {
         if (result is IOperationResult qr)
         {
@@ -104,7 +104,7 @@ public static class CoreExecutionResultExtensions
     /// <summary>
     /// Expect a stream result.
     /// </summary>
-    public static ResponseStream ExpectResponseStream(this IExecutionResult result)
+    public static IResponseStream ExpectResponseStream(this IExecutionResult result)
     {
         if (result is IResponseStream rs)
         {


### PR DESCRIPTION
### Summary

When using a separate (custom) `IResponseStream` this check will fail. Rather, we can allow this check to pass as long as `IResponseStream` is implemented.

#### Note

Not sure is this is safe/ok. I came across this issue in my own unit tests after implementing my own custom `IResponseStream`. Within the middleware, I will replace the original (context.Result) ResponseStream within a wrapper of my own making.

