### PR TITLE
Pack generator DLLs via post-build target to fix empty analyzer packages

### DIFF
--- a/src/CookieCrumble/src/CookieCrumble.Xunit/CookieCrumble.Xunit.csproj
+++ b/src/CookieCrumble/src/CookieCrumble.Xunit/CookieCrumble.Xunit.csproj
@@ -17,9 +17,18 @@
     <ProjectReference Include="../CookieCrumble.Analyzers/CookieCrumble.Analyzers.csproj" PrivateAssets="All" ExcludeAssets="compile;runtime" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Package the generator in the analyzer directory of the nuget package -->
-    <None Include="$(OutputPath)\net10.0\CookieCrumble.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-  </ItemGroup>
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddGeneratorToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Package the generator into the analyzer directory of the NuGet package.
+       Runs after pack's build phase has populated $(OutputPath).
+       This project multi-targets, so emit the analyzer only once (the per-TFM target
+       fires per framework) to avoid a duplicate package-path collision. -->
+  <Target Name="_AddGeneratorToPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Condition="'$(TargetFramework)' == 'net10.0'" Include="$(OutputPath)CookieCrumble.Analyzers.dll" PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/CookieCrumble/src/CookieCrumble.Xunit3/CookieCrumble.Xunit3.csproj
+++ b/src/CookieCrumble/src/CookieCrumble.Xunit3/CookieCrumble.Xunit3.csproj
@@ -16,9 +16,18 @@
     <ProjectReference Include="../CookieCrumble.Analyzers/CookieCrumble.Analyzers.csproj" PrivateAssets="All" ExcludeAssets="compile;runtime" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Package the generator in the analyzer directory of the nuget package -->
-    <None Include="$(OutputPath)\net10.0\CookieCrumble.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-  </ItemGroup>
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddGeneratorToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Package the generator into the analyzer directory of the NuGet package.
+       Runs after pack's build phase has populated $(OutputPath).
+       This project multi-targets, so emit the analyzer only once (the per-TFM target
+       fires per framework) to avoid a duplicate package-path collision. -->
+  <Target Name="_AddGeneratorToPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Condition="'$(TargetFramework)' == 'net10.0'" Include="$(OutputPath)CookieCrumble.Analyzers.dll" PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/HotChocolate/Core/src/Types.Analyzers/HotChocolate.Types.Analyzers.csproj
+++ b/src/HotChocolate/Core/src/Types.Analyzers/HotChocolate.Types.Analyzers.csproj
@@ -28,10 +28,17 @@
     <PackageReference Include="Microsoft.Bcl.HashCode" VersionOverride="1.1.0" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Package the generator in the analyzer directory of the nuget package -->
-    <None Include="$(OutputPath)\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-  </ItemGroup>
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddGeneratorToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Package the generator into the analyzer directory of the NuGet package.
+       Runs after pack's build phase has populated $(OutputPath). -->
+  <Target Name="_AddGeneratorToPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)*.dll" PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <EmbeddedResource Update="Properties\SourceGenResources.resx">

--- a/src/Mocha/src/Mocha.Analyzers/Mocha.Analyzers.csproj
+++ b/src/Mocha/src/Mocha.Analyzers/Mocha.Analyzers.csproj
@@ -18,7 +18,15 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.HashCode" VersionOverride="1.1.0" PrivateAssets="all" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(OutputPath)\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-  </ItemGroup>
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddGeneratorToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Package the generator into the analyzer directory of the NuGet package.
+       Runs after pack's build phase has populated $(OutputPath). -->
+  <Target Name="_AddGeneratorToPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)*.dll" PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary

- Source-generator packages (`HotChocolate.Types.Analyzers`, `Mocha.Analyzers`, `CookieCrumble.Xunit`, `CookieCrumble.Xunit3`) shipped **without their generator DLL** starting with the `16.0.10` previews — e.g. `16.0.10-p.6` contains only the nuspec. This breaks consumers with `error CS0121` on the generated `AddTypes()` (the call falls back to the two runtime overloads, which a zero-arg call matches ambiguously).
- Root cause: each csproj packed its DLL via a static `<None Include="$(OutputPath)...dll" Pack="true" PackagePath="analyzers/dotnet/cs">`. That item is expanded during MSBuild evaluation, *before* Build runs, so on a clean checkout it globs zero files and packs nothing — with no error. Nuke's separate `Compile` step used to pre-populate `bin/`, masking the bug; #9772 replaced that with a single-shot `dotnet pack`, exposing it. Confirmed by package timeline: `16.0.10-p.2` (pre-merge) intact, `-p.5`/`-p.6` (post-merge) empty.
- Fix: collect the DLL in a `TargetsForTfmSpecificContentInPackage` target, which runs during nuspec generation after pack's build phase has populated `$(OutputPath)`. No explicit `Build` dependency, so `dotnet pack --no-build` still works (an explicit dependency would trip NETSDK1085). For the two multi-targeting CookieCrumble packages, the analyzer is emitted only for `net10.0` to avoid a duplicate package-path collision (NU5118).

## Test plan

- Clean single-shot `dotnet pack` of each of the four projects includes `analyzers/dotnet/cs/<generator>.dll` (verified via `unzip -l`).
- `dotnet build` then `dotnet pack --no-build` of each project succeeds (no NETSDK1085) and still includes the analyzer DLL.
- End-to-end: a HotChocolate web project that previously failed with `CS0121` builds successfully against a locally repacked `HotChocolate.Types.Analyzers` `16.0.10-p.6`.
- Swept all `IncludeBuildOutput=false` / analyzer-packing csproj files; the `*.props`/`*.targets`/`*.xaml` pack entries are unaffected (static source files present at evaluation time).
