### PR TITLE
[Fusion] Fix composition crash on unimplemented merged interface field

### DIFF
--- a/src/HotChocolate/Fusion/src/Fusion.Composition/PostMergeValidationRules/ImplementedByInaccessibleRule.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/PostMergeValidationRules/ImplementedByInaccessibleRule.cs
@@ -52,7 +52,14 @@ internal sealed class ImplementedByInaccessibleRule
 
             foreach (var interfaceField in accessibleInterfaceFields)
             {
-                var field = type.Fields[interfaceField.Name];
+                // The implementing type may not provide every field of the interface, for example
+                // when two source schemas contribute different fields to the same-named interface.
+                // The unimplemented field is reported by InterfaceFieldNoImplementationRule, so it
+                // is skipped here.
+                if (!type.Fields.TryGetField(interfaceField.Name, out var field))
+                {
+                    continue;
+                }
 
                 if (field.HasFusionInaccessibleDirective()
                     || type.HasFusionInaccessibleDirective())

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/PostMergeValidationRules/ImplementedByInaccessibleRule.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/PostMergeValidationRules/ImplementedByInaccessibleRule.cs
@@ -52,10 +52,10 @@ internal sealed class ImplementedByInaccessibleRule
 
             foreach (var interfaceField in accessibleInterfaceFields)
             {
-                // The implementing type may not provide every field of the interface, for example
-                // when two source schemas contribute different fields to the same-named interface.
-                // The unimplemented field is reported by InterfaceFieldNoImplementationRule, so it
-                // is skipped here.
+                // An implementing type can be missing fields that were contributed to a merged
+                // interface by another source schema. That missing-field case is validated
+                // separately (e.g. by InterfaceFieldNoImplementationRule for object types), so we
+                // skip it here to avoid throwing when looking up the field on the implementing type.
                 if (!type.Fields.TryGetField(interfaceField.Name, out var field))
                 {
                     continue;

--- a/src/HotChocolate/Fusion/test/Fusion.Composition.Tests/PostMergeValidationRules/ImplementedByInaccessibleRuleTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Composition.Tests/PostMergeValidationRules/ImplementedByInaccessibleRuleTests.cs
@@ -150,4 +150,34 @@ public sealed class ImplementedByInaccessibleRuleTests : RuleTestBase
                 """
             ]);
     }
+
+    // When two source schemas declare the same-named interface with different fields, the merged
+    // interface holds the union of those fields, so an implementing type does not necessarily
+    // provide every field of the interface. This rule must not assume the field exists on the
+    // implementing type; the unimplemented field is reported by InterfaceFieldNoImplementationRule.
+    [Fact]
+    public void Validate_MergedInterfaceFieldNotOnAllImplementers_Succeeds()
+    {
+        AssertValid(
+        [
+            """
+            interface Error {
+                code: String!
+            }
+
+            type ErrorWithCode implements Error {
+                code: String!
+            }
+            """,
+            """
+            interface Error {
+                message: String!
+            }
+
+            type ErrorWithMessage implements Error {
+                message: String!
+            }
+            """
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- Composing two source schemas that declare the same-named interface with different fields crashed with `KeyNotFoundException: The given key '…' was not present in the dictionary` during post-merge validation.
- `ImplementedByInaccessibleRule` indexed `type.Fields[interfaceField.Name]` directly, assuming every implementing type provides every field of the merged interface. When a type implements the interface but is missing a field contributed by another subgraph, the lookup threw.
- Guard the lookup with `TryGetField` and skip absent fields; the unimplemented-field case is already reported by `InterfaceFieldNoImplementationRule`, which now surfaces a clear `INTERFACE_FIELD_NO_IMPLEMENTATION` error instead of an opaque crash.

## Test plan
- Added `ImplementedByInaccessibleRuleTests.Validate_MergedInterfaceFieldNotOnAllImplementers_Succeeds`, which merges two subgraphs whose shared interface has disjoint fields (previously crashed).
- All 7 `ImplementedByInaccessibleRuleTests` pass, including the 6 existing `@inaccessible` detection cases.
