### PR TITLE
Trimmed trailing `=` from UrlSafeBase64-encoded Node IDs

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
@@ -216,6 +216,8 @@ public sealed class DefaultNodeIdSerializer : INodeIdSerializer
                         span[i] = (byte)'_';
                     }
                 }
+
+                span = span.TrimEnd((byte)'=');
             }
 
             return ToString(span);

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
@@ -472,6 +472,8 @@ internal sealed class OptimizedNodeIdSerializer : INodeIdSerializer
                         span[i] = (byte)'_';
                     }
                 }
+
+                span = span.TrimEnd((byte)'=');
             }
 
             return OptimizedNodeIdSerializer.ToString(span);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
@@ -48,7 +48,7 @@ public class DefaultNodeIdSerializerTests
         var value = Encoding.UTF8.GetString(Convert.FromBase64String("Rm9vOkberW9vVHlwZe+/vSs="));
         var id = serializer.Format("Foo", value);
 
-        Assert.Equal("Rm9vCmRGb286Rt6tb29UeXBl77-9Kw==", id);
+        Assert.Equal("Rm9vCmRGb286Rt6tb29UeXBl77-9Kw", id);
     }
 
     [Fact]


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Trimmed trailing `=` from UrlSafeBase64-encoded Node IDs.