### PR TITLE
Serialize sbyte as JSON number in transport and execution writers

### DIFF
--- a/src/HotChocolate/AspNetCore/src/Transport.Abstractions/Serialization/Utf8JsonWriterHelper.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Abstractions/Serialization/Utf8JsonWriterHelper.cs
@@ -337,6 +337,10 @@ internal static class Utf8JsonWriterHelper
                 writer.WriteStringValue(s);
                 break;
 
+            case sbyte sb:
+                writer.WriteNumberValue(sb);
+                break;
+
             case byte b:
                 writer.WriteNumberValue(b);
                 break;

--- a/src/HotChocolate/AspNetCore/test/Transport.Http.Tests/OperationRequestTests.cs
+++ b/src/HotChocolate/AspNetCore/test/Transport.Http.Tests/OperationRequestTests.cs
@@ -32,4 +32,31 @@ public class OperationRequestTests
             """{"id":"abc","operationName":"myOperation","variables":{"abc":"def","hij":null}}""",
             result);
     }
+
+    [Fact]
+    public async Task Should_WriteSByteVariableAsNumber()
+    {
+        // arrange
+        var request = new OperationRequest(
+            null,
+            "abc",
+            "myOperation",
+            variables: new Dictionary<string, object?>
+            {
+                ["value"] = (sbyte)2
+            });
+
+        await using var memory = new MemoryStream();
+        await using var writer = new Utf8JsonWriter(memory);
+
+        // act
+        request.WriteTo(writer);
+        await writer.FlushAsync();
+
+        // assert
+        var result = Encoding.UTF8.GetString(memory.ToArray());
+        Assert.Equal(
+            """{"id":"abc","operationName":"myOperation","variables":{"value":2}}""",
+            result);
+    }
 }

--- a/src/HotChocolate/Core/src/Execution.Abstractions/Execution/JsonValueFormatter.cs
+++ b/src/HotChocolate/Core/src/Execution.Abstractions/Execution/JsonValueFormatter.cs
@@ -53,6 +53,10 @@ public static class JsonValueFormatter
                 writer.WriteStringValue(s);
                 break;
 
+            case sbyte sb:
+                writer.WriteNumberValue(sb);
+                break;
+
             case byte b:
                 writer.WriteNumberValue(b);
                 break;

--- a/src/HotChocolate/Core/test/Execution.Abstractions.Tests/Execution/JsonValueFormatterTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Abstractions.Tests/Execution/JsonValueFormatterTests.cs
@@ -1,0 +1,24 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using HotChocolate.Text.Json;
+
+namespace HotChocolate.Execution;
+
+public class JsonValueFormatterTests
+{
+    [Fact]
+    public void WriteSByteAsNumber()
+    {
+        // arrange
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new JsonWriter(buffer, new JsonWriterOptions { SkipValidation = true });
+
+        // act
+        JsonValueFormatter.WriteValue(writer, (sbyte)2, new JsonSerializerOptions());
+
+        // assert
+        var result = Encoding.UTF8.GetString(buffer.WrittenSpan);
+        Assert.Equal("2", result);
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #9827. That PR added the missing `sbyte` case to StrawberryShake's `JsonSerializationHelper`, but as noted on #9825 that helper is not on the v16 HTTP request path, so `Byte` variables were still serialized as JSON strings.

The `Byte` scalar's runtime type is `sbyte` (`ByteType : IntegerTypeBase<sbyte>`), and the same `byte`-without-`sbyte` gap existed in two more JSON value writers:
- `Utf8JsonWriterHelper` (`HotChocolate.Transport.Abstractions`) — the actual HTTP request path for StrawberryShake, `GraphQLHttpClient`, and Fusion subgraph requests. This is what fixes the reported issue.
- `JsonValueFormatter` (`HotChocolate.Execution.Abstractions`) — reached when a boxed `sbyte` is formatted via `extensions`, `Any`, or raw dictionaries.

Both now emit `sbyte` as a JSON number instead of falling through to string serialization.

## Test plan
- Added `OperationRequestTests.Should_WriteSByteVariableAsNumber` — an `sbyte` variable serializes as `2`, not `"2"`, through `OperationRequest.WriteTo`.
- Added `JsonValueFormatterTests.WriteSByteAsNumber` — `JsonValueFormatter.WriteValue` emits `sbyte` as a number.
- Both confirmed failing before the fix and passing after; `Transport.Http.Tests` (65) and `Execution.Abstractions.Tests` (105) pass on net8.0/net9.0/net10.0.

Closes #9825
