### PR TITLE
Add `AlwaysOutputFractionalSeconds` to DateTime scalar options

### DIFF
--- a/src/HotChocolate/Core/src/Types.NodaTime/DateTimeOptions.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/DateTimeOptions.cs
@@ -62,4 +62,12 @@ public struct DateTimeOptions
             field = value;
         }
     } = DefaultOutputPrecision;
+
+    /// <summary>
+    /// Gets a value indicating whether fractional seconds are always emitted in serialized output,
+    /// padded with trailing zeros up to <see cref="OutputPrecision"/>. When <see langword="false"/>
+    /// (the default), trailing zeros are stripped and the fractional component is omitted entirely
+    /// when zero. Has no effect when <see cref="OutputPrecision"/> is <c>0</c>.
+    /// </summary>
+    public bool AlwaysOutputFractionalSeconds { get; init; }
 }

--- a/src/HotChocolate/Core/src/Types.NodaTime/DateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/DateTimeType.cs
@@ -39,8 +39,9 @@ public class DateTimeType : ScalarType<OffsetDateTime, StringValueNode>
         Description = description;
         Pattern = GetPattern();
         SpecifiedBy = new Uri(SpecifiedByUri);
-        _inputPattern = OffsetDateTimePattern.CreateWithInvariantCulture(GetFormat(_options.InputPrecision));
-        _outputFormat = GetFormat(_options.OutputPrecision);
+        _inputPattern = OffsetDateTimePattern.CreateWithInvariantCulture(
+            GetFormat(_options.InputPrecision, padFractionalSeconds: false));
+        _outputFormat = GetFormat(_options.OutputPrecision, _options.AlwaysOutputFractionalSeconds);
     }
 
     /// <summary>
@@ -124,8 +125,8 @@ public class DateTimeType : ScalarType<OffsetDateTime, StringValueNode>
                 + _options.InputPrecision
                 + @"})?(?:[Zz]|[+-]\d{2}:\d{2})$";
 
-    private static string GetFormat(byte precision)
+    private static string GetFormat(byte precision, bool padFractionalSeconds)
         => precision == 0
             ? "uuuu-MM-dd'T'HH:mm:sso<Z+HH:mm>"
-            : $"uuuu-MM-dd'T'HH:mm:ss.{new string('F', precision)}o<Z+HH:mm>";
+            : $"uuuu-MM-dd'T'HH:mm:ss.{new string(padFractionalSeconds ? 'f' : 'F', precision)}o<Z+HH:mm>";
 }

--- a/src/HotChocolate/Core/src/Types.NodaTime/LocalDateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/LocalDateTimeType.cs
@@ -40,8 +40,9 @@ public class LocalDateTimeType : ScalarType<LocalDateTime, StringValueNode>
         Description = description;
         Pattern = GetPattern();
         SpecifiedBy = new Uri(SpecifiedByUri);
-        _inputPattern = LocalDateTimePattern.CreateWithInvariantCulture(GetFormat(_options.InputPrecision));
-        _outputFormat = GetFormat(_options.OutputPrecision);
+        _inputPattern = LocalDateTimePattern.CreateWithInvariantCulture(
+            GetFormat(_options.InputPrecision, padFractionalSeconds: false));
+        _outputFormat = GetFormat(_options.OutputPrecision, _options.AlwaysOutputFractionalSeconds);
     }
 
     /// <summary>
@@ -117,8 +118,8 @@ public class LocalDateTimeType : ScalarType<LocalDateTime, StringValueNode>
             ? @"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}$"
             : @"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d{1," + _options.InputPrecision + "})?$";
 
-    private static string GetFormat(byte precision)
+    private static string GetFormat(byte precision, bool padFractionalSeconds)
         => precision == 0
             ? @"uuuu-MM-dd'T'HH\:mm\:ss"
-            : @$"uuuu-MM-dd'T'HH\:mm\:ss.{new string('F', precision)}";
+            : @$"uuuu-MM-dd'T'HH\:mm\:ss.{new string(padFractionalSeconds ? 'f' : 'F', precision)}";
 }

--- a/src/HotChocolate/Core/src/Types.NodaTime/LocalTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/LocalTimeType.cs
@@ -39,8 +39,9 @@ public class LocalTimeType : ScalarType<LocalTime, StringValueNode>
         Description = description;
         Pattern = GetPattern();
         SpecifiedBy = new Uri(SpecifiedByUri);
-        _inputPattern = LocalTimePattern.CreateWithInvariantCulture(GetFormat(_options.InputPrecision));
-        _outputFormat = GetFormat(_options.OutputPrecision);
+        _inputPattern = LocalTimePattern.CreateWithInvariantCulture(
+            GetFormat(_options.InputPrecision, padFractionalSeconds: false));
+        _outputFormat = GetFormat(_options.OutputPrecision, _options.AlwaysOutputFractionalSeconds);
     }
 
     /// <summary>
