### PR TITLE
Pack SS meta tools via post-build target to fix empty tools folder

### DIFF
--- a/src/StrawberryShake/MetaPackages/Blazor/StrawberryShake.Blazor.csproj
+++ b/src/StrawberryShake/MetaPackages/Blazor/StrawberryShake.Blazor.csproj
@@ -31,22 +31,19 @@
   </PropertyGroup>
 
   <!-- Package the `dotnet-graphql` tool binaries into tools/net{8,9,10}/.
-       Runs after pack's build phase has populated dotnet-graphql's bin/ for
-       each TFM (the ProjectReference above triggers a build per consumer TFM).
-       This project multi-targets net{8,9,10} via Directory.Build.props, so the
-       target fires once per framework; emit only for net10.0 to avoid the
-       duplicate package-path collision (NU5118). -->
+       Runs after pack's build phase has populated dotnet-graphql's bin/ for the
+       current TFM (the ProjectReference above triggers a build per consumer TFM).
+       Each framework contributes only its own tools/netX folder to avoid NU5118
+       duplicate package-path collisions. -->
   <Target Name="_AddDotnetGraphqlToolsToPackage">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" PackagePath="tools/net8" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*" PackagePath="tools/net9" />
+    </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*">
-        <PackagePath>tools/net8</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*">
-        <PackagePath>tools/net9</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*">
-        <PackagePath>tools/net10</PackagePath>
-      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*" PackagePath="tools/net10" />
     </ItemGroup>
   </Target>
 

--- a/src/StrawberryShake/MetaPackages/Blazor/StrawberryShake.Blazor.csproj
+++ b/src/StrawberryShake/MetaPackages/Blazor/StrawberryShake.Blazor.csproj
@@ -24,9 +24,30 @@
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\StrawberryShake.MSBuild.ContentType.xaml" Pack="true" PackagePath="build/StrawberryShake.MSBuild.ContentType.xaml" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\StrawberryShake.MSBuild.xaml" Pack="true" PackagePath="build/StrawberryShake.MSBuild.xaml" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\global.json" Pack="true" PackagePath="build/global.json" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" Pack="true" PackagePath="tools/net8" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*" Pack="true" PackagePath="tools/net9" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*" Pack="true" PackagePath="tools/net10" Visible="false" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddDotnetGraphqlToolsToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Package the `dotnet-graphql` tool binaries into tools/net{8,9,10}/.
+       Runs after pack's build phase has populated dotnet-graphql's bin/ for
+       each TFM (the ProjectReference above triggers a build per consumer TFM).
+       This project multi-targets net{8,9,10} via Directory.Build.props, so the
+       target fires once per framework; emit only for net10.0 to avoid the
+       duplicate package-path collision (NU5118). -->
+  <Target Name="_AddDotnetGraphqlToolsToPackage">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*">
+        <PackagePath>tools/net8</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*">
+        <PackagePath>tools/net9</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*">
+        <PackagePath>tools/net10</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/StrawberryShake/MetaPackages/Maui/StrawberryShake.Maui.csproj
+++ b/src/StrawberryShake/MetaPackages/Maui/StrawberryShake.Maui.csproj
@@ -23,9 +23,30 @@
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\StrawberryShake.MSBuild.ContentType.xaml" Pack="true" PackagePath="build/StrawberryShake.MSBuild.ContentType.xaml" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\StrawberryShake.MSBuild.xaml" Pack="true" PackagePath="build/StrawberryShake.MSBuild.xaml" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\global.json" Pack="true" PackagePath="build/global.json" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" Pack="true" PackagePath="tools/net8" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*" Pack="true" PackagePath="tools/net9" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*" Pack="true" PackagePath="tools/net10" Visible="false" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddDotnetGraphqlToolsToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Package the `dotnet-graphql` tool binaries into tools/net{8,9,10}/.
+       Runs after pack's build phase has populated dotnet-graphql's bin/ for
+       each TFM (the ProjectReference above triggers a build per consumer TFM).
+       This project multi-targets net{8,9,10} via Directory.Build.props, so the
+       target fires once per framework; emit only for net10.0 to avoid the
+       duplicate package-path collision (NU5118). -->
+  <Target Name="_AddDotnetGraphqlToolsToPackage">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*">
+        <PackagePath>tools/net8</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*">
+        <PackagePath>tools/net9</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*">
+        <PackagePath>tools/net10</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/StrawberryShake/MetaPackages/Maui/StrawberryShake.Maui.csproj
+++ b/src/StrawberryShake/MetaPackages/Maui/StrawberryShake.Maui.csproj
@@ -30,22 +30,19 @@
   </PropertyGroup>
 
   <!-- Package the `dotnet-graphql` tool binaries into tools/net{8,9,10}/.
