### PR TITLE
Fix ApplyPolicy.Validation not enforced on code-first fields

### DIFF
--- a/src/HotChocolate/Core/src/Authorization/Extensions/AuthorizeObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Authorization/Extensions/AuthorizeObjectFieldDescriptorExtensions.cs
@@ -26,7 +26,7 @@ public static class AuthorizeObjectFieldDescriptorExtensions
 
         if (apply is ApplyPolicy.Validation)
         {
-            descriptor.ModifyAuthorizationFieldOptions(o => o with { AuthorizeAtRequestLevel = true });
+            descriptor.Extend().Context.ModifyAuthorizationFieldOptions(o => o with { AuthorizeAtRequestLevel = true });
         }
 
         return descriptor.Directive(new AuthorizeDirective(apply: apply));
@@ -53,7 +53,7 @@ public static class AuthorizeObjectFieldDescriptorExtensions
 
         if (apply is ApplyPolicy.Validation)
         {
-            descriptor.ModifyAuthorizationFieldOptions(o => o with { AuthorizeAtRequestLevel = true });
+            descriptor.Extend().Context.ModifyAuthorizationFieldOptions(o => o with { AuthorizeAtRequestLevel = true });
         }
 
         return descriptor.Directive(new AuthorizeDirective(policy, apply: apply));

--- a/src/HotChocolate/Core/test/Authorization.Tests/CodeFirstAuthorizationTests.cs
+++ b/src/HotChocolate/Core/test/Authorization.Tests/CodeFirstAuthorizationTests.cs
@@ -254,6 +254,54 @@ public class CodeFirstAuthorizationTests
     }
 
     [Fact]
+    public async Task Authorize_Field_Validation_NoAccess_When_Type_Not_Authorized()
+    {
+        // arrange
+        // only the field carries a validation policy; the query type itself is not authorized,
+        // so request-level enforcement must be triggered by the field configuration alone.
+        var handler = new AuthHandler(
+            resolver: (_, _) => AuthorizeResult.Allowed,
+            validation: (_, _) => AuthorizeResult.NotAllowed);
+
+        var executor =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType(d => d
+                    .Name("Query")
+                    .Field("sensitiveData")
+                    .Type<StringType>()
+                    .Resolve("sensitive data")
+                    .Authorize("READ_AUTH", ApplyPolicy.Validation))
+                .AddAuthorizationHandler(_ => handler)
+                .BuildRequestExecutorAsync();
+
+        // act
+        var result = await executor.ExecuteAsync("{ sensitiveData }");
+
+        // assert
+        Snapshot
+            .Create()
+            .Add(result)
+            .MatchInline(
+                """
+                {
+                  "errors": [
+                    {
+                      "message": "The current user is not authorized to access this resource.",
+                      "extensions": {
+                        "code": "AUTH_NOT_AUTHORIZED"
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        Assert.NotNull(result.ContextData);
+        Assert.True(result.ContextData.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
+        Assert.Equal(401, value);
+    }
+
+    [Fact]
     public async Task Authorize_Schema_Field()
     {
         // arrange


### PR DESCRIPTION
## Summary
- Code-first `.Authorize(ApplyPolicy.Validation)` on a field never enforced the policy: unauthenticated requests resolved the protected field, while the annotation-based `[Authorize(Apply = ApplyPolicy.Validation)]` correctly rejected them.
- Regression from the ContextData → Features migration (#8267): the code-first extension wrote the `AuthorizeAtRequestLevel` marker to the field configuration's features (which nothing reads) instead of the descriptor context. The attribute and SDL paths write it to the descriptor context, where the `AuthorizationTypeInterceptor` reads it to flag the schema for request-level enforcement.
- Both `AuthorizeAtRequestLevel` writes in `AuthorizeObjectFieldDescriptorExtensions` now target `descriptor.Extend().Context`, matching `AuthorizeAttribute`. The `AllowAnonymous` write is unchanged (it correctly lives on the field configuration).

## Test plan
- Added `Authorize_Field_Validation_NoAccess_When_Type_Not_Authorized`, which isolates a field-level validation policy on an otherwise-unauthorized query type (the case existing tests masked via a type-level policy). Verified it fails on the old code and passes on the fix.
- `dotnet test` for `HotChocolate.Authorization.Tests` (33/33) and `HotChocolate.AspNetCore.Authorization.Tests` (110/110), green on net8.0/net9.0/net10.0.

Closes #9830