@@ -116,8 +117,8 @@ public class LocalTimeType : ScalarType<LocalTime, StringValueNode>
             ? @"^\d{2}:\d{2}:\d{2}$"
             : @"^\d{2}:\d{2}:\d{2}(?:\.\d{1," + _options.InputPrecision + "})?$";
 
-    private static string GetFormat(byte precision)
+    private static string GetFormat(byte precision, bool padFractionalSeconds)
         => precision == 0
             ? "HH:mm:ss"
-            : $"HH:mm:ss.{new string('F', precision)}";
+            : $"HH:mm:ss.{new string(padFractionalSeconds ? 'f' : 'F', precision)}";
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/DateTimeOptions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/DateTimeOptions.cs
@@ -73,4 +73,12 @@ public struct DateTimeOptions
     /// against the expected format. Defaults to <c>true</c>.
     /// </summary>
     public bool ValidateInputFormat { get; init; } = true;
+
+    /// <summary>
+    /// Gets a value indicating whether fractional seconds are always emitted in serialized output,
+    /// padded with trailing zeros up to <see cref="OutputPrecision"/>. When <see langword="false"/>
+    /// (the default), trailing zeros are stripped and the fractional component is omitted entirely
+    /// when zero. Has no effect when <see cref="OutputPrecision"/> is <c>0</c>.
+    /// </summary>
+    public bool AlwaysOutputFractionalSeconds { get; init; }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/DateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/DateTimeType.cs
@@ -171,20 +171,26 @@ public partial class DateTimeType : ScalarType<DateTimeOffset, StringValueNode>
                 + @"})?(?:[Zz]|[+-]\d{2}:\d{2})$";
 
     private string GetUtcFormat()
-        => _options.OutputPrecision switch
+    {
+        var pad = _options.AlwaysOutputFractionalSeconds;
+        return _options.OutputPrecision switch
         {
-            DateTimeOptions.DefaultOutputPrecision => UtcFormat,
+            DateTimeOptions.DefaultOutputPrecision when !pad => UtcFormat,
             0 => @"yyyy-MM-ddTHH\:mm\:ssZ",
-            _ => @$"yyyy-MM-ddTHH\:mm\:ss.{new string('F', _options.OutputPrecision)}Z"
+            _ => @$"yyyy-MM-ddTHH\:mm\:ss.{new string(pad ? 'f' : 'F', _options.OutputPrecision)}Z"
         };
+    }
 
     private string GetLocalFormat()
-        => _options.OutputPrecision switch
+    {
+        var pad = _options.AlwaysOutputFractionalSeconds;
+        return _options.OutputPrecision switch
         {
-            DateTimeOptions.DefaultOutputPrecision => LocalFormat,
+            DateTimeOptions.DefaultOutputPrecision when !pad => LocalFormat,
             0 => @"yyyy-MM-ddTHH\:mm\:sszzz",
-            _ => @$"yyyy-MM-ddTHH\:mm\:ss.{new string('F', _options.OutputPrecision)}zzz"
+            _ => @$"yyyy-MM-ddTHH\:mm\:ss.{new string(pad ? 'f' : 'F', _options.OutputPrecision)}zzz"
         };
+    }
 
     private Regex GetDateTimeRegex()
         => _options.InputPrecision switch

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/LocalDateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/LocalDateTimeType.cs
@@ -159,12 +159,15 @@ public partial class LocalDateTimeType : ScalarType<DateTime, StringValueNode>
             : @"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d{1," + _options.InputPrecision + "})?$";
 
     private string GetLocalFormat()
-        => _options.OutputPrecision switch
+    {
+        var pad = _options.AlwaysOutputFractionalSeconds;
+        return _options.OutputPrecision switch
         {
-            DateTimeOptions.DefaultOutputPrecision => LocalFormat,
+            DateTimeOptions.DefaultOutputPrecision when !pad => LocalFormat,
             0 => @"yyyy-MM-ddTHH\:mm\:ss",
-            _ => @$"yyyy-MM-ddTHH\:mm\:ss.{new string('F', _options.OutputPrecision)}"
+            _ => @$"yyyy-MM-ddTHH\:mm\:ss.{new string(pad ? 'f' : 'F', _options.OutputPrecision)}"
         };
+    }
 
     private Regex GetLocalDateTimeRegex()
         => _options.InputPrecision switch

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/LocalTimeType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/LocalTimeType.cs
@@ -157,12 +157,15 @@ public partial class LocalTimeType : ScalarType<TimeOnly, StringValueNode>
             : @"^\d{2}:\d{2}:\d{2}(?:\.\d{1," + _options.InputPrecision + "})?$";
 
     private string GetLocalFormat()