-       Runs after pack's build phase has populated dotnet-graphql's bin/ for
-       each TFM (the ProjectReference above triggers a build per consumer TFM).
-       This project multi-targets net{8,9,10} via Directory.Build.props, so the
-       target fires once per framework; emit only for net10.0 to avoid the
-       duplicate package-path collision (NU5118). -->
+       Runs after pack's build phase has populated dotnet-graphql's bin/ for the
+       current TFM (the ProjectReference above triggers a build per consumer TFM).
+       Each framework contributes only its own tools/netX folder to avoid NU5118
+       duplicate package-path collisions. -->
   <Target Name="_AddDotnetGraphqlToolsToPackage">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" PackagePath="tools/net8" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*" PackagePath="tools/net9" />
+    </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*">
-        <PackagePath>tools/net8</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*">
-        <PackagePath>tools/net9</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*">
-        <PackagePath>tools/net10</PackagePath>
-      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*" PackagePath="tools/net10" />
     </ItemGroup>
   </Target>
 

--- a/src/StrawberryShake/MetaPackages/Server/StrawberryShake.Server.csproj
+++ b/src/StrawberryShake/MetaPackages/Server/StrawberryShake.Server.csproj
@@ -23,9 +23,30 @@
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\StrawberryShake.MSBuild.ContentType.xaml" Pack="true" PackagePath="build/StrawberryShake.MSBuild.ContentType.xaml" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\StrawberryShake.MSBuild.xaml" Pack="true" PackagePath="build/StrawberryShake.MSBuild.xaml" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\global.json" Pack="true" PackagePath="build/global.json" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" Pack="true" PackagePath="tools/net8" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*" Pack="true" PackagePath="tools/net9" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*" Pack="true" PackagePath="tools/net10" Visible="false" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddDotnetGraphqlToolsToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Package the `dotnet-graphql` tool binaries into tools/net{8,9,10}/.
+       Runs after pack's build phase has populated dotnet-graphql's bin/ for
+       each TFM (the ProjectReference above triggers a build per consumer TFM).
+       This project multi-targets net{8,9,10} via Directory.Build.props, so the
+       target fires once per framework; emit only for net10.0 to avoid the
+       duplicate package-path collision (NU5118). -->
+  <Target Name="_AddDotnetGraphqlToolsToPackage">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*">
+        <PackagePath>tools/net8</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*">
+        <PackagePath>tools/net9</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*">
+        <PackagePath>tools/net10</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/StrawberryShake/MetaPackages/Server/StrawberryShake.Server.csproj
+++ b/src/StrawberryShake/MetaPackages/Server/StrawberryShake.Server.csproj
@@ -30,22 +30,19 @@
   </PropertyGroup>
 
   <!-- Package the `dotnet-graphql` tool binaries into tools/net{8,9,10}/.
-       Runs after pack's build phase has populated dotnet-graphql's bin/ for
-       each TFM (the ProjectReference above triggers a build per consumer TFM).
-       This project multi-targets net{8,9,10} via Directory.Build.props, so the
-       target fires once per framework; emit only for net10.0 to avoid the
-       duplicate package-path collision (NU5118). -->
+       Runs after pack's build phase has populated dotnet-graphql's bin/ for the
+       current TFM (the ProjectReference above triggers a build per consumer TFM).
+       Each framework contributes only its own tools/netX folder to avoid NU5118
+       duplicate package-path collisions. -->
   <Target Name="_AddDotnetGraphqlToolsToPackage">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" PackagePath="tools/net8" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*" PackagePath="tools/net9" />
+    </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*">
-        <PackagePath>tools/net8</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net9.0\**\*.*">
-        <PackagePath>tools/net9</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*">
-        <PackagePath>tools/net10</PackagePath>
-      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net10.0\**\*.*" PackagePath="tools/net10" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Summary

- `StrawberryShake.Server`, `StrawberryShake.Maui`, and `StrawberryShake.Blazor` shipped with an empty `tools/` folder starting `16.0.10` (`340 KB` vs `35.8 MB` for `16.0.9`) — no `dotnet-graphql` binaries for any of net8/net9/net10.
- Same root cause as #9785: the static `<None Include="$(...)dotnet-graphql\bin\$(Configuration)\netX.X\**\*.*" Pack="true">` items are evaluated during MSBuild evaluation, *before* the build phase populates the referenced bin folders. Under Nuke a separate `Compile` step pre-populated everything; #9772 collapsed that into a single-shot `dotnet pack`, exposing the timing.
- Fix mirrors #9785's approach: collect the binaries via `TargetsForTfmSpecificContentInPackage`, which runs after pack's build phase. Inside the target, three TFM-conditioned `ItemGroup`s each contribute their own `tools/netX` folder (net8 build → `tools/net8`, net9 → `tools/net9`, net10 → `tools/net10`), avoiding the NU5118 duplicate-package-path collision.

## Test plan

- Clean single-shot `dotnet pack` of each project produces the expected `tools/net8` (233 files), `tools/net9` (230 files), `tools/net10` (230 files) — matching the published `16.0.9` package layout.
- `dotnet build` + `dotnet pack --no-build` also works (no `NETSDK1085`), so any future CI variant that splits build and pack remains compatible.
- The other `<None Include>` items in each csproj (`build/*.props`, `build/*.targets`, `build/*.xaml`, `build/global.json`, icons) are unaffected — those reference checked-in source files that exist at evaluation time.