### PR TITLE
suggestion: Add multi-tenant dynamic schema resolution to ASP.NET Core pipeline

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/DynamicSchemaMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/DynamicSchemaMiddleware.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Http;
+using RequestDelegate = Microsoft.AspNetCore.Http.RequestDelegate;
+
+namespace HotChocolate.AspNetCore;
+
+/// <summary>
+/// A middleware that resolves the schema name for the current request
+/// using a delegate and stores it in <see cref="HttpContext.Items"/>
+/// for downstream middleware to use.
+/// </summary>
+public sealed class DynamicSchemaMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly Func<HttpContext, string> _schemaNameResolver;
+
+    internal static readonly object SchemaNameKey = new();
+
+    /// <summary>
+    /// Creates a new instance of <see cref="DynamicSchemaMiddleware"/>.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="schemaNameResolver">
+    /// A delegate that resolves the schema name from the current <see cref="HttpContext"/>.
+    /// </param>
+    public DynamicSchemaMiddleware(
+        RequestDelegate next,
+        Func<HttpContext, string> schemaNameResolver)
+    {
+        ArgumentNullException.ThrowIfNull(next);
+        ArgumentNullException.ThrowIfNull(schemaNameResolver);
+
+        _next = next;
+        _schemaNameResolver = schemaNameResolver;
+    }
+
+    /// <summary>
+    /// Invokes the middleware.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/>.</param>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var schemaName = _schemaNameResolver(context);
+        context.Items[SchemaNameKey] = schemaName;
+        await _next(context);
+    }
+
+    /// <summary>
+    /// Attempts to get the schema name that was resolved by
+    /// <see cref="DynamicSchemaMiddleware"/> for the current request.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/>.</param>
+    /// <param name="schemaName">
+    /// The resolved schema name, or <c>null</c> if no schema name was resolved.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if a schema name was resolved for the current request;
+    /// otherwise, <c>false</c>.
+    /// </returns>
+    public static bool TryGetSchemaName(HttpContext context, out string? schemaName)
+    {
+        if (context.Items.TryGetValue(SchemaNameKey, out var value) && value is string s)
+        {
+            schemaName = s;
+            return true;
+        }
+
+        schemaName = null;
+        return false;
+    }
+}

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Extensions/EndpointRouteBuilderExtensions.cs
@@ -97,6 +97,112 @@ public static class EndpointRouteBuilderExtensions
     }
 
     /// <summary>
