### PR TITLE
Switch to immutable releases

### DIFF
--- a/.github/actions/dispatch-and-watch-workflow/action.yml
+++ b/.github/actions/dispatch-and-watch-workflow/action.yml
@@ -1,0 +1,98 @@
+name: Dispatch and watch workflow
+description: Dispatches a workflow_dispatch in another repository and waits for it to complete.
+
+inputs:
+  repo:
+    description: Target repository in `owner/name` form.
+    required: true
+  workflow:
+    description: Workflow filename (e.g. `release.yaml`) or ID.
+    required: true
+  ref:
+    description: Git ref to dispatch the workflow against.
+    required: false
+    default: main
+  version:
+    description: Version passed as the `version` input to the dispatched workflow.
+    required: true
+  token:
+    description: "Token with `actions: write` on the target repository."
+    required: true
+  locate-attempts:
+    description: How many times to poll for the dispatched run before giving up.
+    required: false
+    default: "30"
+  locate-interval:
+    description: Seconds to wait between locate polls.
+    required: false
+    default: "5"
+
+outputs:
+  run-id:
+    description: Numeric ID of the dispatched run.
+    value: ${{ steps.locate.outputs.run-id }}
+  run-url:
+    description: HTML URL of the dispatched run.
+    value: ${{ steps.locate.outputs.run-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: 🚀 Dispatch workflow
+      id: dispatch
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ inputs.repo }}
+        WORKFLOW: ${{ inputs.workflow }}
+        REF: ${{ inputs.ref }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        CORR=$(uuidgen)
+        echo "correlation-id=$CORR" >> "$GITHUB_OUTPUT"
+
+        gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF" \
+          -f version="$VERSION" \
+          -f correlation_id="$CORR"
+
+    - name: 🔎 Locate dispatched run
+      id: locate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ inputs.repo }}
+        WORKFLOW: ${{ inputs.workflow }}
+        CORR: ${{ steps.dispatch.outputs.correlation-id }}
+        ATTEMPTS: ${{ inputs.locate-attempts }}
+        INTERVAL: ${{ inputs.locate-interval }}
+      run: |
+        set -euo pipefail
+        RUN_ID=""
+        RUN_URL=""
+        for _ in $(seq 1 "$ATTEMPTS"); do
+          read -r RUN_ID RUN_URL < <(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
+            --limit 20 --json databaseId,name,url \
+            --jq "[.[] | select(.name | contains(\"$CORR\"))][0] | \"\(.databaseId) \(.url)\"")
+          if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+            break
+          fi
+          sleep "$INTERVAL"
+        done
+
+        if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+          echo "::error::Could not locate dispatched run for $REPO ($WORKFLOW)"
+          exit 1
+        fi
+
+        echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
+        echo "run-url=$RUN_URL" >> "$GITHUB_OUTPUT"
+        echo "Dispatched run: $RUN_URL"
+
+    - name: 👀 Watch run
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ inputs.repo }}
+        RUN_ID: ${{ steps.locate.outputs.run-id }}
+      run: gh run watch "$RUN_ID" --repo "$REPO" --exit-status

--- a/.github/actions/dispatch-and-watch-workflow/action.yml
+++ b/.github/actions/dispatch-and-watch-workflow/action.yml
@@ -15,6 +15,12 @@ inputs:
   version:
     description: Version passed as the `version` input to the dispatched workflow.
     required: true
+  is_stable:
+    description: Whether the release is a stable (X.Y.Z) version. Forwarded to the dispatched workflow.
+    required: true
+  is_active_major:
+    description: Whether the release targets the top lane (version.major >= highest stable major). Forwarded to the dispatched workflow.
+    required: true
   token:
     description: "Token with `actions: write` on the target repository."
     required: true
@@ -47,6 +53,8 @@ runs:
         WORKFLOW: ${{ inputs.workflow }}
         REF: ${{ inputs.ref }}
         VERSION: ${{ inputs.version }}
+        IS_STABLE: ${{ inputs.is_stable }}
+        IS_ACTIVE_MAJOR: ${{ inputs.is_active_major }}
       run: |
         set -euo pipefail
         CORR=$(uuidgen)
@@ -54,6 +62,8 @@ runs:
 
         gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF" \
           -f version="$VERSION" \
+          -f is_stable="$IS_STABLE" \
+          -f is_active_major="$IS_ACTIVE_MAJOR" \
           -f correlation_id="$CORR"
 
     - name: 🔎 Locate dispatched run
@@ -81,7 +91,7 @@ runs:
         done
 
         if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-          echo "::error::Could not locate dispatched run for $REPO ($WORKFLOW)"
+          echo "::error::Could not locate dispatched run for $REPO ($WORKFLOW) with correlation_id=$CORR"
           exit 1
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   compute-release-context:
     name: 🧮 Compute release context
@@ -38,9 +42,11 @@ jobs:
           fi
 
           # Highest stable major already published as a non-prerelease, non-draft GitHub Release.
