### PR TITLE
Remove 'partial' modifier from type with a single part

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -282,6 +282,8 @@ dotnet_diagnostic.RCS1021.severity = warning
 dotnet_diagnostic.IDE0053.severity = none # see https://github.com/dotnet/roslyn/issues/79246
 # Remove unnecessary braces in switch section.
 dotnet_diagnostic.RCS1031.severity = warning
+# Remove 'partial' modifier from type with a single part.
+dotnet_diagnostic.RCS1043.severity = warning
 # Simplify boolean comparison.
 dotnet_diagnostic.RCS1049.severity = warning
 # Include/omit parentheses when creating new object.

--- a/src/HotChocolate/Core/src/Validation/Extensions/ValidationBuilderExtensions.cs
+++ b/src/HotChocolate/Core/src/Validation/Extensions/ValidationBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// Extension methods for configuring an <see cref="DocumentValidatorBuilder"/>
 /// </summary>
-public static partial class HotChocolateValidationBuilderExtensions
+public static class HotChocolateValidationBuilderExtensions
 {
     /// <summary>
     /// Every argument provided to a field or directive must be defined


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Remove 'partial' modifier from type with a single part.