+    /// Adds a GraphQL endpoint that resolves the schema name dynamically per request.
+    /// The <paramref name="schemaNameResolver"/> delegate is invoked for each incoming
+    /// request to determine which GraphQL schema to use, enabling multi-tenant scenarios
+    /// where the schema is determined from the request context (e.g., JWT claims,
+    /// headers, or route parameters).
+    /// </summary>
+    /// <param name="endpointRouteBuilder">
+    /// The <see cref="IEndpointRouteBuilder"/>.
+    /// </param>
+    /// <param name="path">
+    /// The path to which the GraphQL endpoint shall be mapped.
+    /// </param>
+    /// <param name="schemaNameResolver">
+    /// A delegate that resolves the schema name from the current
+    /// <see cref="HttpContext"/>. The returned schema name must correspond to a schema
+    /// registered via <see cref="M:Microsoft.Extensions.DependencyInjection.HotChocolateAspNetCoreServiceCollectionExtensions.AddGraphQLServer(Microsoft.Extensions.DependencyInjection.IServiceCollection,string,int,bool)"/>.
+    /// </param>
+    /// <returns>
+    /// Returns the <see cref="GraphQLEndpointConventionBuilder"/> so that
+    /// configuration can be chained.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="endpointRouteBuilder" /> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="schemaNameResolver" /> is <c>null</c>.
+    /// </exception>
+    public static GraphQLEndpointConventionBuilder MapGraphQL(
+        this IEndpointRouteBuilder endpointRouteBuilder,
+        string path,
+        Func<HttpContext, string> schemaNameResolver)
+        => MapGraphQL(endpointRouteBuilder, new PathString(path), schemaNameResolver);
+
+    /// <summary>
+    /// Adds a GraphQL endpoint that resolves the schema name dynamically per request.
+    /// The <paramref name="schemaNameResolver"/> delegate is invoked for each incoming
+    /// request to determine which GraphQL schema to use, enabling multi-tenant scenarios
+    /// where the schema is determined from the request context (e.g., JWT claims,
+    /// headers, or route parameters).
+    /// </summary>
+    /// <param name="endpointRouteBuilder">
+    /// The <see cref="IEndpointRouteBuilder"/>.
+    /// </param>
+    /// <param name="path">
+    /// The path to which the GraphQL endpoint shall be mapped.
+    /// </param>
+    /// <param name="schemaNameResolver">
+    /// A delegate that resolves the schema name from the current
+    /// <see cref="HttpContext"/>. The returned schema name must correspond to a schema
+    /// registered via <see cref="M:Microsoft.Extensions.DependencyInjection.HotChocolateAspNetCoreServiceCollectionExtensions.AddGraphQLServer(Microsoft.Extensions.DependencyInjection.IServiceCollection,string,int,bool)"/>.
+    /// </param>
+    /// <returns>
+    /// Returns the <see cref="GraphQLEndpointConventionBuilder"/> so that
+    /// configuration can be chained.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="endpointRouteBuilder" /> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="schemaNameResolver" /> is <c>null</c>.
+    /// </exception>
+    public static GraphQLEndpointConventionBuilder MapGraphQL(
+        this IEndpointRouteBuilder endpointRouteBuilder,
+        PathString path,
+        Func<HttpContext, string> schemaNameResolver)
+    {
+        ArgumentNullException.ThrowIfNull(endpointRouteBuilder);
+        ArgumentNullException.ThrowIfNull(schemaNameResolver);
+
+        path = path.ToString().TrimEnd('/');
+        var pattern = Parse(path + "/{**slug}");
+
+        var requestPipeline = endpointRouteBuilder.CreateApplicationBuilder();
+        var services = endpointRouteBuilder.ServiceProvider;
+
+        var defaultSchemaName = TryResolveSchemaName(services);
+        var executorProvider = services.GetRequiredService<IRequestExecutorProvider>();
+        var executorEvents = services.GetRequiredService<IRequestExecutorEvents>();
+        var formOptions = services.GetRequiredService<IOptions<FormOptions>>();
+        var executor = new HttpRequestExecutorProxy(executorProvider, executorEvents, defaultSchemaName);
+        var serverOptions = services.GetServerOptions(defaultSchemaName);
+
+        requestPipeline
+            .Use(MiddlewareFactory.CreateDynamicSchemaMiddleware(schemaNameResolver))
+            .Use(MiddlewareFactory.CreateCancellationMiddleware())
+            .Use(MiddlewareFactory.CreateWebSocketSubscriptionMiddleware(executor, serverOptions))
+            .Use(MiddlewareFactory.CreateHttpPostMiddleware(executor, serverOptions))
+            .Use(MiddlewareFactory.CreateHttpMultipartMiddleware(executor, serverOptions, formOptions))
+            .Use(MiddlewareFactory.CreateHttpGetMiddleware(executor, serverOptions))
+            .Use(MiddlewareFactory.CreateHttpGetSchemaMiddleware(
+                executor, serverOptions, path, MiddlewareRoutingType.Integrated))
+            .UseNitroApp(path, serverOptions.Tool)
+            .Use(_ => context =>
+            {
+                context.Response.StatusCode = 404;
+                return Task.CompletedTask;
+            });
+
+        return new GraphQLEndpointConventionBuilder(
+            endpointRouteBuilder
+                .Map(pattern, requestPipeline.Build())
+                .WithDisplayName("Hot Chocolate GraphQL Pipeline")
+                .WithMetadata(serverOptions.Tool));
+    }
+
+    /// <summary>
     /// Adds a GraphQL endpoint to the endpoint configurations.
     /// </summary>
     /// <param name="applicationBuilder">
@@ -232,6 +338,99 @@ public static class EndpointRouteBuilderExtensions
     }
 
     /// <summary>
