### PR TITLE
[OpenAPI] Use deduped endpoints for both runtime and document generation

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/OpenApiDefinitionRegistry.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/OpenApiDefinitionRegistry.cs
@@ -171,14 +171,13 @@ internal sealed class OpenApiDefinitionRegistry : IDisposable
 
         var modelsByName = CreateModelsByNameLookup(models);
 
-        _transformer.AddDefinitions(endpoints, models, modelsByName, schema);
-
         // When multiple endpoints share (method, route): a descriptor with a valid document
         // wins. If no duplicate produces a valid descriptor, the first one whose document
         // failed validation is kept so the route is still registered (the middleware returns
         // HTTP 500 on call). Descriptors that fail to construct outright are skipped.
-        // The chosen descriptors are tracked in a list so registration order is deterministic
-        // (first appearance of each key in `endpoints`, which is already sorted by name).
+        // Track the chosen definitions in parallel with the descriptors so the same selection
+        // feeds both the runtime endpoints and the OpenAPI document generation.
+        var chosenDefinitions = new List<OpenApiEndpointDefinition>();
         var chosenDescriptors = new List<OpenApiEndpointDescriptor>();
         var keyToIndex = new Dictionary<(string, string), int>();
         var keyHasValid = new HashSet<(string, string)>();
@@ -208,11 +207,13 @@ internal sealed class OpenApiDefinitionRegistry : IDisposable
                 if (keyToIndex.TryGetValue(key, out var existingIndex))
                 {
                     // Promote: an earlier invalid descriptor is being replaced by a valid one.
+                    chosenDefinitions[existingIndex] = endpoint;
                     chosenDescriptors[existingIndex] = descriptor;
                 }
                 else
                 {
                     keyToIndex[key] = chosenDescriptors.Count;
+                    chosenDefinitions.Add(endpoint);
                     chosenDescriptors.Add(descriptor);
                 }
 
@@ -221,9 +222,12 @@ internal sealed class OpenApiDefinitionRegistry : IDisposable
             else if (!keyToIndex.ContainsKey(key))
             {
                 keyToIndex[key] = chosenDescriptors.Count;
+                chosenDefinitions.Add(endpoint);
                 chosenDescriptors.Add(descriptor);
             }
         }
+
+        _transformer.AddDefinitions(chosenDefinitions.ToArray(), models, modelsByName, schema);
 
         var httpEndpoints = new List<Endpoint>();
 

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Routes_NET10_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Routes_NET10_0.json
@@ -12,7 +12,7 @@
   "paths": {
     "/users": {
       "get": {
-        "operationId": "getUsersWithName",
+        "operationId": "getUsers",
         "responses": {
           "200": {
             "description": null,
@@ -22,23 +22,20 @@
                   "type": "array",
                   "items": {
                     "required": [
-                      "id",
-                      "name"
+                      "address"
                     ],
                     "type": "object",
                     "properties": {
-                      "id": {
-                        "oneOf": [
-                          {
+                      "address": {
+                        "required": [
+                          "street"
+                        ],
+                        "type": "object",
+                        "properties": {
+                          "street": {
                             "type": "string"
-                          },
-                          {
-                            "type": "integer"
                           }
-                        ]
-                      },
-                      "name": {
-                        "type": "string"
+                        }
                       }
                     }
                   }

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Routes_NET9_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Routes_NET9_0.json
@@ -7,7 +7,7 @@
   "paths": {
     "/users": {
       "get": {
-        "operationId": "getUsersWithName",
+        "operationId": "getUsers",
         "responses": {
           "200": {
             "description": null,
@@ -17,23 +17,20 @@
                   "type": "array",
                   "items": {
                     "required": [
-                      "id",
-                      "name"
+                      "address"
                     ],
                     "type": "object",
                     "properties": {
-                      "id": {
-                        "oneOf": [
-                          {
+                      "address": {
+                        "required": [
+                          "street"
+                        ],
+                        "type": "object",
+                        "properties": {
+                          "street": {
                             "type": "string"
-                          },
-                          {
-                            "type": "integer"
                           }
-                        ]
-                      },
-                      "name": {
-                        "type": "string"
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
The transformer was receiving the full endpoint list before dedup ran, so duplicate routes were overwritten in last-by-name order in the generated OpenAPI document while the runtime kept the first. Move the transformer call after dedup and pass the chosen definitions, so the document and the runtime route to the same operation.