### PR TITLE
Use pattern matching to avoid `as` followed by a `null` check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -216,6 +216,9 @@ csharp_style_var_elsewhere = true
 dotnet_diagnostic.RCS1264.severity = none
 # Add braces.
 dotnet_diagnostic.IDE0011.severity = warning
+# Use pattern matching to avoid `as` followed by a `null` check.
+dotnet_diagnostic.IDE0019.severity = warning
+dotnet_diagnostic.RCS1221.severity = none
 # Use collection initializers or expressions.
 dotnet_diagnostic.IDE0028.severity = warning
 # Use null propagation.

--- a/src/HotChocolate/Core/src/Types.Analyzers/IdAttributeOnRecordParameterCodeFixProvider.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/IdAttributeOnRecordParameterCodeFixProvider.cs
@@ -33,8 +33,7 @@ public sealed class IdAttributeOnRecordParameterCodeFixProvider : CodeFixProvide
         var attribute = node.AncestorsAndSelf().OfType<AttributeSyntax>().FirstOrDefault();
 
         // Find the attribute list
-        var attributeList = attribute?.Parent as AttributeListSyntax;
-        if (attributeList is null)
+        if (attribute?.Parent is not AttributeListSyntax attributeList)
         {
             return;
         }

--- a/src/HotChocolate/Core/src/Types.Analyzers/QueryContextProjectionCodeFixProvider.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/QueryContextProjectionCodeFixProvider.cs
@@ -60,8 +60,7 @@ public sealed class QueryContextProjectionCodeFixProvider : CodeFixProvider
         }
 
         // Get the attribute list that contains this attribute
-        var attributeList = attribute.Parent as AttributeListSyntax;
-        if (attributeList is null)
+        if (attribute.Parent is not AttributeListSyntax attributeList)
         {
             return document;
         }

--- a/src/HotChocolate/Core/src/Types.Analyzers/ShareableInterfaceTypeCodeFixProvider.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/ShareableInterfaceTypeCodeFixProvider.cs
@@ -60,8 +60,7 @@ public sealed class ShareableInterfaceTypeCodeFixProvider : CodeFixProvider
         }
 
         // Find the attribute list that contains this attribute
-        var attributeList = attribute.Parent as AttributeListSyntax;
-        if (attributeList is null)
+        if (attribute.Parent is not AttributeListSyntax attributeList)
         {
             return document;
         }

--- a/src/HotChocolate/Core/src/Types.Analyzers/WrongAuthorizationAttributeAnalyzer.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/WrongAuthorizationAttributeAnalyzer.cs
@@ -28,8 +28,7 @@ public sealed class WrongAuthorizationAttributeAnalyzer : DiagnosticAnalyzer
         var methodDeclaration = (MethodDeclarationSyntax)context.Node;
 
         // Get the containing type (class or record)
-        var containingType = methodDeclaration.Parent as TypeDeclarationSyntax;
-        if (containingType is null)
+        if (methodDeclaration.Parent is not TypeDeclarationSyntax containingType)
         {
             return;
         }
@@ -48,8 +47,7 @@ public sealed class WrongAuthorizationAttributeAnalyzer : DiagnosticAnalyzer
         var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
 
         // Get the containing type (class or record)
-        var containingType = propertyDeclaration.Parent as TypeDeclarationSyntax;
-        if (containingType is null)
+        if (propertyDeclaration.Parent is not TypeDeclarationSyntax containingType)
         {
             return;
         }

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -528,9 +528,7 @@ internal sealed class TypeInitializer
         ObjectFieldConfiguration definition,
         IResolverCompiler resolverCompiler)
     {
-        var method = (definition.ResolverMember ?? definition.Member) as MethodInfo;
-
-        if (method is null)
+        if ((definition.ResolverMember ?? definition.Member) is not MethodInfo method)
         {
             return null;
         }
@@ -560,9 +558,7 @@ internal sealed class TypeInitializer
         InterfaceFieldConfiguration definition,
         IResolverCompiler resolverCompiler)
     {
-        var method = (definition.ResolverMember ?? definition.Member) as MethodInfo;
-
-        if (method is null)
+        if ((definition.ResolverMember ?? definition.Member) is not MethodInfo method)
         {
             return null;
         }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Use pattern matching to avoid `as` followed by a `null` check.