### PR TITLE
Stop caching 404s on website deploys

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -86,10 +86,9 @@ jobs:
           publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE }}
           images: ${{ secrets.CONTAINER_REG_DOMAIN }}/ccc-website-${{ github.ref_name }}:${{ github.run_id }}
 
-      - name: Purge CDN Cache
-        run: |
-          curl --request POST \
-            --url https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache \
-            --header 'Content-Type: application/json' \
-            --header 'Authorization: Bearer ${{ secrets.CLOUDFLARE_AUTH_TOKEN }}' \
-            --data '{ "purge_everything": true }'
+      # No purge step. HTML and RSC payloads are served with
+      # cf-cache-status: DYNAMIC (not edge-cached), and every asset under
+      # /_next/static is content-hashed + immutable, so new builds create
+      # new URLs. A purge_everything here would only invalidate the
+      # immutable chunks and stampede the origin right as the container is
+      # being swapped — the exact race that caused the 2026-04-23 outage.

--- a/website/app/global-error.tsx
+++ b/website/app/global-error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    // A ChunkLoadError means the build that rendered this tab's HTML no
+    // longer exists on the server (another deploy shipped newer hashes).
+    // A full reload fetches the current HTML and its matching chunks.
+    if (isChunkLoadError(error)) {
+      window.location.reload();
+    }
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <p>
+          Something went wrong while loading chillicream.com. Please reload the
+          page.
+        </p>
+        <button type="button" onClick={reset}>
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}
+
+function isChunkLoadError(error: Error): boolean {
+  return (
+    error.name === "ChunkLoadError" ||
+    /Loading chunk \d+ failed/i.test(error.message)
+  );
+}

--- a/website/config/conf.d/default.conf
+++ b/website/config/conf.d/default.conf
@@ -3,6 +3,23 @@ server {
   root /usr/share/nginx/html;
 
   error_page 404 /404.html;
+  error_page 500 502 503 504 /404.html;
+
+  # Never let a transient 404/5xx be cached by a CDN or browser. A container
+  # swap can serve a real 404 for a few hundred milliseconds, and with the
+  # default 4h Browser Cache TTL that response would then get pinned at every
+  # edge that saw it.
+  location = /404.html {
+    internal;
+    add_header Cache-Control "no-store" always;
+  }
+
+  # Next.js emits content-hashed filenames under /_next/static, so old and
+  # new builds coexist by URL. Treat them as immutable: browsers never
+  # re-fetch them, and a CDN purge has nothing to re-populate.
+  location ^~ /_next/static/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+  }
 
   set $latestStableVersion v16;
 


### PR DESCRIPTION
## Summary

Root cause of today's outage: Cloudflare's default 4h Browser Cache TTL was being applied to 4xx/5xx responses, so a transient 404 during a container swap got pinned at the edge for 4 hours and served to every subsequent user hitting that URL on that edge. This PR removes the toxic caching window and hardens the deploy path so it can't recur.

- **Never cache 4xx/5xx**: nginx now sends `Cache-Control: no-store` on error responses (via an internal `/404.html` location). A transient origin miss can no longer poison any CDN or browser cache.
- **Immutable static chunks**: `/_next/static/*` now gets `public, max-age=31536000, immutable`. Those filenames are content-hashed, so old and new builds coexist by URL and the browser never re-fetches them.
- **Drop `purge_everything`** from the publish workflow. HTML and RSC payloads are already served as `cf-cache-status: DYNAMIC` (not edge-cached), and chunks are now immutable, so the purge only stampedes the origin against a container that's still finishing its swap &mdash; exactly the race that caused today's outage.
- **Client-side safety net**: `app/global-error.tsx` detects `ChunkLoadError` and reloads, so if anything ever slips past the three changes above, users self-heal instead of seeing an "Application error" screen.

## Test plan

- [ ] Confirm `curl -sI https://chillicream.com/_next/static/chunks/definitely-missing.js` returns `cache-control: no-store` after this ships.
- [ ] Confirm `curl -sI https://chillicream.com/_next/static/chunks/webpack-<hash>.js` returns `cache-control: public, max-age=31536000, immutable`.
- [ ] Ship a follow-up deploy, open the site in incognito across a few docs pages, click around &mdash; no `ChunkLoadError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)