+    /// Adds a GraphQL HTTP endpoint that resolves the schema name dynamically per request.
+    /// The <paramref name="schemaNameResolver"/> delegate is invoked for each incoming
+    /// request to determine which GraphQL schema to use.
+    /// </summary>
+    /// <param name="endpointRouteBuilder">
+    /// The <see cref="IEndpointRouteBuilder"/>.
+    /// </param>
+    /// <param name="pattern">
+    /// The path to which the GraphQL HTTP endpoint shall be mapped.
+    /// </param>
+    /// <param name="schemaNameResolver">
+    /// A delegate that resolves the schema name from the current
+    /// <see cref="HttpContext"/>.
+    /// </param>
+    /// <returns>
+    /// Returns the <see cref="GraphQLHttpEndpointConventionBuilder"/> so that
+    /// configuration can be chained.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="endpointRouteBuilder" /> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="schemaNameResolver" /> is <c>null</c>.
+    /// </exception>
+    public static GraphQLHttpEndpointConventionBuilder MapGraphQLHttp(
+        this IEndpointRouteBuilder endpointRouteBuilder,
+        [StringSyntax("Route")] string pattern,
+        Func<HttpContext, string> schemaNameResolver)
+        => MapGraphQLHttp(endpointRouteBuilder, Parse(pattern), schemaNameResolver);
+
+    /// <summary>
+    /// Adds a GraphQL HTTP endpoint that resolves the schema name dynamically per request.
+    /// The <paramref name="schemaNameResolver"/> delegate is invoked for each incoming
+    /// request to determine which GraphQL schema to use.
+    /// </summary>
+    /// <param name="endpointRouteBuilder">
+    /// The <see cref="IEndpointRouteBuilder"/>.
+    /// </param>
+    /// <param name="pattern">
+    /// The path to which the GraphQL HTTP endpoint shall be mapped.
+    /// </param>
+    /// <param name="schemaNameResolver">
+    /// A delegate that resolves the schema name from the current
+    /// <see cref="HttpContext"/>.
+    /// </param>
+    /// <returns>
+    /// Returns the <see cref="GraphQLHttpEndpointConventionBuilder"/> so that
+    /// configuration can be chained.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="endpointRouteBuilder" /> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="schemaNameResolver" /> is <c>null</c>.
+    /// </exception>
+    public static GraphQLHttpEndpointConventionBuilder MapGraphQLHttp(
+        this IEndpointRouteBuilder endpointRouteBuilder,
+        RoutePattern pattern,
+        Func<HttpContext, string> schemaNameResolver)
+    {
+        ArgumentNullException.ThrowIfNull(endpointRouteBuilder);
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(schemaNameResolver);
+
+        var requestPipeline = endpointRouteBuilder.CreateApplicationBuilder();
+        var services = endpointRouteBuilder.ServiceProvider;
+
+        var defaultSchemaName = TryResolveSchemaName(services);
+        var executorProvider = services.GetRequiredService<IRequestExecutorProvider>();
+        var executorEvents = services.GetRequiredService<IRequestExecutorEvents>();
+        var formOptions = services.GetRequiredService<IOptions<FormOptions>>();
+        var executor = new HttpRequestExecutorProxy(executorProvider, executorEvents, defaultSchemaName);
+        var serverOptions = services.GetServerOptions(defaultSchemaName);
+
+        requestPipeline
+            .Use(MiddlewareFactory.CreateDynamicSchemaMiddleware(schemaNameResolver))
+            .Use(MiddlewareFactory.CreateCancellationMiddleware())
+            .Use(MiddlewareFactory.CreateHttpPostMiddleware(executor, serverOptions))
+            .Use(MiddlewareFactory.CreateHttpMultipartMiddleware(executor, serverOptions, formOptions))
+            .Use(MiddlewareFactory.CreateHttpGetMiddleware(executor, serverOptions))
+            .Use(_ => context =>
+            {
+                context.Response.StatusCode = 404;
+                return Task.CompletedTask;
+            });
+
+        return new GraphQLHttpEndpointConventionBuilder(
+            endpointRouteBuilder
+                .Map(pattern, requestPipeline.Build())
+                .WithDisplayName("Hot Chocolate GraphQL HTTP Pipeline"));
+    }
+
+    /// <summary>
     /// Adds a GraphQL WebSocket endpoint to the endpoint configurations.
     /// </summary>
     /// <param name="endpointRouteBuilder">
@@ -295,6 +494,98 @@ public static class EndpointRouteBuilderExtensions
         var serverOptions = services.GetServerOptions(schemaNameOrDefault);
 
         requestPipeline
