### PR TITLE
Fix AllowNonPersistedOperation to preserve existing override fields

### DIFF
--- a/src/HotChocolate/Core/src/Execution.Abstractions/Execution/Features/PersistedOperationRequestOverridesExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution.Abstractions/Execution/Features/PersistedOperationRequestOverridesExtensions.cs
@@ -27,7 +27,7 @@ public static class PersistedOperationRequestOverridesExtensions
         }
         else
         {
-            options = new PersistedOperationRequestOverrides(AllowNonPersistedOperation: true);
+            options = options with { AllowNonPersistedOperation = true };
         }
 
         builder.Features.Set(options);


### PR DESCRIPTION
The extension previously contained a no-op if/else where both branches allocated a fresh PersistedOperationRequestOverrides, discarding any existing override state. Replace with a branch that constructs a new record when none exists and uses `with` to flip the flag otherwise.