### PR TITLE
Fix assignment of JSON Schema formats in the OpenAPI adapter

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.OpenApi.AspNetCore/DynamicOpenApiDocumentTransformer.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.OpenApi.AspNetCore/DynamicOpenApiDocumentTransformer.cs
@@ -524,31 +524,31 @@ internal sealed class DynamicOpenApiDocumentTransformer : IOpenApiDocumentTransf
 
     private static string? GetJsonSchemaFormat(IScalarTypeDefinition scalarType)
     {
-        var format = scalarType.SpecifiedBy?.OriginalString switch
+        var format = scalarType.Name switch
         {
-            "https://scalars.graphql.org/chillicream/date.html" => "date",
-            "https://scalars.graphql.org/chillicream/date-time.html" => "date-time",
-            "https://scalars.graphql.org/chillicream/duration.html" => "duration",
-            "https://scalars.graphql.org/chillicream/local-date.html" => "date",
-            "https://scalars.graphql.org/chillicream/uuid.html" => "uuid",
-            "https://scalars.graphql.org/chillicream/uri.html" => "uri",
-            "https://scalars.graphql.org/chillicream/url.html" => "uri",
+            SpecScalarNames.Float.Name => "double",
+            SpecScalarNames.Int.Name => "int32",
             _ => null
         };
 
-        if (format is null)
+        return format ?? scalarType.SpecifiedBy?.OriginalString switch
         {
-            var serializationType = scalarType.GetScalarSerializationType();
-
-            return serializationType switch
-            {
-                ScalarSerializationType.Int => "int32",
-                ScalarSerializationType.Float => "float",
-                _ => null
-            };
-        }
-
-        return format;
+            "https://scalars.graphql.org/chillicream/byte.html" => "int8",
+            "https://scalars.graphql.org/chillicream/date-time.html" => "date-time",
+            "https://scalars.graphql.org/chillicream/date.html" => "date",
+            "https://scalars.graphql.org/chillicream/duration.html" => "duration",
+            "https://scalars.graphql.org/chillicream/local-date.html" => "date",
+            "https://scalars.graphql.org/chillicream/long.html" => "int64",
+            "https://scalars.graphql.org/chillicream/short.html" => "int16",
+            "https://scalars.graphql.org/chillicream/unsigned-byte.html" => "uint8",
+            "https://scalars.graphql.org/chillicream/unsigned-int.html" => "uint32",
+            "https://scalars.graphql.org/chillicream/unsigned-long.html" => "uint64",
+            "https://scalars.graphql.org/chillicream/unsigned-short.html" => "uint16",
+            "https://scalars.graphql.org/chillicream/uri.html" => "uri",
+            "https://scalars.graphql.org/chillicream/url.html" => "uri",
+            "https://scalars.graphql.org/chillicream/uuid.html" => "uuid",
+            _ => null
+        };
     }
 
     private static string? GetJsonSchemaPattern(IScalarTypeDefinition scalarType)

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/Endpoints/HttpEndpointIntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/Endpoints/HttpEndpointIntegrationTestBase.cs
@@ -394,6 +394,10 @@ public abstract class HttpEndpointIntegrationTestBase : OpenApiTestBase
                 "short": 1,
                 "string": "test",
                 "unknown": "test",
+                "unsignedByte": 1,
+                "unsignedInt": 65536,
+                "unsignedLong": 4294967296,
+                "unsignedShort": 256,
                 "uri": "https://example.com/",
                 "url": "https://example.com/",
                 "uuid": "00000000-0000-0000-0000-000000000000"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET10_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET10_0.json
@@ -40,6 +40,10 @@
                   "short",
                   "string",
                   "unknown",
+                  "unsignedByte",
+                  "unsignedInt",
+                  "unsignedLong",
+                  "unsignedShort",
                   "uri",
                   "url",
                   "uuid"