+            .Use(MiddlewareFactory.CreateCancellationMiddleware())
+            .Use(MiddlewareFactory.CreateWebSocketSubscriptionMiddleware(executor, serverOptions))
+            .Use(_ => context =>
+            {
+                context.Response.StatusCode = 404;
+                return Task.CompletedTask;
+            });
+
+        var builder = new GraphQLEndpointConventionBuilder(
+            endpointRouteBuilder
+                .Map(pattern, requestPipeline.Build())
+                .WithDisplayName("Hot Chocolate GraphQL WebSocket Pipeline"));
+
+        return new GraphQLWebSocketEndpointConventionBuilder(builder);
+    }
+
+    /// <summary>
+    /// Adds a GraphQL WebSocket endpoint that resolves the schema name dynamically per request.
+    /// The <paramref name="schemaNameResolver"/> delegate is invoked for each incoming
+    /// request to determine which GraphQL schema to use.
+    /// </summary>
+    /// <param name="endpointRouteBuilder">
+    /// The <see cref="IEndpointConventionBuilder"/>.
+    /// </param>
+    /// <param name="pattern">
+    /// The path to which the GraphQL WebSocket endpoint shall be mapped.
+    /// </param>
+    /// <param name="schemaNameResolver">
+    /// A delegate that resolves the schema name from the current
+    /// <see cref="HttpContext"/>.
+    /// </param>
+    /// <returns>
+    /// Returns the <see cref="GraphQLWebSocketEndpointConventionBuilder"/> so that
+    /// configuration can be chained.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="endpointRouteBuilder" /> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="schemaNameResolver" /> is <c>null</c>.
+    /// </exception>
+    public static GraphQLWebSocketEndpointConventionBuilder MapGraphQLWebSocket(
+        this IEndpointRouteBuilder endpointRouteBuilder,
+        [StringSyntax("Route")] string pattern,
+        Func<HttpContext, string> schemaNameResolver)
+        => MapGraphQLWebSocket(endpointRouteBuilder, Parse(pattern), schemaNameResolver);
+
+    /// <summary>
+    /// Adds a GraphQL WebSocket endpoint that resolves the schema name dynamically per request.
+    /// The <paramref name="schemaNameResolver"/> delegate is invoked for each incoming
+    /// request to determine which GraphQL schema to use.
+    /// </summary>
+    /// <param name="endpointRouteBuilder">
+    /// The <see cref="IEndpointConventionBuilder"/>.
+    /// </param>
+    /// <param name="pattern">
+    /// The path to which the GraphQL WebSocket endpoint shall be mapped.
+    /// </param>
+    /// <param name="schemaNameResolver">
+    /// A delegate that resolves the schema name from the current
+    /// <see cref="HttpContext"/>.
+    /// </param>
+    /// <returns>
+    /// Returns the <see cref="GraphQLWebSocketEndpointConventionBuilder"/> so that
+    /// configuration can be chained.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="endpointRouteBuilder" /> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="schemaNameResolver" /> is <c>null</c>.
+    /// </exception>
+    public static GraphQLWebSocketEndpointConventionBuilder MapGraphQLWebSocket(
+        this IEndpointRouteBuilder endpointRouteBuilder,
+        RoutePattern pattern,
+        Func<HttpContext, string> schemaNameResolver)
+    {
+        ArgumentNullException.ThrowIfNull(endpointRouteBuilder);
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(schemaNameResolver);
+
+        var requestPipeline = endpointRouteBuilder.CreateApplicationBuilder();
+        var services = endpointRouteBuilder.ServiceProvider;
+
+        var defaultSchemaName = TryResolveSchemaName(services);
+        var executorProvider = services.GetRequiredService<IRequestExecutorProvider>();
+        var executorEvents = services.GetRequiredService<IRequestExecutorEvents>();
+        var executor = new HttpRequestExecutorProxy(executorProvider, executorEvents, defaultSchemaName);
+        var serverOptions = services.GetServerOptions(defaultSchemaName);
+
+        requestPipeline
+            .Use(MiddlewareFactory.CreateDynamicSchemaMiddleware(schemaNameResolver))
             .Use(MiddlewareFactory.CreateCancellationMiddleware())
             .Use(MiddlewareFactory.CreateWebSocketSubscriptionMiddleware(executor, serverOptions))
             .Use(_ => context =>
@@ -739,6 +1030,17 @@ public static class EndpointRouteBuilderExtensions
 
     private static GraphQLServerOptions GetServerOptions(this IServiceProvider services, string schemaName)
         => services.GetRequiredService<IOptionsMonitor<GraphQLServerOptions>>().Get(schemaName);
+
+    private static string TryResolveSchemaName(IServiceProvider services)
+    {
+        if (services.GetService<IRequestExecutorProvider>() is { } provider
+            && provider.SchemaNames.Length == 1)
+        {
+            return provider.SchemaNames[0];
+        }
+
+        return ISchemaDefinition.DefaultName;
+    }
 
     private static void TryResolveSchemaName(IServiceProvider services, ref string? schemaName)
     {

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpGetMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpGetMiddleware.cs
@@ -28,7 +28,7 @@ public sealed class HttpGetMiddleware : MiddlewareBase
     {
         if (HttpMethods.IsGet(context.Request.Method))
         {
-            var session = await Executor.GetOrCreateSessionAsync(context.RequestAborted);
+            var session = await GetExecutorSessionAsync(context, context.RequestAborted);
             var options = GetOptions(context);
 
             if (options.EnableGetRequests

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpGetSchemaMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpGetSchemaMiddleware.cs
@@ -42,7 +42,7 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
 
         if (isCandidate)
         {
-            var session = await Executor.GetOrCreateSessionAsync(context.RequestAborted);
+            var session = await GetExecutorSessionAsync(context, context.RequestAborted);
             var options = GetOptions(context);
 
             if (options.EnableSchemaRequests)

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpGetSemanticNonNullSchemaMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpGetSemanticNonNullSchemaMiddleware.cs
@@ -18,7 +18,7 @@ public sealed class HttpGetSemanticNonNullSchemaMiddleware : MiddlewareBase
     {
         if (HttpMethods.IsGet(context.Request.Method))
         {
-            var session = await Executor.GetOrCreateSessionAsync(context.RequestAborted);
+            var session = await GetExecutorSessionAsync(context, context.RequestAborted);
             var options = GetOptions(context);
 
             if (options.EnableSchemaRequests)

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpMultipartMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpMultipartMiddleware.cs
@@ -58,7 +58,7 @@ public sealed class HttpMultipartMiddleware : HttpPostMiddlewareBase
         if (HttpMethods.IsPost(context.Request.Method)
             && context.ParseContentType() == RequestContentType.Form)
         {
-            var session = await Executor.GetOrCreateSessionAsync(context.RequestAborted);
+            var session = await GetExecutorSessionAsync(context, context.RequestAborted);
             var options = GetOptions(context);
 
             if (!options.EnableMultipartRequests)

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpPostMiddlewareBase.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpPostMiddlewareBase.cs
@@ -33,7 +33,7 @@ public abstract class HttpPostMiddlewareBase : MiddlewareBase
             && context.ParseContentType() is RequestContentType.Json)
         {
             var ct = context.RequestAborted;
-            var session = await Executor.GetOrCreateSessionAsync(ct);
+            var session = await GetExecutorSessionAsync(context, ct);
 
             using (session.DiagnosticEvents.ExecuteHttpRequest(context, HttpRequestKind.HttpPost))
             {
@@ -48,7 +48,7 @@ public abstract class HttpPostMiddlewareBase : MiddlewareBase
         }
     }
 
-    protected async Task HandleRequestAsync(HttpContext context, ExecutorSession session, CancellationToken ct)
+protected async Task HandleRequestAsync(HttpContext context, ExecutorSession session, CancellationToken ct)
     {
         var options = GetOptions(context);
         HttpStatusCode? statusCode = null;

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/MiddlewareBase.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/MiddlewareBase.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using RequestDelegate = Microsoft.AspNetCore.Http.RequestDelegate;
 
 namespace HotChocolate.AspNetCore;
@@ -40,20 +42,74 @@ public abstract class MiddlewareBase : IDisposable
     /// </param>
     protected Task NextAsync(HttpContext context) => _next(context);
 
+    /// <summary>
+    /// Gets the executor session for the current request.
+    /// If a schema name was resolved dynamically via
+    /// <see cref="DynamicSchemaMiddleware"/>, the session for that
+    /// schema is returned. Otherwise, the session for the default
+    /// schema bound to this middleware is returned.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The executor session.</returns>
+    protected async ValueTask<ExecutorSession> GetExecutorSessionAsync(
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        if (DynamicSchemaMiddleware.TryGetSchemaName(context, out var schemaName))
+        {
+            var executorProvider = context.RequestServices.GetRequiredService<IRequestExecutorProvider>();
+            var executor = await executorProvider.GetExecutorAsync(schemaName, cancellationToken);
+            return new ExecutorSession(executor);
+        }
+
+        return await Executor.GetOrCreateSessionAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the server options for the current request.
+    /// If a schema name was resolved dynamically, the options for
+    /// that schema are returned. Otherwise, the options for the
+    /// default schema bound to this middleware are returned.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/>.</param>
+    /// <returns>The server options.</returns>
     protected GraphQLServerOptions GetOptions(HttpContext context)
     {
+        if (DynamicSchemaMiddleware.TryGetSchemaName(context, out var schemaName))
+        {
+            var optionsMonitor = context.RequestServices.GetRequiredService<IOptionsMonitor<GraphQLServerOptions>>();
+            var schemaOptions = optionsMonitor.Get(schemaName);
+
+            var optionOverrides = context.GetEndpoint()?.Metadata.GetOrderedMetadata<GraphQLServerOptionsOverride>();
+
+            if (optionOverrides is { Count: > 0 })
+            {
+                var options = schemaOptions.Clone();
+
+                foreach (var optionsOverride in optionOverrides)
+                {
+                    optionsOverride.Apply(options);
+                }
+
+                return options;
+            }
+
+            return schemaOptions;
+        }
+
         if (_options is not null)
         {
             return _options;
         }
 
-        var optionOverrides = context.GetEndpoint()?.Metadata.GetOrderedMetadata<GraphQLServerOptionsOverride>();
+        var endpointOverrides = context.GetEndpoint()?.Metadata.GetOrderedMetadata<GraphQLServerOptionsOverride>();
 
-        if (optionOverrides is { Count: > 0 })
+        if (endpointOverrides is { Count: > 0 })
         {
             var options = _baseOptions.Clone();
 
-            foreach (var optionsOverride in optionOverrides)
+            foreach (var optionsOverride in endpointOverrides)
             {
                 optionsOverride.Apply(options);
             }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/MiddlewareFactory.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/MiddlewareFactory.cs
@@ -29,6 +29,16 @@ internal static class MiddlewareFactory
         };
     }
 
+    internal static Func<RequestDelegate, RequestDelegate> CreateDynamicSchemaMiddleware(
+        Func<HttpContext, string> schemaNameResolver)
+    {
+        return next =>
+        {
+            var middleware = new DynamicSchemaMiddleware(next, schemaNameResolver);
+            return context => middleware.InvokeAsync(context);
+        };
+    }
+
     internal static Func<RequestDelegate, RequestDelegate> CreateWebSocketSubscriptionMiddleware(
         HttpRequestExecutorProxy executor,
         GraphQLServerOptions serverOptions)

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/WebSocketSubscriptionMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/WebSocketSubscriptionMiddleware.cs
@@ -30,7 +30,7 @@ public sealed class WebSocketSubscriptionMiddleware : MiddlewareBase
 
     private async Task HandleWebSocketSessionAsync(HttpContext context)
     {
-        var session = await Executor.GetOrCreateSessionAsync(context.RequestAborted);
+        var session = await GetExecutorSessionAsync(context, context.RequestAborted);
         var options = GetOptions(context);
 
         using (session.DiagnosticEvents.WebSocketSession(context))

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/DynamicSchemaTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/DynamicSchemaTests.cs
@@ -1,0 +1,377 @@
+using System.Net;
+using System.Text;
+using HotChocolate.AspNetCore.Tests.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+
+namespace HotChocolate.AspNetCore;
+
+public class DynamicSchemaTests(TestServerFactory serverFactory) : ServerTestBase(serverFactory)
+{
+    [Fact]
+    public async Task MapGraphQL_DynamicSchema_ResolvesSchemaFromHeader()
+    {
+        // arrange
+        var server = ServerFactory.Create(
+            services =>
+            {
+                services.AddRouting();
+                services.AddGraphQLServer("tenant-a")
+                    .AddQueryType<QueryA>();
+                services.AddGraphQLServer("tenant-b")
+                    .AddQueryType<QueryB>();
+            },
+            app => app
+                .UseRouting()
+                .UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGraphQL(
+                        "/graphql",
+                        context => context.Request.Headers["X-Tenant-Id"].ToString());
+                }));
+
+        // act: resolve tenant-a
+        var resultA = await PostDynamicAsync(
+            server,
+            new ClientQueryRequest { Query = "{ who }" },
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-a");
+
+        // act: resolve tenant-b
+        var resultB = await PostDynamicAsync(
+            server,
+            new ClientQueryRequest { Query = "{ who }" },
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-b");
+
+        // assert
+        Assert.Equal("TenantA", resultA.Data!["who"]!.ToString());
+        Assert.Equal("TenantB", resultB.Data!["who"]!.ToString());
+    }
+
+    [Fact]
+    public async Task MapGraphQLHttp_DynamicSchema_ResolvesSchemaPerRequest()
+    {
+        // arrange
+        var server = ServerFactory.Create(
+            services =>
+            {
+                services.AddRouting();
+                services.AddGraphQLServer("tenant-a")
+                    .AddQueryType<QueryA>();
+                services.AddGraphQLServer("tenant-b")
+                    .AddQueryType<QueryB>();
+            },
+            app => app
+                .UseRouting()
+                .UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGraphQLHttp(
+                        "/graphql",
+                        context => context.Request.Headers["X-Tenant-Id"].ToString());
+                }));
+
+        // act
+        var resultA = await PostDynamicAsync(
+            server,
+            new ClientQueryRequest { Query = "{ who }" },
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-a");
+
+        var resultB = await PostDynamicAsync(
+            server,
+            new ClientQueryRequest { Query = "{ who }" },
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-b");
+
+        // assert
+        Assert.Equal("TenantA", resultA.Data!["who"]!.ToString());
+        Assert.Equal("TenantB", resultB.Data!["who"]!.ToString());
+    }
+
+    [Fact]
+    public async Task MapGraphQLHttp_DynamicSchema_GetRequest_ResolvesSchemaPerRequest()
+    {
+        // arrange
+        var server = ServerFactory.Create(
+            services =>
+            {
+                services.AddRouting();
+                services.AddGraphQLServer("tenant-a")
+                    .AddQueryType<QueryA>()
+                    .ModifyServerOptions(o =>
+                        o.AllowedGetOperations = AllowedGetOperations.Query);
+                services.AddGraphQLServer("tenant-b")
+                    .AddQueryType<QueryB>()
+                    .ModifyServerOptions(o =>
+                        o.AllowedGetOperations = AllowedGetOperations.Query);
+            },
+            app => app
+                .UseRouting()
+                .UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGraphQLHttp(
+                        "/graphql",
+                        context => context.Request.Headers["X-Tenant-Id"].ToString());
+                }));
+
+        // act
+        var resultA = await GetDynamicAsync(
+            server,
+            "{ who }",
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-a");
+
+        var resultB = await GetDynamicAsync(
+            server,
+            "{ who }",
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-b");
+
+        // assert
+        Assert.Equal("TenantA", resultA.Data!["who"]!.ToString());
+        Assert.Equal("TenantB", resultB.Data!["who"]!.ToString());
+    }
+
+    [Fact]
+    public async Task MapGraphQL_DynamicSchema_SameEndpointDifferentTenantsConcurrently()
+    {
+        // arrange
+        var server = ServerFactory.Create(
+            services =>
+            {
+                services.AddRouting();
+                services.AddGraphQLServer("tenant-a")
+                    .AddQueryType<QueryA>()
+                    .ModifyServerOptions(o =>
+                        o.AllowedGetOperations = AllowedGetOperations.Query);
+                services.AddGraphQLServer("tenant-b")
+                    .AddQueryType<QueryB>()
+                    .ModifyServerOptions(o =>
+                        o.AllowedGetOperations = AllowedGetOperations.Query);
+            },
+            app => app
+                .UseRouting()
+                .UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGraphQL(
+                        "/graphql",
+                        context => context.Request.Headers["X-Tenant-Id"].ToString());
+                }));
+
+        // act: send multiple requests concurrently
+        var tasks = new List<Task<ClientQueryResult>>();
+        for (var i = 0; i < 5; i++)
+        {
+            tasks.Add(PostDynamicAsync(
+                server,
+                new ClientQueryRequest { Query = "{ who }" },
+                "/graphql",
+                "X-Tenant-Id",
+                "tenant-a"));
+            tasks.Add(PostDynamicAsync(
+                server,
+                new ClientQueryRequest { Query = "{ who }" },
+                "/graphql",
+                "X-Tenant-Id",
+                "tenant-b"));
+        }
+
+        var results = await Task.WhenAll(tasks);
+
+        // assert: tenant-a results
+        var tenantAResults = results.Where((_, i) => i % 2 == 0).ToList();
+        var tenantBResults = results.Where((_, i) => i % 2 != 0).ToList();
+
+        Assert.All(tenantAResults, r => Assert.Equal("TenantA", r.Data!["who"]!.ToString()));
+        Assert.All(tenantBResults, r => Assert.Equal("TenantB", r.Data!["who"]!.ToString()));
+    }
+
+    [Fact]
+    public async Task MapGraphQL_DynamicSchema_IntrospectionReturnsDifferentSchemas()
+    {
+        // arrange
+        var server = ServerFactory.Create(
+            services =>
+            {
+                services.AddRouting();
+                services.AddGraphQLServer("tenant-a")
+                    .AddQueryType<QueryA>();
+                services.AddGraphQLServer("tenant-b")
+                    .AddQueryType<QueryB>();
+            },
+            app => app
+                .UseRouting()
+                .UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGraphQL(
+                        "/graphql",
+                        context => context.Request.Headers["X-Tenant-Id"].ToString());
+                }));
+
+        // act: introspect tenant-a schema, then tenant-b schema
+        var resultA = await PostDynamicAsync(
+            server,
+            new ClientQueryRequest { Query = "{ __typename }" },
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-a");
+
+        var resultB = await PostDynamicAsync(
+            server,
+            new ClientQueryRequest { Query = "{ __typename }" },
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-b");
+
+        // assert: both tenants return valid results (schemas are distinct)
+        Assert.NotNull(resultA.Data);
+        Assert.NotNull(resultB.Data);
+        Assert.Null(resultA.Errors);
+        Assert.Null(resultB.Errors);
+    }
+
+    [Fact]
+    public async Task MapGraphQLWebSocket_DynamicSchema_ResolvesSchemaPerRequest()
+    {
+        // arrange
+        var server = ServerFactory.Create(
+            services =>
+            {
+                services.AddRouting();
+                services.AddGraphQLServer("tenant-a")
+                    .AddQueryType<QueryA>()
+                    .AddInMemorySubscriptions()
+                    .ModifyServerOptions(o =>
+                        o.AllowedGetOperations = AllowedGetOperations.Query);
+                services.AddGraphQLServer("tenant-b")
+                    .AddQueryType<QueryB>()
+                    .AddInMemorySubscriptions()
+                    .ModifyServerOptions(o =>
+                        o.AllowedGetOperations = AllowedGetOperations.Query);
+            },
+            app => app
+                .UseRouting()
+                .UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGraphQLHttp(
+                        "/graphql",
+                        context => context.Request.Headers["X-Tenant-Id"].ToString());
+                    endpoints.MapGraphQLWebSocket(
+                        "/graphql/ws",
+                        context => context.Request.Headers["X-Tenant-Id"].ToString());
+                }));
+
+        // act: verify HTTP still works with dynamic WebSocket endpoint registered
+        var resultA = await PostDynamicAsync(
+            server,
+            new ClientQueryRequest { Query = "{ who }" },
+            "/graphql",
+            "X-Tenant-Id",
+            "tenant-a");
+
+        // assert
+        Assert.Equal("TenantA", resultA.Data!["who"]!.ToString());
+    }
+
+    [Fact]
+    public async Task DynamicSchemaMiddleware_StaticFallback_WhenNoDynamicResolver()
+    {
+        // arrange: use the normal non-dynamic MapGraphQL to ensure it still works
+        var server = ServerFactory.Create(
+            services =>
+            {
+                services.AddRouting();
+                services.AddGraphQLServer()
+                    .AddQueryType<QueryA>()
+                    .ModifyServerOptions(o =>
+                        o.AllowedGetOperations = AllowedGetOperations.Query);
+            },
+            app => app
+                .UseRouting()
+                .UseEndpoints(endpoints =>
+                    endpoints.MapGraphQL("/graphql-static")));
+
+        // act
+        var result = await server.PostAsync(
+            new ClientQueryRequest { Query = "{ who }" },
+            "/graphql-static");
+
+        // assert: static endpoint still works
+        Assert.Equal("TenantA", result.Data!["who"]!.ToString());
+    }
+
+    private static async Task<ClientQueryResult> PostDynamicAsync(
+        TestServer server,
+        ClientQueryRequest request,
+        string path,
+        string headerName,
+        string headerValue)
+    {
+        var json = JsonConvert.SerializeObject(request);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        content.Headers.Clear();
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+        var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(headerName, headerValue);
+        var response = await client.PostAsync(
+            new Uri($"http://localhost:5000{path}"),
+            content);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return new ClientQueryResult { StatusCode = HttpStatusCode.NotFound };
+        }
+
+        var responseJson = await response.Content.ReadAsStringAsync();
+        var result = JsonConvert.DeserializeObject<ClientQueryResult>(responseJson)!;
+        result.StatusCode = response.StatusCode;
+        result.ContentType = response.Content.Headers.ContentType?.ToString();
+        return result;
+    }
+
+    private static async Task<ClientQueryResult> GetDynamicAsync(
+        TestServer server,
+        string query,
+        string path,
+        string headerName,
+        string headerValue)
+    {
+        var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(headerName, headerValue);
+        var message = new HttpRequestMessage(
+            HttpMethod.Get,
+            new Uri($"http://localhost:5000{path}/?query={Uri.EscapeDataString(query)}"));
+
+        var response = await client.SendAsync(message);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return new ClientQueryResult { StatusCode = HttpStatusCode.NotFound };
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonConvert.DeserializeObject<ClientQueryResult>(json)!;
+        result.StatusCode = response.StatusCode;
+        result.ContentType = response.Content.Headers.ContentType?.ToString();
+        return result;
+    }
+
+    public class QueryA
+    {
+        public string Who() => "TenantA";
+    }
+
+    public class QueryB
+    {
+        public string Who() => "TenantB";
+    }
+}


### PR DESCRIPTION
## Summary

This PR enables a single GraphQL endpoint to serve different schemas per request based on tenant identity
