### PR TITLE
Fix `[Parent(requires:)]` dropped for resolvers declared on interface types

### DIFF
--- a/src/HotChocolate/Core/src/Types/Execution/Requirements/RequirementsTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Requirements/RequirementsTypeInterceptor.cs
@@ -25,7 +25,7 @@ internal sealed class RequirementsTypeInterceptor : TypeInterceptor
         "IL2072",
         Justification =
             "Runtime types come from the schema type model and are statically referenced.")]
-    public override void OnBeforeCompleteType(
+    public override void OnAfterCompleteType(
         ITypeCompletionContext completionContext,
         TypeSystemConfiguration configuration)
     {

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Configurations/FieldConfiguration.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Configurations/FieldConfiguration.cs
@@ -127,8 +127,15 @@ public abstract class FieldConfiguration
 
     public void SetConnectionTotalCountFieldFlags() => Flags |= CoreFieldFlags.TotalCount;
 
-    public void SetFieldRequirements(string requirements, Type entityType)
+    public void SetFieldRequirements(string? requirements, Type? entityType)
     {
+        if (string.IsNullOrEmpty(requirements) || entityType is null)
+        {
+            Flags &= ~CoreFieldFlags.WithRequirements;
+            Features.Set<FieldRequirementFeature>(null);
+            return;
+        }
+
         Flags |= CoreFieldFlags.WithRequirements;
         Features.Set(new FieldRequirementFeature(requirements, entityType));
     }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IInterfaceFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IInterfaceFieldDescriptor.cs
@@ -330,4 +330,37 @@ public interface IInterfaceFieldDescriptor
     IInterfaceFieldDescriptor Directive(
         string name,
         params ArgumentNode[] arguments);
+
+    /// <summary>
+    /// Specifies the requirements for the parent object.
+    /// </summary>
+    /// <param name="selector">
+    /// The requirements for the parent object.
+    /// </param>
+    /// <returns>
+    /// Returns the descriptor to chain further configuration.
+    /// </returns>
+    IInterfaceFieldDescriptor ParentRequires<TParent>(Expression<Func<TParent, object>> selector);
+
+    /// <summary>
+    /// Specifies the requirements for the parent object.
+    /// </summary>
+    /// <param name="requires">
+    /// The requirements for the parent object.
+    /// </param>
+    /// <returns>
+    /// Returns the descriptor to chain further configuration.
+    /// </returns>
+    IInterfaceFieldDescriptor ParentRequires<TParent>(string? requires);
+
+    /// <summary>
+    /// Specifies the requirements for the parent object.
+    /// </summary>
+    /// <param name="requires">
+    /// The requirements for the parent object.
+    /// </param>
+    /// <returns>
+    /// Returns the descriptor to chain further configuration.
+    /// </returns>
+    IInterfaceFieldDescriptor ParentRequires(string? requires);
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -99,23 +99,7 @@ public class InterfaceFieldDescriptor
                 definition.GetParameterExpressionBuilders(),
                 IsBatchResolver());
 
-            // Mirror ObjectFieldDescriptor so interface-declared [Parent(requires:)] resolvers still register requirements once inherited by the implementing object type.
-            foreach (var parameter in _parameterInfos)
-            {
-                if (!parameter.IsDefined(typeof(ParentAttribute)))
-                {
-                    continue;
-                }
-
-                var requirements = parameter.GetCustomAttribute<ParentAttribute>()?.Requires;
-                if (!(requirements?.Length > 0))
-                {
-                    continue;
-                }
-
-                Configuration.Flags |= CoreFieldFlags.WithRequirements;
-                Configuration.Features.Set(new FieldRequirementFeature(requirements, parameter.ParameterType));
-            }
+            FieldDescriptorUtilities.DiscoverParentRequirements(_parameterInfos, Configuration);
 
             _argumentsInitialized = true;
         }
