### PR TITLE
Fix access modifier for OnCoerceOutputValue and OnValueToLiteral

### DIFF
--- a/src/HotChocolate/Core/src/Types.Scalars.Upload/UploadType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars.Upload/UploadType.cs
@@ -82,7 +82,7 @@ public sealed class UploadType : ScalarType<IFile>
     /// <param name="runtimeValue">The runtime value (not used).</param>
     /// <param name="resultValue">The result element (not used).</param>
     /// <exception cref="NotSupportedException">Always thrown as output coercion is not supported.</exception>
-    public override void OnCoerceOutputValue(IFile runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(IFile runtimeValue, ResultElement resultValue)
         => throw new NotSupportedException();
 
     /// <summary>
@@ -91,7 +91,7 @@ public sealed class UploadType : ScalarType<IFile>
     /// <param name="runtimeValue">The runtime value (not used).</param>
     /// <returns>Never returns; always throws.</returns>
     /// <exception cref="NotSupportedException">Always thrown as value to literal conversion is not supported.</exception>
-    public override IValueNode OnValueToLiteral(IFile runtimeValue)
+    protected override IValueNode OnValueToLiteral(IFile runtimeValue)
         => throw new NotSupportedException();
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/AnyType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/AnyType.cs
@@ -74,7 +74,7 @@ public sealed class AnyType : ScalarType<JsonElement>
         => inputValue.Clone();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(JsonElement runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(JsonElement runtimeValue, ResultElement resultValue)
     {
         switch (runtimeValue.ValueKind)
         {
@@ -145,7 +145,7 @@ public sealed class AnyType : ScalarType<JsonElement>
     }
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(JsonElement runtimeValue)
+    protected override IValueNode OnValueToLiteral(JsonElement runtimeValue)
         => JsonParser.Parse(runtimeValue);
 
     private static class JsonParser

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/ByteType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/ByteType.cs
@@ -43,10 +43,10 @@ public class ByteType : IntegerTypeBase<sbyte>
         => inputValue.GetSByte();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(sbyte runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(sbyte runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(sbyte runtimeValue)
+    protected override IValueNode OnValueToLiteral(sbyte runtimeValue)
         => new IntValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/DecimalType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/DecimalType.cs
@@ -57,10 +57,10 @@ public class DecimalType : FloatTypeBase<decimal>
         => inputValue.GetDecimal();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(decimal runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(decimal runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(decimal runtimeValue)
+    protected override IValueNode OnValueToLiteral(decimal runtimeValue)
         => new FloatValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/FloatType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/FloatType.cs
@@ -60,10 +60,10 @@ public class FloatType : FloatTypeBase<double>
         => inputValue.GetDouble();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(double runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(double runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(double runtimeValue)
+    protected override IValueNode OnValueToLiteral(double runtimeValue)
         => new FloatValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/IdType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/IdType.cs
@@ -104,10 +104,10 @@ public class IdType : ScalarType<string>
     }
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(string runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(string runtimeValue, ResultElement resultValue)
         => resultValue.SetStringValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(string runtimeValue)
+    protected override IValueNode OnValueToLiteral(string runtimeValue)
         => new StringValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/IntType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/IntType.cs
@@ -60,10 +60,10 @@ public class IntType : IntegerTypeBase<int>
         => inputValue.GetInt32();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(int runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(int runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(int runtimeValue)
+    protected override IValueNode OnValueToLiteral(int runtimeValue)
         => new IntValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/LongType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/LongType.cs
@@ -57,10 +57,10 @@ public class LongType : IntegerTypeBase<long>
         => inputValue.GetInt64();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(long runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(long runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(long runtimeValue)
+    protected override IValueNode OnValueToLiteral(long runtimeValue)
         => new IntValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/ScalarType~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/ScalarType~1.cs
@@ -48,7 +48,7 @@ public abstract class ScalarType<TRuntimeType> : ScalarType where TRuntimeType :
     /// <exception cref="LeafCoercionException">
     /// Unable to coerce the given <paramref name="runtimeValue"/> into an output value.
     /// </exception>
-    public abstract void OnCoerceOutputValue(TRuntimeType runtimeValue, ResultElement resultValue);
+    protected abstract void OnCoerceOutputValue(TRuntimeType runtimeValue, ResultElement resultValue);
 
     /// <inheritdoc />
     public override IValueNode ValueToLiteral(object runtimeValue)
@@ -74,7 +74,7 @@ public abstract class ScalarType<TRuntimeType> : ScalarType where TRuntimeType :
     /// <exception cref="LeafCoercionException">
     /// Unable to convert the given <paramref name="runtimeValue"/> into a literal.
     /// </exception>
-    public abstract IValueNode OnValueToLiteral(TRuntimeType runtimeValue);
+    protected abstract IValueNode OnValueToLiteral(TRuntimeType runtimeValue);
 
     /// <summary>
     /// Creates the exception to throw when <see cref="CoerceOutputValue(object, ResultElement)"/>

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/ShortType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/ShortType.cs
@@ -55,10 +55,10 @@ public class ShortType : IntegerTypeBase<short>
         => inputValue.GetInt16();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(short runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(short runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(short runtimeValue)
+    protected override IValueNode OnValueToLiteral(short runtimeValue)
         => new IntValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UnsignedByteType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UnsignedByteType.cs
@@ -53,9 +53,9 @@ public class UnsignedByteType : IntegerTypeBase<byte>
     protected override byte OnCoerceInputValue(JsonElement inputValue)
         => inputValue.GetByte();
 
-    public override void OnCoerceOutputValue(byte runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(byte runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
-    public override IValueNode OnValueToLiteral(byte runtimeValue)
+    protected override IValueNode OnValueToLiteral(byte runtimeValue)
         => new IntValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UnsignedIntType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UnsignedIntType.cs
@@ -43,10 +43,10 @@ public class UnsignedIntType : IntegerTypeBase<uint>
         => inputValue.GetUInt32();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(uint runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(uint runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(uint runtimeValue)
+    protected override IValueNode OnValueToLiteral(uint runtimeValue)
         => new IntValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UnsignedLongType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UnsignedLongType.cs
@@ -43,10 +43,10 @@ public class UnsignedLongType : IntegerTypeBase<ulong>
         => inputValue.GetUInt64();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(ulong runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(ulong runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(ulong runtimeValue)
+    protected override IValueNode OnValueToLiteral(ulong runtimeValue)
         => new IntValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UnsignedShortType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UnsignedShortType.cs
@@ -43,10 +43,10 @@ public class UnsignedShortType : IntegerTypeBase<ushort>
         => inputValue.GetUInt16();
 
     /// <inheritdoc />
-    public override void OnCoerceOutputValue(ushort runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(ushort runtimeValue, ResultElement resultValue)
         => resultValue.SetNumberValue(runtimeValue);
 
     /// <inheritdoc />
-    public override IValueNode OnValueToLiteral(ushort runtimeValue)
+    protected override IValueNode OnValueToLiteral(ushort runtimeValue)
         => new IntValueNode(runtimeValue);
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Composite/SerializeAsTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Composite/SerializeAsTests.cs
@@ -60,10 +60,10 @@ public static class SerializeAsTests
         public override object CoerceInputValue(JsonElement inputValue, IFeatureProvider context)
             => throw new NotImplementedException();
 
-        public override void OnCoerceOutputValue(string runtimeValue, ResultElement resultValue)
+        protected override void OnCoerceOutputValue(string runtimeValue, ResultElement resultValue)
             => throw new NotImplementedException();
 
-        public override IValueNode OnValueToLiteral(string runtimeValue)
+        protected override IValueNode OnValueToLiteral(string runtimeValue)
             => throw new NotImplementedException();
     }
 
@@ -105,10 +105,10 @@ public static class SerializeAsTests
         public override object CoerceInputValue(JsonElement inputValue, IFeatureProvider context)
             => throw new NotImplementedException();
 
-        public override void OnCoerceOutputValue(string runtimeValue, ResultElement resultValue)
+        protected override void OnCoerceOutputValue(string runtimeValue, ResultElement resultValue)
             => throw new NotImplementedException();
 
-        public override IValueNode OnValueToLiteral(string runtimeValue)
+        protected override IValueNode OnValueToLiteral(string runtimeValue)
             => throw new NotImplementedException();
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/ScalarBindingTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/ScalarBindingTests.cs
@@ -72,12 +72,12 @@ public class ScalarBindingTests
             throw new NotImplementedException();
         }
 
-        public override void OnCoerceOutputValue(int runtimeValue, ResultElement resultValue)
+        protected override void OnCoerceOutputValue(int runtimeValue, ResultElement resultValue)
         {
             throw new NotImplementedException();
         }
 
-        public override IValueNode OnValueToLiteral(int runtimeValue)
+        protected override IValueNode OnValueToLiteral(int runtimeValue)
         {
             throw new NotImplementedException();
         }
@@ -102,12 +102,12 @@ public class ScalarBindingTests
             throw new NotImplementedException();
         }
 
-        public override void OnCoerceOutputValue(int runtimeValue, ResultElement resultValue)
+        protected override void OnCoerceOutputValue(int runtimeValue, ResultElement resultValue)
         {
             throw new NotImplementedException();
         }
 
-        public override IValueNode OnValueToLiteral(int runtimeValue)
+        protected override IValueNode OnValueToLiteral(int runtimeValue)
         {
             throw new NotImplementedException();
         }

--- a/src/HotChocolate/Core/test/Validation.Tests/Types/InvalidScalar.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/Types/InvalidScalar.cs
@@ -21,9 +21,9 @@ public class InvalidScalar : ScalarType<string>
     public override object CoerceInputValue(JsonElement inputValue, IFeatureProvider context)
         => throw new InvalidOperationException();
 
-    public override void OnCoerceOutputValue(string runtimeValue, ResultElement resultValue)
+    protected override void OnCoerceOutputValue(string runtimeValue, ResultElement resultValue)
         => throw new InvalidOperationException();
 
-    public override IValueNode OnValueToLiteral(string runtimeValue)
+    protected override IValueNode OnValueToLiteral(string runtimeValue)
         => throw new InvalidOperationException();
 }


### PR DESCRIPTION
Changes the access modifiers for OnCoerceOutputValue and OnValueToLiteral in `ScalarType<T>` from public to protected for consistency with `ScalarType<TA, TB>`