-          HIGHEST=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 200 \
-            --json tagName,isPrerelease,isDraft \
-            --jq '[.[] | select(.isPrerelease==false and .isDraft==false) | .tagName | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | map(split(".")[0] | tonumber) | max // 0')
+          HIGHEST=$(gh release list --repo "$GITHUB_REPOSITORY" \
+            --exclude-drafts --exclude-pre-releases \
+            --limit 100 \
+            --json tagName \
+            --jq '[.[] | .tagName | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | split(".")[0] | tonumber] | max // 0')
 
           if [[ "$MAJOR" -ge "$HIGHEST" ]]; then
             IS_ACTIVE_MAJOR=true
@@ -135,7 +141,7 @@ jobs:
           NitroIdentityScopes: ${{ secrets.NITRO_IDENTITY_SCOPES }}
 
       - name: 📤 Upload Nitro CLI client operations
-        uses: ChilliCream/nitro-client-upload@v16.0.0-rc.1.14
+        uses: ChilliCream/nitro-client-upload@v16.0.0-rc.1.40
         with:
           tag: ${{ env.GIT_TAG }}
           operations-file: src/Nitro/CommandLine/src/ChilliCream.Nitro.Client/persisted/operations.json
@@ -143,7 +149,7 @@ jobs:
           api-key: ${{ secrets.NITRO_API_KEY }}
 
       - name: 🚀 Publish Nitro CLI client (Dev)
-        uses: ChilliCream/nitro-client-publish@v16.0.0-rc.1.14
+        uses: ChilliCream/nitro-client-publish@v16.0.0-rc.1.40
         with:
           tag: ${{ env.GIT_TAG }}
           stage: Dev
@@ -152,7 +158,7 @@ jobs:
           force: true
 
       - name: 🚀 Publish Nitro CLI client (Prod)
-        uses: ChilliCream/nitro-client-publish@v16.0.0-rc.1.14
+        uses: ChilliCream/nitro-client-publish@v16.0.0-rc.1.40
         with:
           tag: ${{ env.GIT_TAG }}
           stage: Prod
@@ -173,7 +179,9 @@ jobs:
           NuGetApiKey: ${{ steps.login.outputs.NUGET_API_KEY }}
 
       - name: 📤 Attach .nupkg assets to GitHub release
+        shell: bash
         run: |
