### PR TITLE
Bump Marten to 8.37.0 to address GHSA-vmw2-qwm8-x84c

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -77,6 +77,7 @@ frontends
 Fzzz
 GEOGCS
 geolocation
+GHSA
 Giroux
 grafbase
 GraphiQL

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Glob" Version="1.1.9" />
     <PackageVersion Include="JsonPointer.Net" Version="5.0.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
-    <PackageVersion Include="Marten" Version="8.0.0" />
+    <PackageVersion Include="Marten" Version="8.37.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.0.0" />

--- a/src/HotChocolate/Marten/test/Data.Marten.Filters.Tests/__snapshots__/QueryableFilterVisitorBooleanTests.Create_NullableBooleanNotEqual_Expression.snap
+++ b/src/HotChocolate/Marten/test/Data.Marten.Filters.Tests/__snapshots__/QueryableFilterVisitorBooleanTests.Create_NullableBooleanNotEqual_Expression.snap
@@ -4,6 +4,9 @@ true Result:
   "data": {
     "root": [
       {
+        "bar": null
+      },
+      {
         "bar": false
       }
     ]
@@ -13,7 +16,7 @@ true Result:
 
 true SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablefiltervisitorbooleantests_foonullable as d where CAST(d.data ->> 'Bar' as boolean) != :p0;
+select d.id, d.data from public.mt_doc_queryablefiltervisitorbooleantests_foonullable as d where (d.data ->> 'Bar' is null  or  CAST(d.data ->> 'Bar' as boolean) != :p0);
 ---------------
 
 false Result:
@@ -23,6 +26,9 @@ false Result:
     "root": [
       {
         "bar": true
+      },
+      {
+        "bar": null
       }
     ]
   }
@@ -31,7 +37,7 @@ false Result:
 
 false SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablefiltervisitorbooleantests_foonullable as d where CAST(d.data ->> 'Bar' as boolean) != :p0;
+select d.id, d.data from public.mt_doc_queryablefiltervisitorbooleantests_foonullable as d where (d.data ->> 'Bar' is null  or  CAST(d.data ->> 'Bar' as boolean) != :p0);
 ---------------
 
 null Result:

--- a/src/HotChocolate/Marten/test/Data.Marten.Filters.Tests/__snapshots__/QueryableFilterVisitorExecutableTests.Create_NullableBooleanNotEqual_Expression.snap
+++ b/src/HotChocolate/Marten/test/Data.Marten.Filters.Tests/__snapshots__/QueryableFilterVisitorExecutableTests.Create_NullableBooleanNotEqual_Expression.snap
@@ -4,6 +4,9 @@ true
   "data": {
     "rootExecutable": [
       {
+        "bar": null
+      },
+      {
         "bar": false
       }
     ]
@@ -18,6 +21,9 @@ false
     "rootExecutable": [
       {
         "bar": true
+      },
+      {
+        "bar": null
       }
     ]
   }

--- a/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
+++ b/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
@@ -1333,6 +1333,25 @@ mutation {
 
 The transaction boundary now lives inside the resolver for the coarse-grained mutation, where you control it directly with your data access layer.
 
+## Marten nullable boolean `neq` filter now includes null rows
+
+`HotChocolate.Data.Marten` has been updated to Marten 8.37.0 (from 8.0.0) to address the critical advisory [GHSA-vmw2-qwm8-x84c](https://github.com/advisories/GHSA-vmw2-qwm8-x84c). This change lands in **16.0.10**.
+
+Filtering a nullable `bool` property with `neq` now also returns rows where the value is `null`. Marten 8.10.1 changed the SQL it emits for `!=` predicates on nullable boolean JSON properties ([JasperFx/marten#3953](https://github.com/JasperFx/marten/issues/3953)): the `WHERE` clause now includes an `IS NULL OR ...` branch. Other nullable property types (numeric, string, enum) are unaffected.
+
+For a query against a nullable `Bar` column:
+
+```graphql
+{
+  root(where: { bar: { neq: true } }) {
+    bar
+  }
+}
+```
+
+- Previously: only rows where `Bar = false` were returned.
+- Now: rows where `Bar = false` and rows where `Bar IS NULL` are returned.
+
 # Deprecations
 
 Things that will continue to function this release, but we encourage you to move away from.


### PR DESCRIPTION
## Summary
- Bumps `Marten` from 8.0.0 to 8.37.0 in `HotChocolate.Data.Marten` to address [GHSA-vmw2-qwm8-x84c](https://github.com/advisories/GHSA-vmw2-qwm8-x84c) (NU1904).
- Updates the two `NullableBooleanNotEqual_Expression` snapshots to reflect Marten 8.10.1's revised `!=` SQL on nullable booleans ([JasperFx/marten#3953](https://github.com/JasperFx/marten/issues/3953)): the `WHERE` clause now includes an `IS NULL OR ...` branch, so `neq` results include rows where the column is `NULL`.
- Documents the user-visible filter behavior change in the v15→v16 migration guide, flagged as landing in 16.0.10.

## Test plan
- `dotnet restore src/All.slnx` (no NU1904 reported for Marten).
- `dotnet build src/HotChocolate/Marten` (0 warnings / 0 errors across net8.0/net9.0/net10.0).
- `dotnet test src/HotChocolate/Marten`: 82/82 filters + 24/24 sorting passing on net8.0/net9.0/net10.0 with the updated snapshots.