### PR TITLE
[Docs] Update v15 to v16 migration docs for service provider

### DIFF
--- a/website/src/docs/fusion/v16/migration/migrate-from-15-to-16.md
+++ b/website/src/docs/fusion/v16/migration/migrate-from-15-to-16.md
@@ -807,9 +807,28 @@ To access application services within schema services like diagnostic event list
 builder.Services.AddSingleton<MyService>();
 builder.Services.AddGraphQLGatewayServer()
 +   .AddApplicationService<MyService>()
+
+    // either
     .AddDiagnosticEventListener<MyDiagnosticEventListener>();
+    // or
+    .AddDiagnosticEventListener(sp => new MyDiagnosticEventListener(sp.GetRequiredService<MyService>()));
 
 public class MyDiagnosticEventListener(MyService service) : FusionExecutionDiagnosticEventListener;
+```
+
+Sometimes the registration of required services is not as obvious. For example, the types for logging are registered in framework code.
+
+```diff
+builder.Services.AddLogging();
+builder.Services.AddGraphQLGatewayServer()
++   .AddApplicationService<ILogger<MyLoggingDiagnosticEventListener>>()
+
+    // either
+    .AddDiagnosticEventListener<MyLoggingDiagnosticEventListener>();
+    // or
+    .AddDiagnosticEventListener(sp => new MyLoggingDiagnosticEventListener(sp.GetRequiredService<ILogger<MyLoggingDiagnosticEventListener>>()));
+
+public class MyLoggingDiagnosticEventListener(ILogger<MyLoggingDiagnosticEventListener> logger) : FusionExecutionDiagnosticEventListener;
 ```
 
 If you're using any of the following Fusion configuration APIs, ensure that the application services required for their activation are registered via `AddApplicationService<T>()`:

--- a/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
+++ b/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
@@ -57,6 +57,21 @@ builder.AddGraphQL()
 public class MyDiagnosticEventListener(MyService service) : ExecutionDiagnosticEventListener;
 ```
 
+Sometimes the registration of required services is not as obvious. For example, the types for logging are registered in framework code.
+
+```diff
+builder.Services.AddLogging();
+builder.AddGraphQL()
++   .AddApplicationService<ILogger<MyLoggingDiagnosticEventListener>>()
+
+    // either
+    .AddDiagnosticEventListener<MyLoggingDiagnosticEventListener>();
+    // or
+    .AddDiagnosticEventListener(sp => new MyLoggingDiagnosticEventListener(sp.GetRequiredService<ILogger<MyLoggingDiagnosticEventListener>>()));
+
+public class MyLoggingDiagnosticEventListener(ILogger<MyLoggingDiagnosticEventListener> logger) : ExecutionDiagnosticEventListener;
+```
+
 Services registered via `AddApplicationService<T>()` are resolved once during schema initialization from the application service provider and registered as singletons in the schema service provider.
 
 If you're using any of the following configuration APIs, ensure that the application services required for their activation are registered via `AddApplicationService<T>()`:

--- a/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
+++ b/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
@@ -48,9 +48,9 @@ Starting with v16, we're introducing a more explicit model where Hot Chocolate c
 builder.Services.AddSingleton<MyService>();
 builder.AddGraphQL()
 +   .AddApplicationService<MyService>()
-    .AddDiagnosticEventListener<MyDiagnosticEventListener>()
+    .AddDiagnosticEventListener<MyDiagnosticEventListener>();
     // or
-    .AddDiagnosticEventListener(sp => new MyService(sp.GetRequiredService<MyService>()));
+    .AddDiagnosticEventListener(sp => new MyDiagnosticEventListener(sp.GetRequiredService<MyService>()));
 
 public class MyDiagnosticEventListener(MyService service) : ExecutionDiagnosticEventListener;
 ```

--- a/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
+++ b/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
@@ -48,6 +48,8 @@ Starting with v16, we're introducing a more explicit model where Hot Chocolate c
 builder.Services.AddSingleton<MyService>();
 builder.AddGraphQL()
 +   .AddApplicationService<MyService>()
+
+    // either
     .AddDiagnosticEventListener<MyDiagnosticEventListener>();
     // or
     .AddDiagnosticEventListener(sp => new MyDiagnosticEventListener(sp.GetRequiredService<MyService>()));


### PR DESCRIPTION
Fixes registration code example using `GetRequiredService`, to instantiate the correct class.

Makes it clearer that `AddApplicationService` always needs to be added, and the `AddDiagnosticEventListener` examples are two variants for the same thing.

Adds an example for an indirect/hidden registration (in this case logging).