### PR TITLE
Fix double-encoding of escaped string variables in multipart uploads

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpMultipartMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpMultipartMiddleware.cs
@@ -340,7 +340,14 @@ public sealed class HttpMultipartMiddleware : HttpPostMiddlewareBase
                 break;
 
             case JsonTokenType.String:
-                writer.WriteStringValue(reader.ValueSpan);
+                if (reader.ValueIsEscaped)
+                {
+                    writer.WriteStringValue(reader.GetString());
+                }
+                else
+                {
+                    writer.WriteStringValue(reader.ValueSpan);
+                }
                 break;
 
             case JsonTokenType.Number:

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/UploadQuery.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/UploadQuery.cs
@@ -40,6 +40,14 @@ public class UploadQuery
         return await sr.ReadToEndAsync();
     }
 
+    public async Task<string> UploadWithText(IFile file, string text)
+    {
+        await using var stream = file.OpenReadStream();
+        using var sr = new StreamReader(stream, Encoding.UTF8);
+        await sr.ReadToEndAsync();
+        return text;
+    }
+
     public async Task<string?> NullableUpload(IFile? file)
     {
         if (file is null)

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpMultipartMiddlewareTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpMultipartMiddlewareTests.cs
@@ -332,6 +332,55 @@ public class HttpMultipartMiddlewareTests(TestServerFactory serverFactory) : Ser
     }
 
     [Fact]
+    public async Task Upload_File_With_Escaped_String_Variable_Is_Not_Double_Encoded()
+    {
+        // arrange
+        var server = CreateStarWarsServer();
+
+        const string query = @"
+                query ($upload: Upload!, $text: String!) {
+                    uploadWithText(file: $upload, text: $text)
+                }";
+
+        var request = JsonConvert.SerializeObject(
+            new ClientQueryRequest
+            {
+                Query = query,
+                Variables = new Dictionary<string, object?>
+                {
+                    { "upload", null },
+                    { "text", "test \" test" }
+                }
+            });
+
+        // act
+        var form = new MultipartFormDataContent
+        {
+            { new StringContent(request), "operations" },
+            { new StringContent("{ \"1\": [\"variables.upload\"] }"), "map" },
+            { new StringContent("abc"), "1", "foo.bar" }
+        };
+
+        form.Headers.Add(HttpHeaderKeys.Preflight, "1");
+
+        var result = await server.PostMultipartAsync(form, path: "/upload");
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "ContentType": "application/graphql-response+json; charset=utf-8",
+              "StatusCode": "OK",
+              "Data": {
+                "uploadWithText": "test \" test"
+              },
+              "Errors": null,
+              "Extensions": null
+            }
+            """);
+    }
+
+    [Fact]
     public async Task Upload_Nullable_File()
     {
         // arrange


### PR DESCRIPTION
## Summary

When a GraphQL multipart request (`graphql-multipart-request-spec`) is processed, `HttpMultipartMiddleware` rewrites the `operations` JSON to inject file references in place of the `null` placeholders. During this rewrite, any string variable that was *not* a file was copied using `writer.WriteStringValue(reader.ValueSpan)`.

`ValueSpan` returns the **raw, still-escaped** JSON bytes, while `WriteStringValue(ReadOnlySpan<byte>)` treats its input as unescaped text and escapes it again. The result is that every escape sequence in a string variable was doubled.

For example, a variable with the value `test " test` (JSON: `"test \" test"`) was rewritten to `"test \\\" test"`, so the resolver received `test \" test` instead of `test " test`. The same applied to any backslash, newline, unicode escape, etc.

## Fix

Decode the value before writing it back, but keep a zero-allocation fast path when no escaping is involved:

```csharp
case JsonTokenType.String:
    if (reader.ValueIsEscaped)
    {
        writer.WriteStringValue(reader.GetString());
    }
    else
    {
        writer.WriteStringValue(reader.ValueSpan);
    }
    break;
```

- Escaped values are decoded with GetString() so the writer re-escapes them correctly.
- Unescaped values still take the raw-span path, avoiding the string allocation in the common case.

## Tests
Added `Upload_File_With_Escaped_String_Variable_Is_Not_Double_Encoded`, which sends a file upload alongside a string variable containing an escaped quote and asserts the resolver receives the original, correctly-decoded value. Verified on net8.0, net9.0, and net10.0.
