### PR TITLE
Remove redundant 'string.Format()' calls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -122,6 +122,7 @@ resharper_enforce_if_statement_braces_highlighting = error
 resharper_enforce_lock_statement_braces_highlighting = error
 resharper_enforce_using_statement_braces_highlighting = error
 resharper_enforce_while_statement_braces_highlighting = error
+resharper_redundant_string_format_call_highlighting = error
 resharper_unused_variable_highlighting = warning
 resharper_use_utf8_string_literal_highlighting = error
 resharper_use_verbatim_string_highlighting = error

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Utilities/ErrorHelper.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Utilities/ErrorHelper.cs
@@ -96,7 +96,7 @@ internal static class ErrorHelper
 
     public static IError BatchSizeExceeded(int maxBatchSize)
         => ErrorBuilder.New()
-            .SetMessage(string.Format(ErrorHelper_BatchSizeExceeded, maxBatchSize))
+            .SetMessage(ErrorHelper_BatchSizeExceeded, maxBatchSize)
             .SetCode(ErrorCodes.Server.RequestInvalid)
             .Build();
 }

--- a/src/HotChocolate/Core/src/Types/Execution/ThrowHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/ThrowHelper.cs
@@ -272,7 +272,7 @@ internal static class ThrowHelper
     public static GraphQLException OneOfFieldMustBeNonNull(
         SchemaCoordinate field)
         => new(ErrorBuilder.New()
-            .SetMessage(string.Format(ThrowHelper_OneOfFieldMustBeNonNull, field.MemberName))
+            .SetMessage(ThrowHelper_OneOfFieldMustBeNonNull, field.MemberName)
             .SetCode(ErrorCodes.Execution.OneOfFieldMustBeNonNull)
             .SetExtension(nameof(field), field.ToString())
             .Build());

--- a/src/HotChocolate/Core/src/Types/Utilities/ThrowHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ThrowHelper.cs
@@ -734,10 +734,7 @@ internal static class ThrowHelper
     {
         return new LeafCoercionException(
             ErrorBuilder.New()
-                .SetMessage(
-                    string.Format(
-                        TypeResources.RegexType_InvalidFormat,
-                        name))
+                .SetMessage(TypeResources.RegexType_InvalidFormat, name)
                 .SetCode(ErrorCodes.Scalars.InvalidSyntaxFormat)
                 .Build(),
             type);


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Remove redundant 'string.Format()' calls.