@@ -369,6 +353,21 @@ public class InterfaceFieldDescriptor
         params ArgumentNode[] arguments)
     {
         base.Directive(name, arguments);
+        return this;
+    }
+
+    public IInterfaceFieldDescriptor ParentRequires<TParent>(Expression<Func<TParent, object>> selector)
+        => ParentRequires<TParent>(ObjectFieldDescriptor.ExpressionSelectionSetFormatter.Format(selector));
+
+    public IInterfaceFieldDescriptor ParentRequires<TParent>(string? requires)
+    {
+        Configuration.SetFieldRequirements(requires, typeof(TParent));
+        return this;
+    }
+
+    public IInterfaceFieldDescriptor ParentRequires(string? requires)
+    {
+        Configuration.SetFieldRequirements(requires, Configuration.SourceType);
         return this;
     }
 

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceFieldDescriptor.cs
@@ -98,6 +98,25 @@ public class InterfaceFieldDescriptor
                 _parameterInfos,
                 definition.GetParameterExpressionBuilders(),
                 IsBatchResolver());
+
+            // Mirror ObjectFieldDescriptor so interface-declared [Parent(requires:)] resolvers still register requirements once inherited by the implementing object type.
+            foreach (var parameter in _parameterInfos)
+            {
+                if (!parameter.IsDefined(typeof(ParentAttribute)))
+                {
+                    continue;
+                }
+
+                var requirements = parameter.GetCustomAttribute<ParentAttribute>()?.Requires;
+                if (!(requirements?.Length > 0))
+                {
+                    continue;
+                }
+
+                Configuration.Flags |= CoreFieldFlags.WithRequirements;
+                Configuration.Features.Set(new FieldRequirementFeature(requirements, parameter.ParameterType));
+            }
+
             _argumentsInitialized = true;
         }
     }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectFieldDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectFieldDescriptor.cs
@@ -242,22 +242,7 @@ public class ObjectFieldDescriptor
                     definition.GetParameterExpressionBuilders(),
                     IsBatchResolver());
 
-                foreach (var parameter in _parameterInfos)
-                {
-                    if (!parameter.IsDefined(typeof(ParentAttribute)))
-                    {
-                        continue;
-                    }
-
-                    var requirements = parameter.GetCustomAttribute<ParentAttribute>()?.Requires;
-                    if (!(requirements?.Length > 0))
-                    {
-                        continue;
-                    }
-
-                    Configuration.Flags |= CoreFieldFlags.WithRequirements;
-                    Configuration.Features.Set(new FieldRequirementFeature(requirements, parameter.ParameterType));
-                }
+                FieldDescriptorUtilities.DiscoverParentRequirements(_parameterInfos, Configuration);
             }
 
             _argumentsInitialized = true;
@@ -603,29 +588,13 @@ public class ObjectFieldDescriptor
     /// <inheritdoc />
     public IObjectFieldDescriptor ParentRequires<TParent>(string? requires)
     {
-        if (!(requires?.Length > 0))
-        {
-            Configuration.Flags &= ~CoreFieldFlags.WithRequirements;
-            Configuration.Features.Set<FieldRequirementFeature>(null);
-            return this;
-        }
-
-        Configuration.Flags |= CoreFieldFlags.WithRequirements;
-        Configuration.Features.Set(new FieldRequirementFeature(requires, typeof(TParent)));
+        Configuration.SetFieldRequirements(requires, typeof(TParent));
         return this;
     }
 
     public IObjectFieldDescriptor ParentRequires(string? requires)
     {
-        if (!(requires?.Length > 0))
-        {
-            Configuration.Flags &= ~CoreFieldFlags.WithRequirements;
-            Configuration.Features.Set<FieldRequirementFeature>(null);
-            return this;
-        }
-
-        Configuration.Flags |= CoreFieldFlags.WithRequirements;
-        Configuration.Features.Set(new FieldRequirementFeature(requires, Configuration.SourceType));
+        Configuration.SetFieldRequirements(requires, Configuration.SourceType);
         return this;
     }
 

--- a/src/HotChocolate/Core/src/Types/Types/Helpers/FieldDescriptorUtilities.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Helpers/FieldDescriptorUtilities.cs
@@ -138,4 +138,25 @@ public static class FieldDescriptorUtilities
             }
         }
     }