-        => _options.OutputPrecision switch
+    {
+        var pad = _options.AlwaysOutputFractionalSeconds;
+        return _options.OutputPrecision switch
         {
-            DateTimeOptions.DefaultOutputPrecision => LocalFormat,
+            DateTimeOptions.DefaultOutputPrecision when !pad => LocalFormat,
             0 => "HH:mm:ss",
-            _ => $"HH:mm:ss.{new string('F', _options.OutputPrecision)}"
+            _ => $"HH:mm:ss.{new string(pad ? 'f' : 'F', _options.OutputPrecision)}"
         };
+    }
 
     private Regex GetLocalTimeRegex()
         => _options.InputPrecision switch

--- a/src/HotChocolate/Core/test/Types.NodaTime.Tests/DateTimeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.NodaTime.Tests/DateTimeTypeTests.cs
@@ -160,6 +160,80 @@ public sealed class DateTimeTypeTests
         resultValue.MatchInlineSnapshot($"\"{result}\"");
     }
 
+    [Theory]
+    [InlineData(9, "2023-12-24T15:30:00.123456789Z")]
+    [InlineData(3, "2023-12-24T15:30:00.123Z")]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_Pads(byte precision, string expected)
+    {
+        // arrange
+        var type = new DateTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = precision,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var dateTime = new OffsetDateTime(
+            new LocalDateTime(2023, 12, 24, 15, 30, 0, 123),
+            Offset.Zero).PlusNanoseconds(456_789);
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(dateTime, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot($"\"{expected}\"");
+    }
+
+    [Fact]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_EmitsZerosForWholeSecond()
+    {
+        // arrange
+        var type = new DateTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = 3,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var dateTime = new OffsetDateTime(
+            new LocalDateTime(2023, 12, 24, 15, 30, 0),
+            Offset.Zero);
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(dateTime, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot("\"2023-12-24T15:30:00.000Z\"");
+    }
+
+    [Fact]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_NoOpWhenPrecisionZero()
+    {
+        // arrange
+        var type = new DateTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = 0,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var dateTime = new OffsetDateTime(
+            new LocalDateTime(2023, 12, 24, 15, 30, 0, 123),
+            Offset.Zero);
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(dateTime, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot("\"2023-12-24T15:30:00Z\"");
+    }
+
     [Fact]
     public void CoerceOutputValue_OffsetDateTime()
     {

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
@@ -159,6 +159,96 @@ public class DateTimeTypeTests
         resultValue.MatchInlineSnapshot($"\"{result}\"");
     }
 
+    [Theory]
+    [InlineData(DateTimeOptions.DefaultOutputPrecision, "2023-12-24T15:30:00.1234567Z")]
+    [InlineData(3, "2023-12-24T15:30:00.123Z")]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_Pads(byte precision, string expected)
+    {
+        // arrange
+        var type = new DateTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = precision,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var dateTime = new DateTimeOffset(2023, 12, 24, 15, 30, 0, 123, 456, TimeSpan.Zero).AddTicks(7);
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(dateTime, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot($"\"{expected}\"");
+    }
+
+    [Fact]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_EmitsZerosForWholeSecond()
+    {
+        // arrange
+        var type = new DateTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = 3,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var dateTime = new DateTimeOffset(2023, 12, 24, 15, 30, 0, TimeSpan.Zero);
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(dateTime, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot("\"2023-12-24T15:30:00.000Z\"");
+    }
+
+    [Fact]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_NoOpWhenPrecisionZero()
+    {
+        // arrange
+        var type = new DateTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = 0,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var dateTime = new DateTimeOffset(2023, 12, 24, 15, 30, 0, 123, TimeSpan.Zero);
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(dateTime, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot("\"2023-12-24T15:30:00Z\"");
+    }
+
+    [Fact]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_LocalOffset()
+    {
+        // arrange
+        var type = new DateTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = 3,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var dateTime = new DateTimeOffset(2023, 12, 24, 15, 30, 0, TimeSpan.FromHours(4));
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(dateTime, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot("\"2023-12-24T15:30:00.000+04:00\"");
+    }
+
     [Fact]
     public void CoerceOutputValue_Utc_DateTimeOffset()
     {

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/LocalDateTimeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/LocalDateTimeTypeTests.cs
@@ -152,6 +152,29 @@ public class LocalDateTimeTypeTests
     }
 
     [Fact]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_PadsAtDefaultPrecision()
+    {
+        // arrange
+        // exercises the bypass of the `LocalFormat` const-string shortcut at default precision
+        var type = new LocalDateTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = DateTimeOptions.DefaultOutputPrecision,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var dateTime = new DateTime(2023, 12, 24, 15, 30, 0);
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(dateTime, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot("\"2023-12-24T15:30:00.0000000\"");
+    }
+
+    [Fact]
     public void CoerceOutputValue()
     {
         // arrange

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/LocalTimeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/LocalTimeTypeTests.cs
@@ -152,6 +152,29 @@ public class LocalTimeTypeTests
     }
 
     [Fact]
+    public void CoerceOutputValue_AlwaysOutputFractionalSeconds_PadsAtDefaultPrecision()
+    {
+        // arrange
+        // exercises the bypass of the `LocalFormat` const-string shortcut at default precision
+        var type = new LocalTimeType(
+            new DateTimeOptions
+            {
+                OutputPrecision = DateTimeOptions.DefaultOutputPrecision,
+                AlwaysOutputFractionalSeconds = true
+            });
+        var timeOnly = new TimeOnly(8, 46, 14);
+
+        // act
+        var operation = CommonTestExtensions.CreateOperation();
+        var resultDocument = new ResultDocument(operation, 0);
+        var resultValue = resultDocument.Data.GetProperty("first");
+        type.CoerceOutputValue(timeOnly, resultValue);
+
+        // assert
+        resultValue.MatchInlineSnapshot("\"08:46:14.0000000\"");
+    }
+
+    [Fact]
     public void CoerceOutputValue()
     {
         // arrange

--- a/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
+++ b/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
@@ -736,7 +736,20 @@ Note that this option is likely to be removed in a later release, so it's recomm
 
 ## DateTime scalar serialization
 
-The `DateTime` scalar now serializes with up to 7 fractional seconds (`FFFFFFF`) as opposed to exactly 3 (`fff`).
+The `DateTime` scalar now serializes with up to 7 fractional seconds (`FFFFFFF`) as opposed to exactly 3 (`fff`). Trailing zeros are stripped, and the fractional component is omitted entirely when zero, so `2023-12-24T15:30:00.5000000Z` is now emitted as `2023-12-24T15:30:00.5Z` and `2023-12-24T15:30:00.0000000Z` is emitted as `2023-12-24T15:30:00Z`.
+
+If you need fractional seconds to always be present in the output (for example, to preserve a fixed-width format your clients depend on), set `AlwaysOutputFractionalSeconds = true` on `DateTimeOptions`. You can also tune the precision via `OutputPrecision`. To restore the exact v15 behavior of always emitting three fractional digits, combine both:
+
+```csharp
+builder.AddGraphQL()
+    .AddType(new DateTimeType(new DateTimeOptions
+    {
+        OutputPrecision = 3,
+        AlwaysOutputFractionalSeconds = true
+    }));
+```
+
+The same options apply to the `LocalDateTime` and `LocalTime` scalars (and to their counterparts in `HotChocolate.Types.NodaTime`, which expose a matching `DateTimeOptions` struct).
 
 ## IHasRuntimeType is now IRuntimeTypeProvider
 


### PR DESCRIPTION
## Summary
- Adds an opt-in `AlwaysOutputFractionalSeconds` option to both `DateTimeOptions` structs — the core scalars one (`HotChocolate.Types.DateTimeOptions`) and the NodaTime one (`HotChocolate.Types.NodaTime.DateTimeOptions`). When enabled, fractional seconds are always emitted in serialized output, padded with trailing zeros up to `OutputPrecision`. Defaults to `false`, preserving today's trailing-zero-stripping behavior.
- Affects all six scalars that share these option structs: `DateTimeType`, `LocalDateTimeType`, `LocalTimeType` in each of the two packages. Input parsing is unchanged.
- For the core scalars, the default-precision const-string shortcut (`UtcFormat` / `LocalFormat`) is bypassed when padding is requested, since those constants encode the `F` (non-padding) specifier.
- Updates the v15→v16 migration guide for `DateTime` scalar serialization with the new option and a recipe to restore the v15 `fff` shape (`OutputPrecision = 3` + `AlwaysOutputFractionalSeconds = true`).

## Test plan
- New tests in core `DateTimeTypeTests` covering: padding at default precision (exercises the const-shortcut bypass), padding at precision 3, whole-second value emitting `.000`, precision-0 no-op, and the local-offset (non-Utc) format path.
- New default-precision pad tests in core `LocalDateTimeTypeTests` and `LocalTimeTypeTests` guarding each class's own const-shortcut bypass.
- New tests in NodaTime `DateTimeTypeTests` covering: padding at precisions 9 and 3, whole-second value emitting `.000`, and precision-0 no-op.
- Existing test suites pass: NodaTime (524 tests) and core `DateTimeType` / `LocalDateTimeType` / `LocalTimeType` (176 tests).