### PR TITLE
Write EOF newline when exporting schema and settings

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.CommandLine.Tests/__snapshots__/SchemaExportCommandTests.App_Should_WriteSchemaToFile_When_OutputOptionIsSpecified.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.CommandLine.Tests/__snapshots__/SchemaExportCommandTests.App_Should_WriteSchemaToFile_When_OutputOptionIsSpecified.md
@@ -10,6 +10,7 @@ schema {
 type Query {
   foo: String
 }
+
 ```
 
 ## Settings
@@ -23,5 +24,6 @@ type Query {
     }
   }
 }
+
 ```
 

--- a/src/HotChocolate/Core/src/Execution/Internal/SchemaFileExporter.cs
+++ b/src/HotChocolate/Core/src/Execution/Internal/SchemaFileExporter.cs
@@ -37,7 +37,7 @@ internal static class SchemaFileExporter
 
         await File.WriteAllTextAsync(
             schemaFileName,
-            sdl,
+            sdl + Environment.NewLine,
             new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true),
             cancellationToken);
 
@@ -83,6 +83,7 @@ internal static class SchemaFileExporter
                 await using var writer = new Utf8JsonWriter(writeStream, new JsonWriterOptions { Indented = true });
                 root.WriteTo(writer);
                 await writer.FlushAsync(cancellationToken);
+                await writeStream.WriteAsync(Encoding.UTF8.GetBytes(Environment.NewLine), cancellationToken);
                 return true;
             }
 
@@ -119,6 +120,7 @@ internal static class SchemaFileExporter
         jsonWriter.WriteEndObject();
 
         await jsonWriter.FlushAsync(cancellationToken);
+        await settingsFileStream.WriteAsync(Encoding.UTF8.GetBytes(Environment.NewLine), cancellationToken);
     }
 }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Write EOF newline when exporting schema and settings.