@@ -80,7 +84,7 @@
                   "byte": {
                     "type": "integer",
                     "description": "The `Byte` scalar type represents a signed 8-bit integer.",
-                    "format": "int32"
+                    "format": "int8"
                   },
                   "date": {
                     "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
@@ -96,8 +100,7 @@
                   },
                   "decimal": {
                     "type": "number",
-                    "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision.",
-                    "format": "float"
+                    "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision."
                   },
                   "duration": {
                     "pattern": "^-?P(?:\\d+W|(?=\\d|T(?:\\d|$))(?:\\d+Y)?(?:\\d+M)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d+)?S)?)?)$",
@@ -114,7 +117,7 @@
                   },
                   "float": {
                     "type": "number",
-                    "format": "float"
+                    "format": "double"
                   },
                   "id": {
                     "oneOf": [
@@ -178,7 +181,7 @@
                   "long": {
                     "type": "integer",
                     "description": "The `Long` scalar type represents a signed 64-bit integer.",
-                    "format": "int32"
+                    "format": "int64"
                   },
                   "object": {
                     "required": [
@@ -214,13 +217,33 @@
                   "short": {
                     "type": "integer",
                     "description": "The `Short` scalar type represents a signed 16-bit integer.",
-                    "format": "int32"
+                    "format": "int16"
                   },
                   "string": {
                     "type": "string"
                   },
                   "unknown": {
                     "type": "string"
+                  },
+                  "unsignedByte": {
+                    "type": "integer",
+                    "description": "The `UnsignedByte` scalar type represents an unsigned 8-bit integer.",
+                    "format": "uint8"
+                  },
+                  "unsignedInt": {
+                    "type": "integer",
+                    "description": "The `UnsignedInt` scalar type represents an unsigned 32-bit integer.",
+                    "format": "uint32"
+                  },
+                  "unsignedLong": {
+                    "type": "integer",
+                    "description": "The `UnsignedLong` scalar type represents an unsigned 64-bit integer.",
+                    "format": "uint64"
+                  },
+                  "unsignedShort": {
+                    "type": "integer",
+                    "description": "The `UnsignedShort` scalar type represents an unsigned 16-bit integer.",
+                    "format": "uint16"
                   },
                   "uri": {
                     "type": "string",
@@ -321,7 +344,7 @@
                         "integer"
                       ],
                       "description": "The `Byte` scalar type represents a signed 8-bit integer.",
-                      "format": "int32"
+                      "format": "int8"
                     },
                     "date": {
                       "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
@@ -346,8 +369,7 @@
                         "null",
                         "number"
                       ],
-                      "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision.",
-                      "format": "float"
+                      "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision."
                     },
                     "duration": {
                       "pattern": "^-?P(?:\\d+W|(?=\\d|T(?:\\d|$))(?:\\d+Y)?(?:\\d+M)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d+)?S)?)?)$",
@@ -373,7 +395,7 @@
                         "null",
                         "number"
                       ],
-                      "format": "float"
+                      "format": "double"
                     },
                     "id": {
                       "oneOf": [
@@ -458,7 +480,7 @@
                         "integer"
                       ],
                       "description": "The `Long` scalar type represents a signed 64-bit integer.",
-                      "format": "int32"
+                      "format": "int64"
                     },
                     "object": {
                       "required": [
@@ -507,7 +529,7 @@
                         "integer"
                       ],
                       "description": "The `Short` scalar type represents a signed 16-bit integer.",
-                      "format": "int32"
+                      "format": "int16"
                     },
                     "string": {
                       "type": [

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET10_0_Fusion.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET10_0_Fusion.json
@@ -40,6 +40,10 @@
                   "short",
                   "string",
                   "unknown",
+                  "unsignedByte",
+                  "unsignedInt",
+                  "unsignedLong",
+                  "unsignedShort",
                   "uri",
                   "url",
                   "uuid"
@@ -80,7 +84,7 @@
                   "byte": {
                     "type": "integer",
                     "description": "The `Byte` scalar type represents a signed 8-bit integer.",
-                    "format": "int32"
+                    "format": "int8"
                   },
                   "date": {
                     "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
@@ -96,8 +100,7 @@
                   },
                   "decimal": {
                     "type": "number",
-                    "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision.",
-                    "format": "float"
+                    "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision."
                   },
                   "duration": {
                     "pattern": "^-?P(?:\\d+W|(?=\\d|T(?:\\d|$))(?:\\d+Y)?(?:\\d+M)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d+)?S)?)?)$",
@@ -114,7 +117,7 @@
                   },
                   "float": {
                     "type": "number",
-                    "format": "float"
+                    "format": "double"
                   },
                   "id": {
                     "oneOf": [
@@ -178,7 +181,7 @@
                   "long": {
                     "type": "integer",
                     "description": "The `Long` scalar type represents a signed 64-bit integer.",
-                    "format": "int32"
+                    "format": "int64"
                   },
                   "object": {
                     "required": [
@@ -214,13 +217,33 @@
                   "short": {
                     "type": "integer",
                     "description": "The `Short` scalar type represents a signed 16-bit integer.",
-                    "format": "int32"
+                    "format": "int16"
                   },
                   "string": {
                     "type": "string"
                   },
                   "unknown": {
                     "type": "string"
+                  },
+                  "unsignedByte": {
+                    "type": "integer",
+                    "description": "The `UnsignedByte` scalar type represents an unsigned 8-bit integer.",
+                    "format": "uint8"
+                  },
+                  "unsignedInt": {
+                    "type": "integer",
+                    "description": "The `UnsignedInt` scalar type represents an unsigned 32-bit integer.",
+                    "format": "uint32"
+                  },
+                  "unsignedLong": {
+                    "type": "integer",
+                    "description": "The `UnsignedLong` scalar type represents an unsigned 64-bit integer.",
+                    "format": "uint64"
+                  },
+                  "unsignedShort": {
+                    "type": "integer",
+                    "description": "The `UnsignedShort` scalar type represents an unsigned 16-bit integer.",
+                    "format": "uint16"
                   },
                   "uri": {
                     "type": "string",
@@ -321,7 +344,7 @@
                         "integer"
                       ],
                       "description": "The `Byte` scalar type represents a signed 8-bit integer.",
-                      "format": "int32"
+                      "format": "int8"
                     },
                     "date": {
                       "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
@@ -346,8 +369,7 @@
                         "null",
                         "number"
                       ],
-                      "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision.",
-                      "format": "float"
+                      "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision."
                     },
                     "duration": {
                       "pattern": "^-?P(?:\\d+W|(?=\\d|T(?:\\d|$))(?:\\d+Y)?(?:\\d+M)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d+)?S)?)?)$",
@@ -373,7 +395,7 @@
                         "null",
                         "number"
                       ],
-                      "format": "float"
+                      "format": "double"
                     },
                     "id": {
                       "oneOf": [
@@ -458,7 +480,7 @@
                         "integer"
                       ],
                       "description": "The `Long` scalar type represents a signed 64-bit integer.",
-                      "format": "int32"
+                      "format": "int64"
                     },
                     "object": {
                       "required": [
@@ -507,7 +529,7 @@
                         "integer"
                       ],
                       "description": "The `Short` scalar type represents a signed 16-bit integer.",
-                      "format": "int32"
+                      "format": "int16"
                     },
                     "string": {
                       "type": [

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET9_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET9_0.json
@@ -35,6 +35,10 @@
                   "short",
                   "string",
                   "unknown",
+                  "unsignedByte",
+                  "unsignedInt",
+                  "unsignedLong",
+                  "unsignedShort",
                   "uri",
                   "url",
                   "uuid"
@@ -75,7 +79,7 @@
                   "byte": {
                     "type": "integer",
                     "description": "The `Byte` scalar type represents a signed 8-bit integer.",
-                    "format": "int32"
+                    "format": "int8"
                   },
                   "date": {
                     "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
@@ -91,8 +95,7 @@
                   },
                   "decimal": {
                     "type": "number",
-                    "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision.",
-                    "format": "float"
+                    "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision."
                   },
                   "duration": {
                     "pattern": "^-?P(?:\\d+W|(?=\\d|T(?:\\d|$))(?:\\d+Y)?(?:\\d+M)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d+)?S)?)?)$",
@@ -109,7 +112,7 @@
                   },
                   "float": {
                     "type": "number",
-                    "format": "float"
+                    "format": "double"
                   },
                   "id": {
                     "oneOf": [
@@ -173,7 +176,7 @@
                   "long": {
                     "type": "integer",
                     "description": "The `Long` scalar type represents a signed 64-bit integer.",
-                    "format": "int32"
+                    "format": "int64"
                   },
                   "object": {
                     "required": [
@@ -209,13 +212,33 @@
                   "short": {
                     "type": "integer",
                     "description": "The `Short` scalar type represents a signed 16-bit integer.",
-                    "format": "int32"
+                    "format": "int16"
                   },
                   "string": {
                     "type": "string"
                   },
                   "unknown": {
                     "type": "string"
+                  },
+                  "unsignedByte": {
+                    "type": "integer",
+                    "description": "The `UnsignedByte` scalar type represents an unsigned 8-bit integer.",
+                    "format": "uint8"
+                  },
+                  "unsignedInt": {
+                    "type": "integer",
+                    "description": "The `UnsignedInt` scalar type represents an unsigned 32-bit integer.",
+                    "format": "uint32"
+                  },
+                  "unsignedLong": {
+                    "type": "integer",
+                    "description": "The `UnsignedLong` scalar type represents an unsigned 64-bit integer.",
+                    "format": "uint64"
+                  },
+                  "unsignedShort": {
+                    "type": "integer",
+                    "description": "The `UnsignedShort` scalar type represents an unsigned 16-bit integer.",
+                    "format": "uint16"
                   },
                   "uri": {
                     "type": "string",
@@ -310,7 +333,7 @@
                     "byte": {
                       "type": "integer",
                       "description": "The `Byte` scalar type represents a signed 8-bit integer.",
-                      "format": "int32",
+                      "format": "int8",
                       "nullable": true
                     },
                     "date": {
@@ -330,7 +353,6 @@
                     "decimal": {
                       "type": "number",
                       "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision.",
-                      "format": "float",
                       "nullable": true
                     },
                     "duration": {
@@ -350,7 +372,7 @@
                     },
                     "float": {
                       "type": "number",
-                      "format": "float",
+                      "format": "double",
                       "nullable": true
                     },
                     "id": {
@@ -423,7 +445,7 @@
                     "long": {
                       "type": "integer",
                       "description": "The `Long` scalar type represents a signed 64-bit integer.",
-                      "format": "int32",
+                      "format": "int64",
                       "nullable": true
                     },
                     "object": {
@@ -462,7 +484,7 @@
                     "short": {
                       "type": "integer",
                       "description": "The `Short` scalar type represents a signed 16-bit integer.",
-                      "format": "int32",
+                      "format": "int16",
                       "nullable": true
                     },
                     "string": {

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET9_0_Fusion.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET9_0_Fusion.json
@@ -35,6 +35,10 @@
                   "short",
                   "string",
                   "unknown",
+                  "unsignedByte",
+                  "unsignedInt",
+                  "unsignedLong",
+                  "unsignedShort",
                   "uri",
                   "url",
                   "uuid"
@@ -75,7 +79,7 @@
                   "byte": {
                     "type": "integer",
                     "description": "The `Byte` scalar type represents a signed 8-bit integer.",
-                    "format": "int32"
+                    "format": "int8"
                   },
                   "date": {
                     "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
@@ -91,8 +95,7 @@
                   },
                   "decimal": {
                     "type": "number",
-                    "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision.",
-                    "format": "float"
+                    "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision."
                   },
                   "duration": {
                     "pattern": "^-?P(?:\\d+W|(?=\\d|T(?:\\d|$))(?:\\d+Y)?(?:\\d+M)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d+)?S)?)?)$",
@@ -109,7 +112,7 @@
                   },
                   "float": {
                     "type": "number",
-                    "format": "float"
+                    "format": "double"
                   },
                   "id": {
                     "oneOf": [
@@ -173,7 +176,7 @@
                   "long": {
                     "type": "integer",
                     "description": "The `Long` scalar type represents a signed 64-bit integer.",
-                    "format": "int32"
+                    "format": "int64"
                   },
                   "object": {
                     "required": [
@@ -209,13 +212,33 @@
                   "short": {
                     "type": "integer",
                     "description": "The `Short` scalar type represents a signed 16-bit integer.",
-                    "format": "int32"
+                    "format": "int16"
                   },
                   "string": {
                     "type": "string"
                   },
                   "unknown": {
                     "type": "string"
+                  },
+                  "unsignedByte": {
+                    "type": "integer",
+                    "description": "The `UnsignedByte` scalar type represents an unsigned 8-bit integer.",
+                    "format": "uint8"
+                  },
+                  "unsignedInt": {
+                    "type": "integer",
+                    "description": "The `UnsignedInt` scalar type represents an unsigned 32-bit integer.",
+                    "format": "uint32"
+                  },
+                  "unsignedLong": {
+                    "type": "integer",
+                    "description": "The `UnsignedLong` scalar type represents an unsigned 64-bit integer.",
+                    "format": "uint64"
+                  },
+                  "unsignedShort": {
+                    "type": "integer",
+                    "description": "The `UnsignedShort` scalar type represents an unsigned 16-bit integer.",
+                    "format": "uint16"
                   },
                   "uri": {
                     "type": "string",
@@ -310,7 +333,7 @@
                     "byte": {
                       "type": "integer",
                       "description": "The `Byte` scalar type represents a signed 8-bit integer.",
-                      "format": "int32",
+                      "format": "int8",
                       "nullable": true
                     },
                     "date": {
@@ -330,7 +353,6 @@
                     "decimal": {
                       "type": "number",
                       "description": "The `Decimal` scalar type represents a decimal floating-point number with high precision.",
-                      "format": "float",
                       "nullable": true
                     },
                     "duration": {
@@ -350,7 +372,7 @@
                     },
                     "float": {
                       "type": "number",
-                      "format": "float",
+                      "format": "double",
                       "nullable": true
                     },
                     "id": {
@@ -423,7 +445,7 @@
                     "long": {
                       "type": "integer",
                       "description": "The `Long` scalar type represents a signed 64-bit integer.",
-                      "format": "int32",
+                      "format": "int64",
                       "nullable": true
                     },
                     "object": {
@@ -462,7 +484,7 @@
                     "short": {
                       "type": "integer",
                       "description": "The `Short` scalar type represents a signed 16-bit integer.",
-                      "format": "int32",
+                      "format": "int16",
                       "nullable": true
                     },
                     "string": {

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/TestSchema.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/TestSchema.cs
@@ -84,6 +84,10 @@ public sealed class TestSchema
                 input.Short,
                 input.String,
                 input.Unknown,
+                input.UnsignedByte,
+                input.UnsignedInt,
+                input.UnsignedLong,
+                input.UnsignedShort,
                 input.Uri,
                 input.Url,
                 input.Uuid);
@@ -210,6 +214,10 @@ public sealed class TestSchema
         short? Short,
         string? String,
         [property: GraphQLType<UnknownType>] string? Unknown,
+        byte? UnsignedByte,
+        uint? UnsignedInt,
+        ulong? UnsignedLong,
+        ushort? UnsignedShort,
         Uri? Uri,
         [property: GraphQLType<UrlType>] Uri? Url,
         Guid? Uuid);
@@ -237,6 +245,10 @@ public sealed class TestSchema
         short Short,
         string String,
         [property: GraphQLType<NonNullType<UnknownType>>] string Unknown,
+        byte UnsignedByte,
+        uint UnsignedInt,
+        ulong UnsignedLong,
+        ushort UnsignedShort,
         Uri Uri,
         [property: GraphQLType<NonNullType<UrlType>>] Uri Url,
         Guid Uuid);


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fix assignment of JSON Schema formats in the OpenAPI adapter.