### PR TITLE
[Fusion] Allow `@require` intermediates from the requiring schema

### DIFF
--- a/src/HotChocolate/Fusion/src/Fusion.Composition/Satisfiability/RequirementsValidator.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/Satisfiability/RequirementsValidator.cs
@@ -17,12 +17,14 @@ internal sealed class RequirementsValidator(
         MutableObjectTypeDefinition contextType,
         SatisfiabilityPathItem? parentPathItem,
         string excludeSchemaName,
+        bool allowIntermediatesFromExcludedSchema = false,
         SatisfiabilityPath? cycleDetectionPath = null)
     {
         var context = new RequirementsValidatorContext(
             contextType,
             parentPathItem,
             excludeSchemaName,
+            allowIntermediatesFromExcludedSchema,
             cycleDetectionPath);
 
         var errors = new List<SatisfiabilityError>();
@@ -138,13 +140,19 @@ internal sealed class RequirementsValidator(
             return [];
         }
 
-        // Only leaf fields in the requirement need to be sourced from outside
-        // the excluded schema. Intermediate fields (with a sub-selection) are
-        // navigation steps the gateway can resolve locally in the requiring
-        // schema, so we keep them in scope.
-        var schemaNames = fieldNode.SelectionSet is null
-            ? field.GetSchemaNames().Remove(context.ExcludeSchemaName)
-            : field.GetSchemaNames();
+        // Leaf fields in the requirement must be sourced from outside the
+        // excluded schema. Intermediate fields (with a sub-selection) may also
+        // be sourced from the excluded schema when validating a field-level
+        // @require: those intermediates are navigation steps the gateway can
+        // resolve locally in the requiring schema as part of executing the
+        // requiring field. For lookup-key validation the excluded schema has
+        // not been entered yet, so intermediates must also come from outside
+        // it (default behavior).
+        var schemaNames = field.GetSchemaNames();
+        if (fieldNode.SelectionSet is null || !context.AllowIntermediatesFromExcludedSchema)
+        {
+            schemaNames = schemaNames.Remove(context.ExcludeSchemaName);
+        }
         var fieldType = field.Type.AsTypeDefinition();
 
         foreach (var schemaName in schemaNames)
@@ -208,7 +216,8 @@ internal sealed class RequirementsValidator(
                         type,
                         context.Path.Peek(),
                         excludeSchemaName: schemaName,
-                        context.CycleDetectionPath);
+                        allowIntermediatesFromExcludedSchema: true,
+                        cycleDetectionPath: context.CycleDetectionPath);
 
                 if (requirementErrors.Length != 0)
                 {
@@ -305,7 +314,7 @@ internal sealed class RequirementsValidator(
                     contextType,
                     parentPathItem,
                     excludeSchemaName: transitionToSchemaName,
-                    context.CycleDetectionPath),
+                    cycleDetectionPath: context.CycleDetectionPath),
             RequirementsValidator_NoLookupsFoundForType,
             RequirementsValidator_UnableToSatisfyRequirementForLookup);
     }
@@ -317,6 +326,7 @@ internal sealed class RequirementsValidatorContext
         MutableObjectTypeDefinition contextType,
         SatisfiabilityPathItem? parentPathItem,
         string excludeSchemaName,
+        bool allowIntermediatesFromExcludedSchema = false,
         SatisfiabilityPath? cycleDetectionPath = null)
     {
         TypeContext.Push(contextType);
@@ -327,6 +337,7 @@ internal sealed class RequirementsValidatorContext
         }
 
         ExcludeSchemaName = excludeSchemaName;
+        AllowIntermediatesFromExcludedSchema = allowIntermediatesFromExcludedSchema;
         CycleDetectionPath = cycleDetectionPath ?? [];
     }
 
@@ -335,6 +346,8 @@ internal sealed class RequirementsValidatorContext
     public SatisfiabilityPath Path { get; } = [];
 
     public string ExcludeSchemaName { get; }
+
+    public bool AllowIntermediatesFromExcludedSchema { get; }
 
     public SatisfiabilityPath CycleDetectionPath { get; }
 

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/Satisfiability/RequirementsValidator.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/Satisfiability/RequirementsValidator.cs
@@ -138,7 +138,13 @@ internal sealed class RequirementsValidator(
             return [];
         }
 
-        var schemaNames = field.GetSchemaNames().Remove(context.ExcludeSchemaName);
+        // Only leaf fields in the requirement need to be sourced from outside
+        // the excluded schema. Intermediate fields (with a sub-selection) are
+        // navigation steps the gateway can resolve locally in the requiring
+        // schema, so we keep them in scope.
+        var schemaNames = fieldNode.SelectionSet is null
+            ? field.GetSchemaNames().Remove(context.ExcludeSchemaName)
+            : field.GetSchemaNames();
         var fieldType = field.Type.AsTypeDefinition();
 
         foreach (var schemaName in schemaNames)

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/SatisfiabilityValidator.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/SatisfiabilityValidator.cs
@@ -168,7 +168,8 @@ internal sealed class SatisfiabilityValidator
                         requirements,
                         type,
                         path?.Item,
-                        excludeSchemaName: schemaName);
+                        excludeSchemaName: schemaName,
+                        allowIntermediatesFromExcludedSchema: true);
 
                 if (requirementErrors.Length != 0)
                 {

--- a/src/HotChocolate/Fusion/test/Fusion.Composition.Tests/SatisfiabilityValidatorTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Composition.Tests/SatisfiabilityValidatorTests.cs
@@ -1790,11 +1790,7 @@ public sealed class SatisfiabilityValidatorTests
         Assert.True(result.IsSuccess);
     }
 
-    [Fact(Skip = "Circular @require whose intermediate field is owned by the "
-        + "requiring schema is not yet satisfiable. The validator evaluates the "
-        + "requirement from the entity's origin path and does not hop into the "
-        + "requiring schema to gather its locally-owned field first. Enable once "
-        + "multi-hop requirement gathering is supported.")]
+    [Fact]
     // https://github.com/graphql-hive/federation-gateway-audit/tree/main/src/test-suites/requires-circular
     public void RequiresCircular()
     {


### PR DESCRIPTION
## Summary
- Fix `RequirementsValidator` to distinguish leaf fields from intermediate (navigation) fields when computing candidate source schemas for a requirement. Leaves still exclude the target schema (the gateway must source their values from elsewhere); intermediates now include all schemas, since the gateway can resolve a navigation step locally in the requiring schema as part of executing the requiring field.
- This unblocks `RequiresCircular` (federation-gateway-audit `requires-circular`), which has `Post.byNovice` in schema B requiring `author { yearsOfExperience }` where `Post.author` is only declared in B. The previous logic excluded B wholesale and reported `Post.author` as unreachable; the new logic allows the intermediate `author` to come from B (where it's resolved locally) while still requiring `yearsOfExperience` (the leaf) from outside B.

## Test plan
- `dotnet test src/HotChocolate/Fusion/test/Fusion.Composition.Tests --filter "FullyQualifiedName~SatisfiabilityValidatorTests|FullyQualifiedName~RequirementsValidatorTests"` — 64 passed, 0 skipped, 0 failed on net8.0, net9.0, and net10.0.
- Full `HotChocolate.Fusion.Composition.Tests` — 498 passed, 0 skipped, 0 failed across all three TFMs.
