### PR TITLE
Remove Snapshooter and ChilliCream.Testing.Utilities

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,6 @@
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.dotMemory" Version="0.15.8" />
     <PackageVersion Include="ChilliCream.ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <PackageVersion Include="ChilliCream.Nitro.App" Version="$(NitroVersion)" />
-    <PackageVersion Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="DiffPlex" Version="1.9.0" />
     <PackageVersion Include="Duende.IdentityModel" Version="7.1.0" />
@@ -54,7 +53,6 @@
     <PackageVersion Include="ProjNET" Version="2.0.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.0.0" />
     <PackageVersion Include="RavenDB.Client" Version="7.0.0" />
-    <PackageVersion Include="Snapshooter.Xunit" Version="0.5.4" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.55.2" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.55.2" />

--- a/src/StrawberryShake/Client/test/Core.Tests/Integration/IntegrationTests.cs
+++ b/src/StrawberryShake/Client/test/Core.Tests/Integration/IntegrationTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using ChilliCream.Testing;
+using CookieCrumble;
 using StrawberryShake.Integration.Mappers;
 using StrawberryShake.Serialization;
 

--- a/src/StrawberryShake/Client/test/Core.Tests/Integration/Mappers/DroidHeroMapper.cs
+++ b/src/StrawberryShake/Client/test/Core.Tests/Integration/Mappers/DroidHeroMapper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using CookieCrumble;
 
 namespace StrawberryShake.Integration.Mappers
 {

--- a/src/StrawberryShake/Client/test/Core.Tests/Integration/Mappers/DroidHeroMapper.cs
+++ b/src/StrawberryShake/Client/test/Core.Tests/Integration/Mappers/DroidHeroMapper.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using ChilliCream.Testing;
+using CookieCrumble;
 
 namespace StrawberryShake.Integration.Mappers
 {

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/EntityGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/EntityGeneratorTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 
 namespace StrawberryShake.CodeGeneration.CSharp;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/ErrorGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/ErrorGeneratorTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 
 namespace StrawberryShake.CodeGeneration.CSharp;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/GeneratorTestHelper.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/GeneratorTestHelper.cs
@@ -230,6 +230,7 @@ public static class GeneratorTestHelper
 
         if (!File.Exists(snapshotFile))
         {
+            CheckStrictMode();
             File.WriteAllText(snapshotFile, content);
             return;
         }
@@ -247,6 +248,20 @@ public static class GeneratorTestHelper
         File.WriteAllText(mismatchFile, content);
 
         Assert.Fail($"Snapshot mismatch. Mismatch file written to {mismatchFile}");
+    }
+
+    private static void CheckStrictMode()
+    {
+        var value = Environment.GetEnvironmentVariable("COOKIE_CRUMBLE_STRICT_MODE");
+
+        if (string.Equals(value, "on", StringComparison.Ordinal)
+            || (bool.TryParse(value, out var b) && b))
+        {
+            Assert.Fail(
+                "Strict mode is enabled and no snapshot has been found "
+                + "for the current test. Create a new snapshot locally and "
+                + "rerun your tests.");
+        }
     }
 
     private static ClientModel CreateClientModel(

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/GeneratorTestHelper.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/GeneratorTestHelper.cs
@@ -195,7 +195,13 @@ public static class GeneratorTestHelper
         [CallerMemberName] string? testName = null,
         [CallerFilePath] string? callerFilePath = null)
     {
-        var folder = System.IO.Path.GetDirectoryName(callerFilePath)!;
+        ArgumentException.ThrowIfNullOrEmpty(testName);
+        ArgumentException.ThrowIfNullOrEmpty(callerFilePath);
+
+        var folder = System.IO.Path.GetDirectoryName(callerFilePath)
+            ?? throw new ArgumentException(
+                $"Could not determine directory from caller file path '{callerFilePath}'.",
+                nameof(callerFilePath));
         var testFile = System.IO.Path.Combine(folder, testName + "Test.cs");
         var ns = "StrawberryShake.CodeGeneration.CSharp.Integration." + testName;
 
@@ -210,7 +216,7 @@ public static class GeneratorTestHelper
 
         return new AssertSettings
         {
-            ClientName = testName! + "Client",
+            ClientName = testName + "Client",
             Namespace = ns,
             AccessModifier = accessModifier,
             StrictValidation = true,

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/GeneratorTestHelper.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/GeneratorTestHelper.cs
@@ -2,15 +2,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using ChilliCream.Testing;
 using HotChocolate;
 using HotChocolate.Language;
-using Snapshooter;
-using Snapshooter.Xunit;
 using StrawberryShake.CodeGeneration.Analyzers;
 using StrawberryShake.CodeGeneration.Analyzers.Models;
 using StrawberryShake.CodeGeneration.Utilities;
-using Snapshot = Snapshooter.Xunit.Snapshot;
 using RequestStrategyGen = StrawberryShake.Tools.Configuration.RequestStrategy;
 using static StrawberryShake.CodeGeneration.CSharp.CSharpGenerator;
 
@@ -140,11 +136,7 @@ public static class GeneratorTestHelper
 
         if (settings.SnapshotFile is not null)
         {
-            documents.ToString()
-                .MatchSnapshot(
-                    new SnapshotFullName(
-                        settings.SnapshotFile,
-                        Snapshot.FullName().FolderPath));
+            MatchSnapshotAtPath(documents.ToString(), settings.SnapshotFile);
         }
         else
         {
@@ -200,12 +192,11 @@ public static class GeneratorTestHelper
         TransportProfile[]? profiles = null,
         AccessModifier accessModifier = AccessModifier.Public,
         bool noStore = false,
-        [CallerMemberName] string? testName = null)
+        [CallerMemberName] string? testName = null,
+        [CallerFilePath] string? callerFilePath = null)
     {
-        var snapshotFullName = Snapshot.FullName();
-        var testFile = System.IO.Path.Combine(
-            snapshotFullName.FolderPath,
-            testName + "Test.cs");
+        var folder = System.IO.Path.GetDirectoryName(callerFilePath)!;
+        var testFile = System.IO.Path.Combine(folder, testName + "Test.cs");
         var ns = "StrawberryShake.CodeGeneration.CSharp.Integration." + testName;
 
         if (!File.Exists(testFile))
@@ -223,9 +214,7 @@ public static class GeneratorTestHelper
             Namespace = ns,
             AccessModifier = accessModifier,
             StrictValidation = true,
-            SnapshotFile = System.IO.Path.Combine(
-                snapshotFullName.FolderPath,
-                testName + "Test.Client.cs"),
+            SnapshotFile = System.IO.Path.Combine(folder, testName + "Test.Client.cs"),
             RequestStrategy = requestStrategy,
             NoStore = noStore,
             Profiles = (profiles ??
@@ -233,6 +222,31 @@ public static class GeneratorTestHelper
                 TransportProfile.Default
             ]).ToList()
         };
+    }
+
+    private static void MatchSnapshotAtPath(string content, string snapshotFile)
+    {
+        content = content.Replace("\r\n", "\n");
+
+        if (!File.Exists(snapshotFile))
+        {
+            File.WriteAllText(snapshotFile, content);
+            return;
+        }
+
+        var existing = File.ReadAllText(snapshotFile).Replace("\r\n", "\n");
+        if (string.Equals(existing, content, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var folder = System.IO.Path.GetDirectoryName(snapshotFile)!;
+        var mismatchDir = System.IO.Path.Combine(folder, "__snapshots__", "__mismatch__");
+        Directory.CreateDirectory(mismatchDir);
+        var mismatchFile = System.IO.Path.Combine(mismatchDir, System.IO.Path.GetFileName(snapshotFile));
+        File.WriteAllText(mismatchFile, content);
+
+        Assert.Fail($"Snapshot mismatch. Mismatch file written to {mismatchFile}");
     }
 
     private static ClientModel CreateClientModel(

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/InputGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/InputGeneratorTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 
 namespace StrawberryShake.CodeGeneration.CSharp;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/AnyScalarDefaultSerializationTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/AnyScalarDefaultSerializationTest.cs
@@ -2,7 +2,6 @@ using HotChocolate;
 using HotChocolate.AspNetCore.Tests.Utilities;
 using HotChocolate.Types;
 using Microsoft.Extensions.DependencyInjection;
-using Snapshooter.Xunit;
 using StrawberryShake.Transport.WebSockets;
 
 namespace StrawberryShake.CodeGeneration.CSharp.Integration.AnyScalarDefaultSerialization;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/EntityIdOrDataTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/EntityIdOrDataTest.cs
@@ -1,7 +1,6 @@
 using HotChocolate.AspNetCore.Tests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using HotChocolate.Types;
-using Snapshooter.Xunit;
 
 namespace StrawberryShake.CodeGeneration.CSharp.Integration.EntityIdOrData;
 

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsIntrospectionTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsIntrospectionTest.cs
@@ -1,6 +1,5 @@
 using HotChocolate.AspNetCore.Tests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
-using Snapshooter.Xunit;
 using StrawberryShake.Transport.WebSockets;
 
 namespace StrawberryShake.CodeGeneration.CSharp.Integration.StarWarsIntrospection;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsTypeNameOnInterfacesTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsTypeNameOnInterfacesTest.cs
@@ -1,6 +1,5 @@
 using HotChocolate.AspNetCore.Tests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
-using Snapshooter.Xunit;
 using StrawberryShake.Transport.WebSockets;
 
 namespace StrawberryShake.CodeGeneration.CSharp.Integration.StarWarsTypeNameOnInterfaces;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsTypeNameOnUnionsTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsTypeNameOnUnionsTest.cs
@@ -1,6 +1,5 @@
 using HotChocolate.AspNetCore.Tests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
-using Snapshooter.Xunit;
 using StrawberryShake.Transport.WebSockets;
 
 namespace StrawberryShake.CodeGeneration.CSharp.Integration.StarWarsTypeNameOnUnions;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsUnionListTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsUnionListTest.cs
@@ -1,6 +1,5 @@
 using HotChocolate.AspNetCore.Tests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
-using Snapshooter.Xunit;
 using StrawberryShake.Transport.WebSockets;
 
 namespace StrawberryShake.CodeGeneration.CSharp.Integration.StarWarsUnionList;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/TestGeneration.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/TestGeneration.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using StrawberryShake.Tools.Configuration;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/__snapshots__/StarWarsIntrospectionTest.Execute_StarWarsIntrospection_Test.snap
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/__snapshots__/StarWarsIntrospectionTest.Execute_StarWarsIntrospection_Test.snap
@@ -1,4 +1,4 @@
-﻿{
+{
   "Data": {
     "__schema": {
       "QueryType": {

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/NoStoreStarWarsGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/NoStoreStarWarsGeneratorTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 
 namespace StrawberryShake.CodeGeneration.CSharp;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/OperationGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/OperationGeneratorTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 
 namespace StrawberryShake.CodeGeneration.CSharp;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/ScalarGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/ScalarGeneratorTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using Xunit.Sdk;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/SchemaGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/SchemaGeneratorTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 
 namespace StrawberryShake.CodeGeneration.CSharp;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/StarWarsGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/StarWarsGeneratorTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using static StrawberryShake.CodeGeneration.CSharp.GeneratorTestHelper;
 
 namespace StrawberryShake.CodeGeneration.CSharp;

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests/GeneratorTestHelper.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests/GeneratorTestHelper.cs
@@ -226,6 +226,7 @@ public static class GeneratorTestHelper
 
         if (!File.Exists(snapshotFile))
         {
+            CheckStrictMode();
             File.WriteAllText(snapshotFile, content);
             return;
         }
@@ -243,6 +244,20 @@ public static class GeneratorTestHelper
         File.WriteAllText(mismatchFile, content);
 
         Assert.Fail($"Snapshot mismatch. Mismatch file written to {mismatchFile}");
+    }
+
+    private static void CheckStrictMode()
+    {
+        var value = Environment.GetEnvironmentVariable("COOKIE_CRUMBLE_STRICT_MODE");
+
+        if (string.Equals(value, "on", StringComparison.Ordinal)
+            || (bool.TryParse(value, out var b) && b))
+        {
+            Assert.Fail(
+                "Strict mode is enabled and no snapshot has been found "
+                + "for the current test. Create a new snapshot locally and "
+                + "rerun your tests.");
+        }
     }
 
     private static ClientModel CreateClientModel(

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests/GeneratorTestHelper.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests/GeneratorTestHelper.cs
@@ -1,15 +1,11 @@
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using ChilliCream.Testing;
 using HotChocolate;
 using HotChocolate.Language;
-using Snapshooter;
-using Snapshooter.Xunit;
 using StrawberryShake.CodeGeneration.Analyzers;
 using StrawberryShake.CodeGeneration.Analyzers.Models;
 using StrawberryShake.CodeGeneration.Utilities;
-using Snapshot = Snapshooter.Xunit.Snapshot;
 using RequestStrategyGen = StrawberryShake.Tools.Configuration.RequestStrategy;
 using static StrawberryShake.CodeGeneration.CSharp.CSharpGenerator;
 
@@ -138,11 +134,7 @@ public static class GeneratorTestHelper
 
         if (settings.SnapshotFile is not null)
         {
-            documents.ToString()
-                .MatchSnapshot(
-                    new SnapshotFullName(
-                        settings.SnapshotFile,
-                        Snapshot.FullName().FolderPath));
+            MatchSnapshotAtPath(documents.ToString(), settings.SnapshotFile);
         }
         else
         {
@@ -197,12 +189,11 @@ public static class GeneratorTestHelper
         RequestStrategyGen requestStrategy = RequestStrategyGen.Default,
         TransportProfile[]? profiles = null,
         bool noStore = false,
-        [CallerMemberName] string? testName = null)
+        [CallerMemberName] string? testName = null,
+        [CallerFilePath] string? callerFilePath = null)
     {
-        var snapshotFullName = Snapshot.FullName();
-        var testFile = System.IO.Path.Combine(
-            snapshotFullName.FolderPath,
-            testName + "Test.cs");
+        var folder = System.IO.Path.GetDirectoryName(callerFilePath)!;
+        var testFile = System.IO.Path.Combine(folder, testName + "Test.cs");
         var ns = "StrawberryShake.CodeGeneration.CSharp.Integration." + testName;
 
         if (!File.Exists(testFile))
@@ -219,9 +210,7 @@ public static class GeneratorTestHelper
             ClientName = testName! + "Client",
             Namespace = ns,
             StrictValidation = true,
-            SnapshotFile = System.IO.Path.Combine(
-                snapshotFullName.FolderPath,
-                testName + "Test.Client.cs"),
+            SnapshotFile = System.IO.Path.Combine(folder, testName + "Test.Client.cs"),
             RequestStrategy = requestStrategy,
             NoStore = noStore,
             Profiles = (profiles ??
@@ -229,6 +218,31 @@ public static class GeneratorTestHelper
                 TransportProfile.Default
             ]).ToList()
         };
+    }
+
+    private static void MatchSnapshotAtPath(string content, string snapshotFile)
+    {
+        content = content.Replace("\r\n", "\n");
+
+        if (!File.Exists(snapshotFile))
+        {
+            File.WriteAllText(snapshotFile, content);
+            return;
+        }
+
+        var existing = File.ReadAllText(snapshotFile).Replace("\r\n", "\n");
+        if (string.Equals(existing, content, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var folder = System.IO.Path.GetDirectoryName(snapshotFile)!;
+        var mismatchDir = System.IO.Path.Combine(folder, "__snapshots__", "__mismatch__");
+        Directory.CreateDirectory(mismatchDir);
+        var mismatchFile = System.IO.Path.Combine(mismatchDir, System.IO.Path.GetFileName(snapshotFile));
+        File.WriteAllText(mismatchFile, content);
+
+        Assert.Fail($"Snapshot mismatch. Mismatch file written to {mismatchFile}");
     }
 
     private static ClientModel CreateClientModel(

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests/GeneratorTestHelper.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests/GeneratorTestHelper.cs
@@ -192,7 +192,13 @@ public static class GeneratorTestHelper
         [CallerMemberName] string? testName = null,
         [CallerFilePath] string? callerFilePath = null)
     {
-        var folder = System.IO.Path.GetDirectoryName(callerFilePath)!;
+        ArgumentException.ThrowIfNullOrEmpty(testName);
+        ArgumentException.ThrowIfNullOrEmpty(callerFilePath);
+
+        var folder = System.IO.Path.GetDirectoryName(callerFilePath)
+            ?? throw new ArgumentException(
+                $"Could not determine directory from caller file path '{callerFilePath}'.",
+                nameof(callerFilePath));
         var testFile = System.IO.Path.Combine(folder, testName + "Test.cs");
         var ns = "StrawberryShake.CodeGeneration.CSharp.Integration." + testName;
 
@@ -207,7 +213,7 @@ public static class GeneratorTestHelper
 
         return new AssertSettings
         {
-            ClientName = testName! + "Client",
+            ClientName = testName + "Client",
             Namespace = ns,
             StrictValidation = true,
             SnapshotFile = System.IO.Path.Combine(folder, testName + "Test.Client.cs"),

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Mappers/TestDataHelper.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Mappers/TestDataHelper.cs
@@ -6,7 +6,7 @@ using HotChocolate.StarWars;
 using StrawberryShake.CodeGeneration.Analyzers;
 using StrawberryShake.CodeGeneration.Analyzers.Models;
 using StrawberryShake.CodeGeneration.Utilities;
-using static ChilliCream.Testing.FileResource;
+using static CookieCrumble.FileResource;
 
 namespace StrawberryShake.CodeGeneration.Mappers;
 

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Utilities/OperationDocumentHelperTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Utilities/OperationDocumentHelperTests.cs
@@ -1,6 +1,5 @@
 using HotChocolate.Language;
-using Snapshooter.Xunit;
-using static ChilliCream.Testing.FileResource;
+using static CookieCrumble.FileResource;
 using static HotChocolate.Language.Utf8GraphQLParser;
 using static StrawberryShake.CodeGeneration.Utilities.OperationDocumentHelper;
 

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Utilities/QueryDocumentRewriterTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Utilities/QueryDocumentRewriterTests.cs
@@ -3,7 +3,6 @@ using HotChocolate.Language;
 using HotChocolate.Language.Utilities;
 using HotChocolate.StarWars;
 using Microsoft.Extensions.DependencyInjection;
-using Snapshooter.Xunit;
 
 namespace StrawberryShake.CodeGeneration.Utilities;
 

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Utilities/SchemaHelperTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Utilities/SchemaHelperTests.cs
@@ -1,4 +1,3 @@
-using ChilliCream.Testing;
 using HotChocolate.Language;
 using HotChocolate.Types;
 using StrawberryShake.CodeGeneration.Extensions;

--- a/src/StrawberryShake/CodeGeneration/test/Directory.Build.props
+++ b/src/StrawberryShake/CodeGeneration/test/Directory.Build.props
@@ -7,11 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="CookieCrumble" />
+    <Using Include="CookieCrumble.Xunit" />
     <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ChilliCream.Testing.Utilities" />
+    <ProjectReference Include="..\..\..\..\CookieCrumble\src\CookieCrumble.Xunit\CookieCrumble.Xunit.csproj" />
+    <ProjectReference Include="..\..\..\..\CookieCrumble\src\CookieCrumble.Analyzers\CookieCrumble.Analyzers.csproj" OutputItemType="Analyzer" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -19,12 +25,18 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="Snapshooter.Xunit" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Some integration-test snapshots are *.Client.cs files written alongside the test sources;
+         a failed assertion drops them under __snapshots__/__mismatch__/ where the default compile
+         glob would otherwise pick them up and break the next build with duplicate-type errors. -->
+    <Compile Remove="**\__mismatch__\**" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Drops the last `Snapshooter.Xunit` and `ChilliCream.Testing.Utilities` users from the repo (StrawberryShake CodeGeneration tests) in favor of `CookieCrumble`, which already powers ~99% of the snapshot suite.
- Reworks `GeneratorTestHelper` to use `[CallerFilePath]` and a small inline file-snapshot helper, replacing the Snapshooter-specific `SnapshotFullName` + custom-path `MatchSnapshot` mechanic that has no direct CookieCrumble equivalent.
- Removes both `PackageVersion` entries from `Directory.Packages.props` and the corresponding `PackageReference`s from `CodeGeneration/test/Directory.Build.props`; wires up `CookieCrumble.Xunit` + `CookieCrumble.Analyzers` via `ProjectReference` matching the convention used by `HotChocolate/Core/test` and `StrawberryShake/Client/test`.

## Test plan

- `dotnet build src/StrawberryShake/CodeGeneration/StrawberryShake.CodeGeneration.slnx`
- `dotnet test src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests` — 29 passed, 1 skipped
- `dotnet test src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests` — 188 passed, 1 skipped
- `dotnet test src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests` — 1 passed