+
+    public static void DiscoverParentRequirements(
+        ParameterInfo[] parameters,
+        FieldConfiguration configuration)
+    {
+        foreach (var parameter in parameters)
+        {
+            if (!parameter.IsDefined(typeof(ParentAttribute)))
+            {
+                continue;
+            }
+
+            var requirements = parameter.GetCustomAttribute<ParentAttribute>()?.Requires;
+            if (!(requirements?.Length > 0))
+            {
+                continue;
+            }
+
+            configuration.SetFieldRequirements(requirements, parameter.ParameterType);
+        }
+    }
 }

--- a/src/HotChocolate/Core/src/Types/Types/ObjectType.Initialization.cs
+++ b/src/HotChocolate/Core/src/Types/Types/ObjectType.Initialization.cs
@@ -1,4 +1,5 @@
 using HotChocolate.Configuration;
+using HotChocolate.Features;
 using HotChocolate.Internal;
 using HotChocolate.Resolvers;
 using HotChocolate.Types.Descriptors;
@@ -133,15 +134,32 @@ public partial class ObjectType
             if (processed.Add(field.Name)
                 && interfaceFields.TryGetValue(field.Name, out var interfaceField))
             {
+                var inheritedResolver = false;
+
                 if (!field.Resolvers.HasResolvers)
                 {
                     field.Resolvers = interfaceField.Resolvers;
+                    inheritedResolver = true;
                 }
 
                 if (field.BatchResolver is null && interfaceField.BatchResolver is not null)
                 {
                     field.BatchResolver = interfaceField.BatchResolver;
                     field.SetBatchResolverFlags();
+                    inheritedResolver = true;
+                }
+
+                // The [Parent(requires:)] metadata is bound to the inherited resolver, so it has
+                // to travel with it. The CopyTo path below already does this for fields that are
+                // created from the interface field, but a field that is already declared on the
+                // object type reuses this merge path and would otherwise drop the requirement,
+                // leaving the required column out of the projection.
+                if (inheritedResolver
+                    && (interfaceField.Flags & CoreFieldFlags.WithRequirements) == CoreFieldFlags.WithRequirements
+                    && (field.Flags & CoreFieldFlags.WithRequirements) != CoreFieldFlags.WithRequirements)
+                {
+                    field.Flags |= CoreFieldFlags.WithRequirements;
+                    field.Features.Set(interfaceField.Features.GetRequired<FieldRequirementFeature>());
                 }
             }
         }

--- a/src/HotChocolate/Core/src/Types/Types/ObjectType.Initialization.cs
+++ b/src/HotChocolate/Core/src/Types/Types/ObjectType.Initialization.cs
@@ -158,8 +158,8 @@ public partial class ObjectType
                     && (interfaceField.Flags & CoreFieldFlags.WithRequirements) == CoreFieldFlags.WithRequirements
                     && (field.Flags & CoreFieldFlags.WithRequirements) != CoreFieldFlags.WithRequirements)
                 {
-                    field.Flags |= CoreFieldFlags.WithRequirements;
-                    field.Features.Set(interfaceField.Features.GetRequired<FieldRequirementFeature>());
+                    var requirements = interfaceField.Features.GetRequired<FieldRequirementFeature>();
+                    field.SetFieldRequirements(requirements.Requirements, requirements.EntityType);
                 }
             }
         }