+          set -euo pipefail
           for file in ./output/packages/*.nupkg; do
             echo "📤 Uploading $file"
             gh release upload ${{ env.GIT_TAG }} "$file" --repo "${{ github.repository }}"
@@ -184,11 +192,12 @@ jobs:
   build-nitro-cli:
     name: 🧱 Build and Publish Nitro CLI
     runs-on: ${{ matrix.os }}
-    # We need to depend on this job, as it publishes the persisted operations of the CLI.
-    needs: [release]
-    if: startsWith(github.ref, 'refs/tags/')
+    # We need to depend on `release`, as it publishes the persisted operations of the CLI.
+    needs: [compute-release-context, release]
     permissions:
       contents: write
+    env:
+      GIT_TAG: ${{ needs.compute-release-context.outputs.git_tag }}
     strategy:
       matrix:
         include:
@@ -221,16 +230,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
-
-      - name: 🏷 Get the version from tag (Windows)
-        if: runner.os == 'Windows'
-        run: echo "GIT_TAG=$($env:GITHUB_REF -replace '^refs/tags/','')" >> $env:GITHUB_ENV
-        shell: pwsh
-
-      - name: 🏷 Get the version from tag (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: 📦 Publish binary (Windows)
         if: runner.os == 'Windows'
@@ -343,22 +342,10 @@ jobs:
       - name: 🖋️ Notarize binary (macOS)
         if: runner.os == 'macOS'
         env:
-          CODESIGN_IDENTITY: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_IDENTITY }}
           APPLE_DEVELOPER_ID_EMAIL: ${{ secrets.APPLE_DEVELOPER_ID_EMAIL }}
           APPLE_DEVELOPER_TEAM_ID: ${{ secrets.APPLE_DEVELOPER_TEAM_ID }}
           APPLE_DEVELOPER_NITRO_CLI_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_DEVELOPER_NITRO_CLI_APP_SPECIFIC_PASSWORD }}
         run: |
-          echo "Code signing 'nitro-${{ matrix.rid }}.zip'..."
-
-          codesign --sign "$CODESIGN_IDENTITY" \
-            --verbose=3 \
-            --options runtime \
-            --timestamp \
-            --force \
-            nitro-${{ matrix.rid }}.zip
-
-          codesign --verify --deep --strict --verbose=2 nitro-${{ matrix.rid }}.zip
-
           echo "Notarizing 'nitro-${{ matrix.rid }}.zip'..."
 
           xcrun notarytool submit nitro-${{ matrix.rid }}.zip \
@@ -366,9 +353,6 @@ jobs:
             --team-id "$APPLE_DEVELOPER_TEAM_ID" \
             --password "$APPLE_DEVELOPER_NITRO_CLI_APP_SPECIFIC_PASSWORD" \
             --wait
-
-          spctl --assess --type exec -vv nitro-${{ matrix.rid }}.zip || true
-          codesign -dvv nitro-${{ matrix.rid }}.zip || true
 
       - name: 🖋️ Clean up signing resources (macOS)
         if: always() && runner.os == 'macOS'
@@ -392,7 +376,6 @@ jobs:
     name: 🧱 Publish Nitro CLI binary to npm
     runs-on: ubuntu-latest
     needs: [compute-release-context, build-nitro-cli]
-    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
       id-token: write
@@ -428,9 +411,6 @@ jobs:
         with:
           name: nitro-${{ matrix.rid }}
           path: dist
-
-      - name: 🏷 Get the version from tag
-        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: 🗂️ Stage binary in package directory
         shell: bash
@@ -508,7 +488,6 @@ jobs:
     name: 🧱 Publish Nitro CLI to npm
     runs-on: ubuntu-latest
     needs: [compute-release-context, publish-nitro-cli-platforms]
-    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
       id-token: write
@@ -614,23 +593,25 @@ jobs:
     name: 🚀 Publish Release
     runs-on: ubuntu-22.04
     needs:
+      - compute-release-context
       - release
       - build-nitro-cli
       - publish-nitro-cli-platforms
       - publish-nitro-cli-npm
-    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
+    env:
+      GIT_TAG: ${{ needs.compute-release-context.outputs.git_tag }}
+      IS_STABLE: ${{ needs.compute-release-context.outputs.is_stable }}
 
     steps:
-      - name: 🏷 Get the version from tag
-        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
       - name: 🚀 Publish draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          if [[ "$GIT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          set -euo pipefail
+          if [[ "$IS_STABLE" == "true" ]]; then
             prerelease=false
           else
             prerelease=true
@@ -644,7 +625,6 @@ jobs:
     name: 🍺 Update Homebrew Tap
     runs-on: ubuntu-latest
     needs: [compute-release-context, publish-release]
-    if: startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: 📦 Checkout
@@ -676,7 +656,6 @@ jobs:
     name: 🔄 Update GitHub Actions
     runs-on: ubuntu-latest
     needs: [compute-release-context, publish-release]
-    if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
         repo:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "$GIT_TAG" \
-            --repo "${{ github.repository }}" \
-            --draft \
-            --title "$GIT_TAG" \
-            --generate-notes \
-            --target "$GITHUB_SHA"
+          if gh release view "$GIT_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release for $GIT_TAG already exists; leaving it untouched."
+          else
+            gh release create "$GIT_TAG" \
+              --repo "${{ github.repository }}" \
+              --draft \
+              --title "$GIT_TAG" \
+              --generate-notes \
+              --target "$GITHUB_SHA"
+          fi
 
   release:
     name: 📦 Build & Publish NuGet Packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,14 @@ jobs:
           if gh release view "$GIT_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             echo "Release for $GIT_TAG already exists; leaving it untouched."
           else
+            prerelease_flag=()
+            if [[ ! "$GIT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              prerelease_flag=(--prerelease)
+            fi
             gh release create "$GIT_TAG" \
               --repo "${{ github.repository }}" \
               --draft \
+              "${prerelease_flag[@]}" \
               --title "$GIT_TAG" \
               --generate-notes \
               --target "$GITHUB_SHA"
@@ -516,9 +521,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [[ "$GIT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            prerelease=false
+          else
+            prerelease=true
+          fi
           gh release edit "$GIT_TAG" \
             --repo "${{ github.repository }}" \
-            --draft=false
+            --draft=false \
+            --prerelease=$prerelease
 
   update-homebrew:
     name: 🍺 Update Homebrew Tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,42 +9,108 @@ permissions:
   contents: read
 
 jobs:
+  compute-release-context:
+    name: 🧮 Compute release context
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    outputs:
+      git_tag: ${{ steps.ctx.outputs.git_tag }}
+      major: ${{ steps.ctx.outputs.major }}
+      is_stable: ${{ steps.ctx.outputs.is_stable }}
+      is_active_major: ${{ steps.ctx.outputs.is_active_major }}
+      is_highest_stable_major: ${{ steps.ctx.outputs.is_highest_stable_major }}
+    steps:
+      - name: 🧮 Compute
+        id: ctx
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          GIT_TAG="${GITHUB_REF#refs/tags/}"
+          MAJOR="${GIT_TAG%%.*}"
+
+          if [[ "$GIT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            IS_STABLE=true
+          else
+            IS_STABLE=false
+          fi
+
+          # Highest stable major already published as a non-prerelease, non-draft GitHub Release.
+          HIGHEST=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 200 \
+            --json tagName,isPrerelease,isDraft \
+            --jq '[.[] | select(.isPrerelease==false and .isDraft==false) | .tagName | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | map(split(".")[0] | tonumber) | max // 0')
+
+          if [[ "$MAJOR" -ge "$HIGHEST" ]]; then
+            IS_ACTIVE_MAJOR=true
+          else
+            IS_ACTIVE_MAJOR=false
+          fi
+
+          if [[ "$IS_STABLE" == "true" && "$IS_ACTIVE_MAJOR" == "true" ]]; then
+            IS_HIGHEST_STABLE_MAJOR=true
+          else
+            IS_HIGHEST_STABLE_MAJOR=false
+          fi
+
+          echo "git_tag=$GIT_TAG" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "is_stable=$IS_STABLE" >> "$GITHUB_OUTPUT"
+          echo "is_active_major=$IS_ACTIVE_MAJOR" >> "$GITHUB_OUTPUT"
+          echo "is_highest_stable_major=$IS_HIGHEST_STABLE_MAJOR" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Release context"
+            echo "- git_tag: \`$GIT_TAG\`"
+            echo "- major: \`$MAJOR\`"
+            echo "- is_stable: \`$IS_STABLE\`"
+            echo "- is_active_major: \`$IS_ACTIVE_MAJOR\`"
+            echo "- is_highest_stable_major: \`$IS_HIGHEST_STABLE_MAJOR\`"
+            echo "- highest_stable_major (registry): \`$HIGHEST\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   create-draft:
     name: 📝 Create Draft Release
     runs-on: ubuntu-22.04
+    needs: [compute-release-context]
     permissions:
       contents: write
+    env:
+      GIT_TAG: ${{ needs.compute-release-context.outputs.git_tag }}
+      IS_STABLE: ${{ needs.compute-release-context.outputs.is_stable }}
     steps:
-      - name: 🏷 Get the version from tag
-        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
       - name: 📝 Create draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh release view "$GIT_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             echo "Release for $GIT_TAG already exists; leaving it untouched."
-          else
-            prerelease_flag=()
-            if [[ ! "$GIT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              prerelease_flag=(--prerelease)
-            fi
-            gh release create "$GIT_TAG" \
-              --repo "${{ github.repository }}" \
-              --draft \
-              "${prerelease_flag[@]}" \
-              --title "$GIT_TAG" \
-              --generate-notes \
-              --target "$GITHUB_SHA"
+            exit 0
           fi
+
+          prerelease_flag=()
+          if [[ "$IS_STABLE" != "true" ]]; then
+            prerelease_flag=(--prerelease)
+          fi
+
+          gh release create "$GIT_TAG" \
+            --repo "${{ github.repository }}" \
+            --draft \
+            "${prerelease_flag[@]}" \
+            --title "$GIT_TAG" \
+            --generate-notes \
+            --target "$GITHUB_SHA"
 
   release:
     name: 📦 Build & Publish NuGet Packages
     runs-on: ubuntu-22.04
-    needs: [create-draft]
+    needs: [compute-release-context, create-draft]
     permissions:
       contents: write
       id-token: write
+    env:
+      GIT_TAG: ${{ needs.compute-release-context.outputs.git_tag }}
 
     steps:
       - name: 📦 Checkout
@@ -59,9 +125,6 @@ jobs:
             8.x
             9.x
             10.x
-
-      - name: 🏷 Get the version from tag
-        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: 📦 Build NuGet Packages
         run: |
@@ -328,11 +391,16 @@ jobs:
   publish-nitro-cli-platforms:
     name: 🧱 Publish Nitro CLI binary to npm
     runs-on: ubuntu-latest
-    needs: [build-nitro-cli]
+    needs: [compute-release-context, build-nitro-cli]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
       id-token: write
+    env:
+      GIT_TAG: ${{ needs.compute-release-context.outputs.git_tag }}
+      MAJOR: ${{ needs.compute-release-context.outputs.major }}
+      IS_STABLE: ${{ needs.compute-release-context.outputs.is_stable }}
+      IS_HIGHEST_STABLE_MAJOR: ${{ needs.compute-release-context.outputs.is_highest_stable_major }}
     strategy:
       matrix:
         rid:
@@ -392,11 +460,50 @@ jobs:
       - name: 🚀 Publish tarball to npm
         working-directory: src/Nitro/CommandLine/src/npm/chillicream-nitro-${{ matrix.rid }}
         shell: bash
+        env:
+          REGISTRY: ${{ vars.NPM_REGISTRY_URL }}
+          PKG: "@chillicream/nitro-${{ matrix.rid }}"
+          TARBALL: "./chillicream-nitro-${{ matrix.rid }}-${{ needs.compute-release-context.outputs.git_tag }}.tgz"
         run: |
-          npm publish "./chillicream-nitro-${{ matrix.rid }}-${GIT_TAG}.tgz" \
+          set -euo pipefail
+
+          # 1. Pick the band this release publishes under.
+          if [[ "$IS_HIGHEST_STABLE_MAJOR" == "true" ]]; then
+            PRIMARY_BAND="latest"
+            SECONDARY_BAND="${MAJOR}"
+          elif [[ "$IS_STABLE" == "true" ]]; then
+            PRIMARY_BAND="${MAJOR}"
+            SECONDARY_BAND=""
+          elif [[ "$GIT_TAG" =~ -rc\. ]]; then
+            PRIMARY_BAND="rc"
+            SECONDARY_BAND=""
+          else
+            PRIMARY_BAND="preview"
+            SECONDARY_BAND=""
+          fi
+
+          # 2. Snapshot the current value of the primary band, then publish under it.
+          PREVIOUS=$(npm view "$PKG" "dist-tags.${PRIMARY_BAND}" --registry="$REGISTRY" 2>/dev/null || echo "")
+          npm publish "$TARBALL" \
             --access public \
-            --registry="${{ vars.NPM_REGISTRY_URL }}" \
-            --tag latest
+            --registry="$REGISTRY" \
+            --tag "$PRIMARY_BAND"
+
+          # 3. If the publish was a backport, restore the band to its previous version.
+          if [[ -n "$PREVIOUS" ]] && ! npx --yes semver -r ">$PREVIOUS" "$GIT_TAG" >/dev/null 2>&1; then
+            npm dist-tag add "${PKG}@${PREVIOUS}" "$PRIMARY_BAND" --registry="$REGISTRY"
+            echo "Restored '${PRIMARY_BAND}' to ${PREVIOUS} (backport publish: ${GIT_TAG} <= ${PREVIOUS})."
+          fi
+
+          # 4. Stable highest also binds the major band, soft-skipped if backport.
+          if [[ -n "$SECONDARY_BAND" ]]; then
+            CUR=$(npm view "$PKG" "dist-tags.${SECONDARY_BAND}" --registry="$REGISTRY" 2>/dev/null || echo "0.0.0")
+            if npx --yes semver -r ">$CUR" "$GIT_TAG" >/dev/null 2>&1; then
+              npm dist-tag add "${PKG}@${GIT_TAG}" "$SECONDARY_BAND" --registry="$REGISTRY"
+            else
+              echo "Skipping '${SECONDARY_BAND}' band update: current=${CUR}, new=${GIT_TAG}."
+            fi
+          fi
 
       - name: 📤 Upload tarball as artifact
         uses: actions/upload-artifact@v7
@@ -414,11 +521,16 @@ jobs:
   publish-nitro-cli-npm:
     name: 🧱 Publish Nitro CLI to npm
     runs-on: ubuntu-latest
-    needs: [publish-nitro-cli-platforms]
+    needs: [compute-release-context, publish-nitro-cli-platforms]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
       id-token: write
+    env:
+      GIT_TAG: ${{ needs.compute-release-context.outputs.git_tag }}
+      MAJOR: ${{ needs.compute-release-context.outputs.major }}
+      IS_STABLE: ${{ needs.compute-release-context.outputs.is_stable }}
+      IS_HIGHEST_STABLE_MAJOR: ${{ needs.compute-release-context.outputs.is_highest_stable_major }}
 
     steps:
       - name: 📦 Checkout
@@ -430,20 +542,6 @@ jobs:
           node-version: 24
           registry-url: ${{ vars.NPM_REGISTRY_URL }}
           scope: "@chillicream"
-
-      - name: 🏷 Get the version from tag
-        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: 🏷 Compute dist-tag
-        shell: bash
-        run: |
-          if [[ "$GIT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "DIST_TAG=latest" >> $GITHUB_ENV
-          elif [[ "$GIT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\. ]]; then
-            echo "DIST_TAG=rc" >> $GITHUB_ENV
-          else
-            echo "DIST_TAG=preview" >> $GITHUB_ENV
-          fi
 
       - name: 🧰 Enable corepack
         run: corepack enable
@@ -482,11 +580,50 @@ jobs:
       - name: 🚀 Publish tarball to npm
         working-directory: src/Nitro/CommandLine/src/npm/chillicream-nitro
         shell: bash
+        env:
+          REGISTRY: ${{ vars.NPM_REGISTRY_URL }}
+          PKG: "@chillicream/nitro"
+          TARBALL: "./chillicream-nitro-${{ needs.compute-release-context.outputs.git_tag }}.tgz"
         run: |
-          npm publish "./chillicream-nitro-${GIT_TAG}.tgz" \
+          set -euo pipefail
+
+          # 1. Pick the band this release publishes under.
+          if [[ "$IS_HIGHEST_STABLE_MAJOR" == "true" ]]; then
+            PRIMARY_BAND="latest"
+            SECONDARY_BAND="${MAJOR}"
+          elif [[ "$IS_STABLE" == "true" ]]; then
+            PRIMARY_BAND="${MAJOR}"
+            SECONDARY_BAND=""
+          elif [[ "$GIT_TAG" =~ -rc\. ]]; then
+            PRIMARY_BAND="rc"
+            SECONDARY_BAND=""
+          else
+            PRIMARY_BAND="preview"
+            SECONDARY_BAND=""
+          fi
+
+          # 2. Snapshot the current value of the primary band, then publish under it.
+          PREVIOUS=$(npm view "$PKG" "dist-tags.${PRIMARY_BAND}" --registry="$REGISTRY" 2>/dev/null || echo "")
+          npm publish "$TARBALL" \
             --access public \
-            --registry="${{ vars.NPM_REGISTRY_URL }}" \
-            --tag "${DIST_TAG}"
+            --registry="$REGISTRY" \
+            --tag "$PRIMARY_BAND"
+
+          # 3. If the publish was a backport, restore the band to its previous version.
+          if [[ -n "$PREVIOUS" ]] && ! npx --yes semver -r ">$PREVIOUS" "$GIT_TAG" >/dev/null 2>&1; then
+            npm dist-tag add "${PKG}@${PREVIOUS}" "$PRIMARY_BAND" --registry="$REGISTRY"
+            echo "Restored '${PRIMARY_BAND}' to ${PREVIOUS} (backport publish: ${GIT_TAG} <= ${PREVIOUS})."
+          fi
+
+          # 4. Stable highest also binds the major band, soft-skipped if backport.
+          if [[ -n "$SECONDARY_BAND" ]]; then
+            CUR=$(npm view "$PKG" "dist-tags.${SECONDARY_BAND}" --registry="$REGISTRY" 2>/dev/null || echo "0.0.0")
+            if npx --yes semver -r ">$CUR" "$GIT_TAG" >/dev/null 2>&1; then
+              npm dist-tag add "${PKG}@${GIT_TAG}" "$SECONDARY_BAND" --registry="$REGISTRY"
+            else
+              echo "Skipping '${SECONDARY_BAND}' band update: current=${CUR}, new=${GIT_TAG}."
+            fi
+          fi
 
       - name: 📤 Upload tarball as artifact
         uses: actions/upload-artifact@v7
@@ -534,7 +671,7 @@ jobs:
   update-homebrew:
     name: 🍺 Update Homebrew Tap
     runs-on: ubuntu-latest
-    needs: [publish-release]
+    needs: [compute-release-context, publish-release]
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
@@ -543,9 +680,6 @@ jobs:
         with:
           sparse-checkout: .github/actions
           show-progress: false
-
-      - name: 🏷️ Get release version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: 🔐 Create GitHub App token
         id: app-token
@@ -561,13 +695,15 @@ jobs:
         with:
           repo: ChilliCream/homebrew-tools
           workflow: release.yaml
-          version: ${{ env.VERSION }}
+          version: ${{ needs.compute-release-context.outputs.git_tag }}
+          is_stable: ${{ needs.compute-release-context.outputs.is_stable }}
+          is_active_major: ${{ needs.compute-release-context.outputs.is_active_major }}
           token: ${{ steps.app-token.outputs.token }}
 
   update-github-actions:
     name: 🔄 Update GitHub Actions
     runs-on: ubuntu-latest
-    needs: [publish-release]
+    needs: [compute-release-context, publish-release]
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
@@ -595,9 +731,6 @@ jobs:
           sparse-checkout: .github/actions
           show-progress: false
 
-      - name: 🏷️ Get release version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
       - name: 🔐 Create GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -612,5 +745,7 @@ jobs:
         with:
           repo: ChilliCream/${{ matrix.repo }}
           workflow: release.yaml
-          version: ${{ env.VERSION }}
+          version: ${{ needs.compute-release-context.outputs.git_tag }}
+          is_stable: ${{ needs.compute-release-context.outputs.is_stable }}
+          is_active_major: ${{ needs.compute-release-context.outputs.is_active_major }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,30 @@ permissions:
   contents: read
 
 jobs:
+  create-draft:
+    name: 📝 Create Draft Release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: 🏷 Get the version from tag
+        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: 📝 Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GIT_TAG" \
+            --repo "${{ github.repository }}" \
+            --draft \
+            --title "$GIT_TAG" \
+            --generate-notes \
+            --target "$GITHUB_SHA"
+
   release:
     name: 📦 Build & Publish NuGet Packages
     runs-on: ubuntu-22.04
+    needs: [create-draft]
     permissions:
       contents: write
       id-token: write
@@ -471,92 +492,67 @@ jobs:
         run: |
           gh release upload "${{ github.ref_name }}" "chillicream-nitro-${{ github.ref_name }}.tgz" --repo "${{ github.repository }}"
 
+  publish-release:
+    name: 🚀 Publish Release
+    runs-on: ubuntu-22.04
+    needs:
+      - release
+      - build-nitro-cli
+      - publish-nitro-cli-platforms
+      - publish-nitro-cli-npm
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+
+    steps:
+      - name: 🏷 Get the version from tag
+        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: 🚀 Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "$GIT_TAG" \
+            --repo "${{ github.repository }}" \
+            --draft=false
+
   update-homebrew:
-    name: 🍺 Update Homebrew Formula
+    name: 🍺 Update Homebrew Tap
     runs-on: ubuntu-latest
-    needs: [build-nitro-cli]
+    needs: [publish-release]
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-      - name: 📥 Checkout main repo
+      - name: 📦 Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          sparse-checkout: .github/actions
+          show-progress: false
 
       - name: 🏷️ Get release version
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
-      - name: ⬇️ Download macOS ARM64 release
-        run: |
-          curl -L -o nitro-osx-arm64.zip \
-            "https://github.com/ChilliCream/graphql-platform/releases/download/${{ steps.version.outputs.version }}/nitro-osx-arm64.zip"
-
-      - name: ⬇️ Download macOS x64 release
-        run: |
-          curl -L -o nitro-osx-x64.zip \
-            "https://github.com/ChilliCream/graphql-platform/releases/download/${{ steps.version.outputs.version }}/nitro-osx-x64.zip"
-
-      - name: 🔢 Calculate SHA256 hashes
-        id: hashes
-        run: |
-          ARM64_SHA=$(sha256sum nitro-osx-arm64.zip | cut -d' ' -f1)
-          X64_SHA=$(sha256sum nitro-osx-x64.zip | cut -d' ' -f1)
-          echo "arm64_sha=$ARM64_SHA" >> $GITHUB_OUTPUT
-          echo "x64_sha=$X64_SHA" >> $GITHUB_OUTPUT
-          echo "🔍 ARM64 SHA: $ARM64_SHA"
-          echo "🔍 X64 SHA: $X64_SHA"
-
-      - name: 📝 Generate Homebrew formula
-        run: |
-          cat > nitro-cli.rb << EOF
-          class NitroCli < Formula
-            desc "ChilliCream Nitro Command Line"
-            homepage "https://chillicream.com"
-            url "https://github.com/ChilliCream/graphql-platform"
-            license "MIT"
-
-            on_macos do
-              if Hardware::CPU.arm?
-                url "https://github.com/ChilliCream/graphql-platform/releases/download/${{ steps.version.outputs.version }}/nitro-osx-arm64.zip"
-                sha256 "${{ steps.hashes.outputs.arm64_sha }}"
-              else
-                url "https://github.com/ChilliCream/graphql-platform/releases/download/${{ steps.version.outputs.version }}/nitro-osx-x64.zip"
-                sha256 "${{ steps.hashes.outputs.x64_sha }}"
-              end
-            end
-
-            def install
-              bin.install "nitro"
-            end
-
-            test do
-              system "#{bin}/nitro", "--version"
-            end
-          end
-          EOF
-
-      - name: 📥 Checkout homebrew repo
-        uses: actions/checkout@v6
+      - name: 🔐 Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
         with:
-          repository: ChilliCream/homebrew-tools
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tools
+          app-id: ${{ secrets.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ChilliCream
+          repositories: homebrew-tools
 
-      - name: 🚀 Update formula in homebrew repo
-        run: |
-          cp nitro-cli.rb homebrew-tools/nitro-cli.rb
-          cd homebrew-tools
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add nitro-cli.rb
-          git commit -m "🍺 Update nitro formula to ${{ steps.version.outputs.version }}" || exit 0
-          git push
+      - name: 🍺 Run homebrew tap update workflow
+        uses: ./.github/actions/dispatch-and-watch-workflow
+        with:
+          repo: ChilliCream/homebrew-tools
+          workflow: release.yaml
+          version: ${{ env.VERSION }}
+          token: ${{ steps.app-token.outputs.token }}
 
   update-github-actions:
     name: 🔄 Update GitHub Actions
     runs-on: ubuntu-latest
-    needs: [build-nitro-cli]
+    needs: [publish-release]
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
@@ -578,6 +574,12 @@ jobs:
           - nitro-schema-validate
 
     steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions
+          show-progress: false
+
       - name: 🏷️ Get release version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
@@ -590,11 +592,10 @@ jobs:
           owner: ChilliCream
           repositories: ${{ matrix.repo }}
 
-      - name: 🚀 Trigger action repository update workflow
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api --method POST \
-            "/repos/ChilliCream/${{ matrix.repo }}/dispatches" \
-            -f event_type=update-from-platform \
-            -f client_payload[version]="$VERSION"
+      - name: 🔄 Run action repository update workflow
+        uses: ./.github/actions/dispatch-and-watch-workflow
+        with:
+          repo: ChilliCream/${{ matrix.repo }}
+          workflow: release.yaml
+          version: ${{ env.VERSION }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,7 +467,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # 1. Pick the band this release publishes under.
+          # Pick the band this release publishes under, based on release context.
           if [[ "$IS_HIGHEST_STABLE_MAJOR" == "true" ]]; then
             PRIMARY_BAND="latest"
             SECONDARY_BAND="${MAJOR}"
@@ -482,27 +482,13 @@ jobs:
             SECONDARY_BAND=""
           fi
 
-          # 2. Snapshot the current value of the primary band, then publish under it.
-          PREVIOUS=$(npm view "$PKG" "dist-tags.${PRIMARY_BAND}" --registry="$REGISTRY" 2>/dev/null || echo "")
           npm publish "$TARBALL" \
             --access public \
             --registry="$REGISTRY" \
             --tag "$PRIMARY_BAND"
 
-          # 3. If the publish was a backport, restore the band to its previous version.
-          if [[ -n "$PREVIOUS" ]] && ! npx --yes semver -r ">$PREVIOUS" "$GIT_TAG" >/dev/null 2>&1; then
-            npm dist-tag add "${PKG}@${PREVIOUS}" "$PRIMARY_BAND" --registry="$REGISTRY"
-            echo "Restored '${PRIMARY_BAND}' to ${PREVIOUS} (backport publish: ${GIT_TAG} <= ${PREVIOUS})."
-          fi
-
-          # 4. Stable highest also binds the major band, soft-skipped if backport.
           if [[ -n "$SECONDARY_BAND" ]]; then
-            CUR=$(npm view "$PKG" "dist-tags.${SECONDARY_BAND}" --registry="$REGISTRY" 2>/dev/null || echo "0.0.0")
-            if npx --yes semver -r ">$CUR" "$GIT_TAG" >/dev/null 2>&1; then
-              npm dist-tag add "${PKG}@${GIT_TAG}" "$SECONDARY_BAND" --registry="$REGISTRY"
-            else
-              echo "Skipping '${SECONDARY_BAND}' band update: current=${CUR}, new=${GIT_TAG}."
-            fi
+            npm dist-tag add "${PKG}@${GIT_TAG}" "$SECONDARY_BAND" --registry="$REGISTRY"
           fi
 
       - name: 📤 Upload tarball as artifact
@@ -587,7 +573,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # 1. Pick the band this release publishes under.
+          # Pick the band this release publishes under, based on release context.
           if [[ "$IS_HIGHEST_STABLE_MAJOR" == "true" ]]; then
             PRIMARY_BAND="latest"
             SECONDARY_BAND="${MAJOR}"
@@ -602,27 +588,13 @@ jobs:
             SECONDARY_BAND=""
           fi
 
-          # 2. Snapshot the current value of the primary band, then publish under it.
-          PREVIOUS=$(npm view "$PKG" "dist-tags.${PRIMARY_BAND}" --registry="$REGISTRY" 2>/dev/null || echo "")
           npm publish "$TARBALL" \
             --access public \
             --registry="$REGISTRY" \
             --tag "$PRIMARY_BAND"
 
-          # 3. If the publish was a backport, restore the band to its previous version.
-          if [[ -n "$PREVIOUS" ]] && ! npx --yes semver -r ">$PREVIOUS" "$GIT_TAG" >/dev/null 2>&1; then
-            npm dist-tag add "${PKG}@${PREVIOUS}" "$PRIMARY_BAND" --registry="$REGISTRY"
-            echo "Restored '${PRIMARY_BAND}' to ${PREVIOUS} (backport publish: ${GIT_TAG} <= ${PREVIOUS})."
-          fi
-
-          # 4. Stable highest also binds the major band, soft-skipped if backport.
           if [[ -n "$SECONDARY_BAND" ]]; then
-            CUR=$(npm view "$PKG" "dist-tags.${SECONDARY_BAND}" --registry="$REGISTRY" 2>/dev/null || echo "0.0.0")
-            if npx --yes semver -r ">$CUR" "$GIT_TAG" >/dev/null 2>&1; then
-              npm dist-tag add "${PKG}@${GIT_TAG}" "$SECONDARY_BAND" --registry="$REGISTRY"
-            else
-              echo "Skipping '${SECONDARY_BAND}' band update: current=${CUR}, new=${GIT_TAG}."
-            fi
+            npm dist-tag add "${PKG}@${GIT_TAG}" "$SECONDARY_BAND" --registry="$REGISTRY"
           fi
 
       - name: 📤 Upload tarball as artifact


### PR DESCRIPTION
- Aligns homebrew publishing to GitHub actions with short-lived app token
- Release workflow now waits for the child (GitHub actions / homebrew) release workflows to finish
- Introduced version bands for npm, homebrew and GitHub actions. Ensures we don't overwrite latest versions or other funky behavior if we start patching older versions.

### Changes to our release workflow

- **No longer publish releases via the UI!**
- Instead create a git tag through the CLI. The release workflow will create a draft release with the auto-generated changelog and publish it once all artifacts have been appended to the draft release.
- If you need to take control over the release content, create a release with the expected name and your content, but instead of publishing save as draft and push the tag from the CLI. The workflow will reuse the existing draft release instead of creating its own.