### PR TITLE
[Nitro CLI] Prevent markup exception in middleware

### DIFF
--- a/src/Nitro/CommandLine/src/CommandLine.Core/Extensions/CommandLineBuilderExtensions.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Core/Extensions/CommandLineBuilderExtensions.cs
@@ -79,7 +79,7 @@ public static class CommandLineBuilderExtensions
         catch (Exception exception)
         {
             context.ExitCode = ExitCodes.Error;
-            context.BindingContext.GetRequiredService<IAnsiConsole>().ErrorLine(exception.Message);
+            await context.BindingContext.GetRequiredService<IAnsiConsole>().Error.WriteLineAsync(exception.Message);
             throw;
         }
     }


### PR DESCRIPTION
Previously Spectre.Console would attempt to parse markup characters from the exception message and it might fail with the following exception:

<img width="4192" height="404" alt="CleanShot 2026-01-20 at 14 15 26@2x" src="https://github.com/user-attachments/assets/46b3570f-1ce6-4ccf-81b3-e8c25e961b4d" />

Now we write directly to stderr.