--- a/src/HotChocolate/Data/test/Data.Tests/ParentRequiresInterfaceProjectionTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/ParentRequiresInterfaceProjectionTests.cs
@@ -125,6 +125,46 @@ public class ParentRequiresInterfaceProjectionTests
             """);
     }
 
+    [Fact]
+    public async Task ParentRequires_Should_ProjectRequiredColumn_When_DeclaredViaFluentApiOnInterface()
+    {
+        // arrange
+        // The requirement is declared through the fluent .ParentRequires<Brand>(...) on the interface
+        // field rather than the [Parent(requires:)] attribute; Name must still reach the projection.
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryContext()
+            .AddQueryType<Query>()
+            .AddType<BrandFluentInterfaceType>()
+            .AddType<BrandFluentType>()
+            .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
+            .BuildRequestExecutorAsync();
+
+        // act
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              brands {
+                displayName
+              }
+            }
+            """);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "brands": [
+                  {
+                    "displayName": "Acme"
+                  }
+                ]
+              }
+            }
+            """);
+    }
+
     public interface IBrand
     {
         int Id { get; }
@@ -151,6 +191,33 @@ public class ParentRequiresInterfaceProjectionTests
                 .Field("displayName")
                 .Type<NonNullType<StringType>>()
                 .ResolveWith<BrandResolvers>(r => r.GetDisplayName(default!));
+        }
+    }
+
+    public class BrandFluentResolvers
+    {
+        public string GetDisplayName([Parent] Brand brand)
+            => brand.Name;
+    }
+
+    public class BrandFluentInterfaceType : InterfaceType<IBrand>
+    {
+        protected override void Configure(IInterfaceTypeDescriptor<IBrand> descriptor)
+        {
+            // The requirement is supplied via the fluent ParentRequires API, not the attribute.
+            descriptor
+                .Field("displayName")
+                .Type<NonNullType<StringType>>()
+                .ParentRequires<Brand>(nameof(Brand.Name))
+                .ResolveWith<BrandFluentResolvers>(r => r.GetDisplayName(default!));
+        }
+    }
+
+    public class BrandFluentType : ObjectType<Brand>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Brand> descriptor)
+        {
+            descriptor.Implements<BrandFluentInterfaceType>();
         }
     }
 

--- a/src/HotChocolate/Data/test/Data.Tests/ParentRequiresInterfaceProjectionTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/ParentRequiresInterfaceProjectionTests.cs
@@ -10,6 +10,9 @@ public class ParentRequiresInterfaceProjectionTests
     [Fact]
     public async Task ParentRequires_Should_ProjectRequiredColumn_When_ResolverDeclaredOnInterface()
     {
+        // arrange
+        // displayName is derived from Name, but the query selects only displayName; Name
+        // must reach the projection via [Parent(requires:)], not through the selection set.
         var executor = await new ServiceCollection()
             .AddGraphQL()
             .AddQueryContext()
@@ -19,8 +22,7 @@ public class ParentRequiresInterfaceProjectionTests
             .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
             .BuildRequestExecutorAsync();
 
-        // displayName is derived from Name, but the query selects only displayName; Name
-        // must reach the projection via [Parent(requires:)], not through the selection set.
+        // act
         var result = await executor.ExecuteAsync(
             """
             {
@@ -30,6 +32,7 @@ public class ParentRequiresInterfaceProjectionTests
             }
             """);
 
+        // assert
         result.MatchInlineSnapshot(
             """
             {
@@ -47,6 +50,8 @@ public class ParentRequiresInterfaceProjectionTests
     [Fact]
     public async Task ParentRequires_Should_ProjectRequiredColumn_When_ResolverDeclaredOnObjectType()
     {
+        // arrange
+        // Same requirement, but declared directly on the object type (the path that already works).
         var executor = await new ServiceCollection()
             .AddGraphQL()
             .AddQueryContext()
@@ -55,7 +60,7 @@ public class ParentRequiresInterfaceProjectionTests
             .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
             .BuildRequestExecutorAsync();
 
-        // Same requirement, but declared directly on the object type (the path that already works).
+        // act
         var result = await executor.ExecuteAsync(
             """
             {
@@ -65,6 +70,47 @@ public class ParentRequiresInterfaceProjectionTests
             }
             """);
 
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "brands": [
+                  {
+                    "displayName": "Acme"
+                  }
+                ]
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task ParentRequires_Should_ProjectRequiredColumn_When_ObjectTypeRedeclaresInterfaceField()
+    {
+        // arrange
+        // The object type declares displayName itself but without a resolver, so it inherits the
+        // interface resolver through the field-merge path instead of receiving a copied field.
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryContext()
+            .AddQueryType<Query>()
+            .AddType<BrandInterfaceType>()
+            .AddType<BrandRedeclaredType>()
+            .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
+            .BuildRequestExecutorAsync();
+
+        // act
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              brands {
+                displayName
+              }
+            }
+            """);
+
+        // assert
         result.MatchInlineSnapshot(
             """
             {
@@ -113,6 +159,20 @@ public class ParentRequiresInterfaceProjectionTests
         protected override void Configure(IObjectTypeDescriptor<Brand> descriptor)
         {
             descriptor.Implements<BrandInterfaceType>();
+        }
+    }
+
+    public class BrandRedeclaredType : ObjectType<Brand>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Brand> descriptor)
+        {
+            descriptor.Implements<BrandInterfaceType>();
+
+            // displayName is declared here without its own resolver; the interface resolver and its
+            // [Parent(requires:)] requirement must be merged onto this already-declared field.
+            descriptor
+                .Field("displayName")
+                .Type<NonNullType<StringType>>();
         }
     }
 

