### PR TITLE
Fix AnyType serialization with empty-string dictionary keys

### DIFF
--- a/src/HotChocolate/Core/src/Types/Text/Json/ResultDocument.cs
+++ b/src/HotChocolate/Core/src/Types/Text/Json/ResultDocument.cs
@@ -448,6 +448,11 @@ public sealed partial class ResultDocument : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private ReadOnlySpan<byte> ReadLocalData(int location, int size)
     {
+        if (size == 0)
+        {
+            return [];
+        }
+
         var startChunkIndex = location / JsonMemory.BufferSize;
         var offsetInStartChunk = location % JsonMemory.BufferSize;
 

--- a/src/HotChocolate/Core/src/Types/Text/Json/ResultDocument.cs
+++ b/src/HotChocolate/Core/src/Types/Text/Json/ResultDocument.cs
@@ -725,6 +725,11 @@ public sealed partial class ResultDocument : IDisposable
 
     private void WriteDataCore(int position, ReadOnlySpan<byte> data)
     {
+        if (data.Length == 0)
+        {
+            return;
+        }
+
         var chunkIndex = position / JsonMemory.BufferSize;
         var offset = position % JsonMemory.BufferSize;
         var availableInChunk = JsonMemory.BufferSize - offset;

--- a/src/HotChocolate/Core/src/Types/Text/Json/ResultElement.cs
+++ b/src/HotChocolate/Core/src/Types/Text/Json/ResultElement.cs
@@ -931,11 +931,6 @@ public readonly partial struct ResultElement
     {
         CheckValidInstance();
 
-        if (propertyName.Length == 0)
-        {
-            throw new ArgumentNullException(nameof(propertyName));
-        }
-
         var encoding = Encoding.UTF8;
         var requiredBytes = encoding.GetByteCount(propertyName);
         byte[]? rented = null;
@@ -960,11 +955,6 @@ public readonly partial struct ResultElement
     public void SetPropertyName(ReadOnlySpan<byte> propertyName)
     {
         CheckValidInstance();
-
-        if (propertyName.Length == 0)
-        {
-            throw new ArgumentNullException(nameof(propertyName));
-        }
 
         _parent.AssignPropertyName(this, propertyName);
     }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/AnyTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/AnyTypeTests.cs
@@ -167,7 +167,7 @@ public class AnyTypeTests
                         .Name("Query")
                         .Field("foo")
                         .Type<AnyType>()
-                        .Resolve(_ => new Dictionary<string, object?> { [""] = 1 }))
+                        .Resolve(_ => new Dictionary<string, object?> { [""] = null }))
                 .AddJsonTypeConverter()
                 .BuildRequestExecutorAsync();
 
@@ -181,7 +181,7 @@ public class AnyTypeTests
             {
               "data": {
                 "foo": {
-                  "": 1
+                  "": null
                 }
               }
             }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/AnyTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/AnyTypeTests.cs
@@ -156,6 +156,39 @@ public class AnyTypeTests
     }
 
     [Fact]
+    public async Task Output_Return_Dictionary_With_Empty_Key()
+    {
+        // arrange
+        var executor =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType(
+                    d => d
+                        .Name("Query")
+                        .Field("foo")
+                        .Type<AnyType>()
+                        .Resolve(_ => new Dictionary<string, object?> { [""] = 1 }))
+                .AddJsonTypeConverter()
+                .BuildRequestExecutorAsync();
+
+        // act
+        var result = (await executor.ExecuteAsync("{ foo }")).ExpectOperationResult();
+
+        // assert
+        Assert.Empty(result.Errors);
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "foo": {
+                  "": 1
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task Output_Return_DateTime()
     {
         // arrange


### PR DESCRIPTION
## Summary
- `ResultDocument.WriteDataCore` early-returns on a zero-length span, fixing an `ArgumentOutOfRangeException` when writing an empty property name.
- `ResultDocument.ReadLocalData` early-returns on a zero-length read, so properties with `SizeOrLength == 0` whose `Location` was never backed by a rented chunk (e.g. `{ "": null }` with no other local data) don't trip `_data[startChunkIndex]`.
- Removes the `propertyName.Length == 0` throws from both `ResultElement.SetPropertyName` overloads — empty strings are valid JSON property names and the previous guard was masking the writer bug above.
- Adds an `AnyType` regression test covering a resolver returning a `Dictionary<string, object?>` with an empty-string key and a `null` value (the minimal case that exercises both the zero-length write and zero-length read paths).

## Test plan
- `dotnet test src/HotChocolate/Core/test/Types.Tests/HotChocolate.Types.Tests.csproj --filter "FullyQualifiedName~AnyTypeTests.Output_Return_Dictionary_With_Empty_Key"` — green on net9.0.
- `dotnet test src/HotChocolate/Core/test/Types.Tests/HotChocolate.Types.Tests.csproj --filter "FullyQualifiedName~AnyType"` — full `AnyType` suite 75/75 on net9.0.

Closes #9774