### PR TITLE
Re-pin nitro-client actions to v16.0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
           show-progress: false
 
       - name: Validate Client
-        uses: ChilliCream/nitro-client-validate@30ce13815d90dad9ca50a96e5746a4e5abb11e8f # v16.0.1-p.5
+        uses: ChilliCream/nitro-client-validate@e9856650fe21377cd2a7f0c82002cf121dbe9a30 # v16.0.13
         with:
           client-id: ${{ secrets.NITRO_API_CLIENT_ID }}
           operations-file: src/Nitro/Common/src/ChilliCream.Nitro.Client/persisted/operations.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
           NitroIdentityScopes: ${{ secrets.NITRO_IDENTITY_SCOPES }}
 
       - name: 📤 Upload Nitro CLI client operations
-        uses: ChilliCream/nitro-client-upload@1a35b3fbdc6dac5d2aa3c49b2fb061ce15b6999c # v16.0.1-p.5
+        uses: ChilliCream/nitro-client-upload@877527c3e690daa0e7e8ad400e4950617b5f6f8d # v16.0.13
         with:
           tag: ${{ env.GIT_TAG }}
           operations-file: src/Nitro/Common/src/ChilliCream.Nitro.Client/persisted/operations.json
@@ -163,7 +163,7 @@ jobs:
           api-key: ${{ secrets.NITRO_API_KEY }}
 
       - name: 🚀 Publish Nitro CLI client (Dev)
-        uses: ChilliCream/nitro-client-publish@6b0b716ab02a9b1009facb78e4aeb2ae0c0629a1 # v16.0.1-p.5
+        uses: ChilliCream/nitro-client-publish@f25bbe5bf209f3432ede55b482a2df1b0fa714f0 # v16.0.13
         with:
           tag: ${{ env.GIT_TAG }}
           stage: Dev
@@ -172,7 +172,7 @@ jobs:
           force: true
 
       - name: 🚀 Publish Nitro CLI client (Prod)
-        uses: ChilliCream/nitro-client-publish@6b0b716ab02a9b1009facb78e4aeb2ae0c0629a1 # v16.0.1-p.5
+        uses: ChilliCream/nitro-client-publish@f25bbe5bf209f3432ede55b482a2df1b0fa714f0 # v16.0.13
         with:
           tag: ${{ env.GIT_TAG }}
           stage: Prod


### PR DESCRIPTION
## Summary
- `v16.0.1-p.5` was removed from GitHub, leaving the `nitro-client-validate`, `nitro-client-upload`, and `nitro-client-publish` action refs pointing at unreachable commit SHAs.
- Re-pins all four refs in [ci.yml](.github/workflows/ci.yml) and [release.yml](.github/workflows/release.yml) to the commit SHAs that `v16` currently resolves to (`v16.0.13`), preserving the repo-wide SHA-pin convention rather than switching to a floating `@v16` tag.

## Test plan
- Verified `v16` resolves to `v16.0.13` in all three public action repos, and that the new 40-char SHAs match those tags.
- Confirmed these are now the only externally-referenced actions in the workflows and all are SHA-pinned with `# v16.0.13` comments, consistent with every other `uses:` entry.