--- a/src/HotChocolate/Data/test/Data.Tests/ParentRequiresInterfaceProjectionTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/ParentRequiresInterfaceProjectionTests.cs
@@ -1,0 +1,150 @@
+using GreenDonut.Data;
+using HotChocolate.Execution;
+using HotChocolate.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Data;
+
+public class ParentRequiresInterfaceProjectionTests
+{
+    [Fact]
+    public async Task ParentRequires_Should_ProjectRequiredColumn_When_ResolverDeclaredOnInterface()
+    {
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryContext()
+            .AddQueryType<Query>()
+            .AddType<BrandInterfaceType>()
+            .AddType<BrandType>()
+            .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
+            .BuildRequestExecutorAsync();
+
+        // displayName is derived from Name, but the query selects only displayName; Name
+        // must reach the projection via [Parent(requires:)], not through the selection set.
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              brands {
+                displayName
+              }
+            }
+            """);
+
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "brands": [
+                  {
+                    "displayName": "Acme"
+                  }
+                ]
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task ParentRequires_Should_ProjectRequiredColumn_When_ResolverDeclaredOnObjectType()
+    {
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryContext()
+            .AddQueryType<ControlQuery>()
+            .AddType<BrandControlType>()
+            .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
+            .BuildRequestExecutorAsync();
+
+        // Same requirement, but declared directly on the object type (the path that already works).
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              brands {
+                displayName
+              }
+            }
+            """);
+
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "brands": [
+                  {
+                    "displayName": "Acme"
+                  }
+                ]
+              }
+            }
+            """);
+    }
+
+    public interface IBrand
+    {
+        int Id { get; }
+    }
+
+    public class Brand : IBrand
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class BrandResolvers
+    {
+        public string GetDisplayName([Parent(requires: nameof(Brand.Name))] Brand brand)
+            => brand.Name;
+    }
+
+    public class BrandInterfaceType : InterfaceType<IBrand>
+    {
+        protected override void Configure(IInterfaceTypeDescriptor<IBrand> descriptor)
+        {
+            descriptor
+                .Field("displayName")
+                .Type<NonNullType<StringType>>()
+                .ResolveWith<BrandResolvers>(r => r.GetDisplayName(default!));
+        }
+    }
+
+    public class BrandType : ObjectType<Brand>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Brand> descriptor)
+        {
+            descriptor.Implements<BrandInterfaceType>();
+        }
+    }
+
+    public class Query
+    {
+        public IQueryable<Brand> GetBrands(QueryContext<Brand> query)
+            => s_brands.AsQueryable().With(query);
+    }
+
+    public class BrandControlType : ObjectType<Brand>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Brand> descriptor)
+        {
+            descriptor
+                .Field("displayName")
+                .Type<NonNullType<StringType>>()
+                .ResolveWith<BrandResolvers>(r => r.GetDisplayName(default!));
+        }
+    }
+
+    public class ControlQuery
+    {
+        public IQueryable<Brand> GetBrands(QueryContext<Brand> query)
+            => s_brands.AsQueryable().With(query);
+    }
+
+    private static readonly Brand[] s_brands =
+    [
+        new()
+        {
+            Id = 1,
+            Name = "Acme"
+        }
+    ];
+}


### PR DESCRIPTION
Fixes #9822 and adds associated tests.