### PR TITLE
[Fusion] Parse `@cost` weight with InvariantCulture

### DIFF
--- a/src/HotChocolate/Fusion/src/Fusion.Composition/Directives/CostDirective.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/Directives/CostDirective.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using HotChocolate.Language;
 using HotChocolate.Types;
 using static HotChocolate.Fusion.Properties.CompositionResources;
@@ -17,6 +18,6 @@ internal sealed class CostDirective(double weight)
             throw new InvalidOperationException(CostDirective_WeightArgument_Invalid);
         }
 
-        return new CostDirective(double.Parse(name.Value));
+        return new CostDirective(double.Parse(name.Value, CultureInfo.InvariantCulture));
     }
 }


### PR DESCRIPTION
## Summary
- `CostDirective.From` parsed the `@cost(weight:)` string with the current culture, so any locale where `.` is not the decimal separator threw `FormatException` on `"1.0"` / `"-1.0"` during composition.
- Switched to `double.Parse(name.Value, CultureInfo.InvariantCulture)`, matching the existing invariant-culture parses in `Fusion.Execution/Execution/Introspection/Query.cs`.

## Test plan
- `dotnet test src/HotChocolate/Fusion/test/Fusion.Composition.Tests/HotChocolate.Fusion.Composition.Tests.csproj --filter "FullyQualifiedName~SourceSchemaMergerCostDirectiveTests"` — passes on net8.0, net9.0, net10.0 (previously 2 failures per TFM).
