### PR TITLE
Implement message type binding for receive endpoints and enhance error handling

### DIFF
--- a/src/Mocha/examples/PostgresTransport/PostgresTransport.OrderService/Program.cs
+++ b/src/Mocha/examples/PostgresTransport/PostgresTransport.OrderService/Program.cs
@@ -33,9 +33,13 @@ builder
         // Explicit topology for Send pattern demo
         t.DeclareQueue("process-order");
         t.Endpoint("process-order-ep").Queue("process-order").Handler<ProcessOrderCommandHandler>();
-        // Alternative: bind by message type instead of handler type
-        // t.Endpoint("process-order-ep").Queue("process-order").Receives<ProcessOrderCommand>();
         t.DispatchEndpoint("send-demo").ToQueue("process-order").Send<ProcessOrderCommand>();
+
+        // Explicit topology bound by message type instead of handler type. Every handler
+        // registered for OrderShippedEvent is bound to this endpoint via Receives.
+        t.DeclareQueue("ship-order");
+        t.Endpoint("ship-order-ep").Queue("ship-order").Receives<OrderShippedEvent>();
+        t.DispatchEndpoint("ship-demo").ToQueue("ship-order").Send<OrderShippedEvent>();
     });
 
 builder.Services.AddHostedService<OrderSimulatorWorker>();
@@ -85,6 +89,17 @@ app.MapPost(
                 OrderId = orderId,
                 Action = "validate",
                 RequestedAt = DateTimeOffset.UtcNow
+            },
+            ct);
+
+        // Routes to the ship-order-ep endpoint, which binds its handlers via Receives<OrderShippedEvent>().
+        await messageBus.SendAsync(
+            new OrderShippedEvent
+            {
+                OrderId = orderId,
+                TrackingNumber = "TRK-" + orderId.ToString("N")[..8],
+                Carrier = "Demo Express",
+                ShippedAt = DateTimeOffset.UtcNow
             },
             ct);
 

--- a/src/Mocha/examples/PostgresTransport/PostgresTransport.OrderService/Program.cs
+++ b/src/Mocha/examples/PostgresTransport/PostgresTransport.OrderService/Program.cs
@@ -33,6 +33,8 @@ builder
         // Explicit topology for Send pattern demo
         t.DeclareQueue("process-order");
         t.Endpoint("process-order-ep").Queue("process-order").Handler<ProcessOrderCommandHandler>();
+        // Alternative: bind by message type instead of handler type
+        // t.Endpoint("process-order-ep").Queue("process-order").Receives<ProcessOrderCommand>();
         t.DispatchEndpoint("send-demo").ToQueue("process-order").Send<ProcessOrderCommand>();
     });
 

--- a/src/Mocha/src/Mocha.Transport.InMemory/Descriptors/IInMemoryReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.InMemory/Descriptors/IInMemoryReceiveEndpointDescriptor.cs
@@ -19,6 +19,12 @@ public interface IInMemoryReceiveEndpointDescriptor : IReceiveEndpointDescriptor
     new IInMemoryReceiveEndpointDescriptor Consumer<TConsumer>() where TConsumer : class, IConsumer;
 
     /// <inheritdoc />
+    new IInMemoryReceiveEndpointDescriptor Receives<TMessage>();
+
+    /// <inheritdoc />
+    new IInMemoryReceiveEndpointDescriptor Receives(Type messageType);
+
+    /// <inheritdoc />
     new IInMemoryReceiveEndpointDescriptor Kind(ReceiveEndpointKind kind);
 
     /// <inheritdoc />

--- a/src/Mocha/src/Mocha.Transport.InMemory/Descriptors/InMemoryReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.InMemory/Descriptors/InMemoryReceiveEndpointDescriptor.cs
@@ -38,6 +38,20 @@ internal sealed class InMemoryReceiveEndpointDescriptor
         return this;
     }
 
+    public new IInMemoryReceiveEndpointDescriptor Receives<TMessage>()
+    {
+        base.Receives<TMessage>();
+
+        return this;
+    }
+
+    public new IInMemoryReceiveEndpointDescriptor Receives(Type messageType)
+    {
+        base.Receives(messageType);
+
+        return this;
+    }
+
     public new IInMemoryReceiveEndpointDescriptor Kind(ReceiveEndpointKind kind)
     {
         base.Kind(kind);

--- a/src/Mocha/src/Mocha.Transport.Postgres/Descriptors/IPostgresReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.Postgres/Descriptors/IPostgresReceiveEndpointDescriptor.cs
@@ -18,6 +18,12 @@ public interface IPostgresReceiveEndpointDescriptor : IReceiveEndpointDescriptor
     /// <inheritdoc cref="IReceiveEndpointDescriptor{T}.Consumer{TConsumer}"/>
     new IPostgresReceiveEndpointDescriptor Consumer<TConsumer>() where TConsumer : class, IConsumer;
 
+    /// <inheritdoc cref="IReceiveEndpointDescriptor{T}.Receives{TMessage}"/>
+    new IPostgresReceiveEndpointDescriptor Receives<TMessage>();
+
+    /// <inheritdoc cref="IReceiveEndpointDescriptor{T}.Receives(Type)"/>
+    new IPostgresReceiveEndpointDescriptor Receives(Type messageType);
+
     /// <inheritdoc cref="IReceiveEndpointDescriptor{T}.Kind(ReceiveEndpointKind)"/>
     new IPostgresReceiveEndpointDescriptor Kind(ReceiveEndpointKind kind);
 

--- a/src/Mocha/src/Mocha.Transport.Postgres/Descriptors/PostgresReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.Postgres/Descriptors/PostgresReceiveEndpointDescriptor.cs
@@ -43,6 +43,22 @@ internal sealed class PostgresReceiveEndpointDescriptor
     }
 
     /// <inheritdoc />
+    public new IPostgresReceiveEndpointDescriptor Receives<TMessage>()
+    {
+        base.Receives<TMessage>();
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public new IPostgresReceiveEndpointDescriptor Receives(Type messageType)
+    {
+        base.Receives(messageType);
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public new IPostgresReceiveEndpointDescriptor Kind(ReceiveEndpointKind kind)
     {
         base.Kind(kind);

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/IRabbitMQReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/IRabbitMQReceiveEndpointDescriptor.cs
@@ -18,6 +18,12 @@ public interface IRabbitMQReceiveEndpointDescriptor : IReceiveEndpointDescriptor
     /// <inheritdoc cref="IReceiveEndpointDescriptor{TConfiguration}.Consumer{TConsumer}" />
     new IRabbitMQReceiveEndpointDescriptor Consumer<TConsumer>() where TConsumer : class, IConsumer;
 
+    /// <inheritdoc cref="IReceiveEndpointDescriptor{TConfiguration}.Receives{TMessage}" />
+    new IRabbitMQReceiveEndpointDescriptor Receives<TMessage>();
+
+    /// <inheritdoc cref="IReceiveEndpointDescriptor{TConfiguration}.Receives(Type)" />
+    new IRabbitMQReceiveEndpointDescriptor Receives(Type messageType);
+
     /// <inheritdoc cref="IReceiveEndpointDescriptor{TConfiguration}.Kind" />
     new IRabbitMQReceiveEndpointDescriptor Kind(ReceiveEndpointKind kind);
 

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/RabbitMQReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/RabbitMQReceiveEndpointDescriptor.cs
@@ -43,6 +43,22 @@ internal sealed class RabbitMQReceiveEndpointDescriptor
     }
 
     /// <inheritdoc />
+    public new IRabbitMQReceiveEndpointDescriptor Receives<TMessage>()
+    {
+        base.Receives<TMessage>();
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public new IRabbitMQReceiveEndpointDescriptor Receives(Type messageType)
+    {
+        base.Receives(messageType);
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public new IRabbitMQReceiveEndpointDescriptor Kind(ReceiveEndpointKind kind)
     {
         base.Kind(kind);

--- a/src/Mocha/src/Mocha/Endpoints/Configurations/ReceiveEndpointConfiguration.cs
+++ b/src/Mocha/src/Mocha/Endpoints/Configurations/ReceiveEndpointConfiguration.cs
@@ -31,6 +31,11 @@ public class ReceiveEndpointConfiguration : MessagingConfiguration
     public List<Type> ConsumerIdentities { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets the list of message types that this endpoint receives, used to bind all handlers for those types.
+    /// </summary>
+    public List<Type> ReceivedMessageTypes { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets whether this is a temporary (auto-delete) endpoint.
     /// </summary>
     public bool IsTemporary { get; set; }

--- a/src/Mocha/src/Mocha/Endpoints/Descriptors/IReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha/Endpoints/Descriptors/IReceiveEndpointDescriptor.cs
@@ -38,6 +38,20 @@ public interface IReceiveEndpointDescriptor<out TConfiguration>
     IReceiveEndpointDescriptor<TConfiguration> Consumer<TConsumer>() where TConsumer : class, IConsumer;
 
     /// <summary>
+    /// Binds all handlers for the specified message type to this receive endpoint.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type to receive.</typeparam>
+    /// <returns>The descriptor instance for method chaining.</returns>
+    IReceiveEndpointDescriptor<TConfiguration> Receives<TMessage>();
+
+    /// <summary>
+    /// Binds all handlers for the specified message type to this receive endpoint.
+    /// </summary>
+    /// <param name="messageType">The message type to receive.</param>
+    /// <returns>The descriptor instance for method chaining.</returns>
+    IReceiveEndpointDescriptor<TConfiguration> Receives(Type messageType);
+
+    /// <summary>
     /// Sets the kind of this receive endpoint (e.g., default, temporary).
     /// </summary>
     /// <param name="kind">The receive endpoint kind.</param>

--- a/src/Mocha/src/Mocha/Endpoints/Descriptors/ReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha/Endpoints/Descriptors/ReceiveEndpointDescriptor.cs
@@ -44,6 +44,28 @@ public abstract class ReceiveEndpointDescriptor<T>(IMessagingConfigurationContex
         return this;
     }
 
+    /// <summary>
+    /// Binds all handlers for the specified message type to this receive endpoint.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type to receive.</typeparam>
+    /// <returns>The descriptor instance for method chaining.</returns>
+    public IReceiveEndpointDescriptor<T> Receives<TMessage>()
+    {
+        Configuration.ReceivedMessageTypes.Add(typeof(TMessage));
+        return this;
+    }
+
+    /// <summary>
+    /// Binds all handlers for the specified message type to this receive endpoint.
+    /// </summary>
+    /// <param name="messageType">The message type to receive.</param>
+    /// <returns>The descriptor instance for method chaining.</returns>
+    public IReceiveEndpointDescriptor<T> Receives(Type messageType)
+    {
+        Configuration.ReceivedMessageTypes.Add(messageType);
+        return this;
+    }
+
     public IReceiveEndpointDescriptor<T> Kind(ReceiveEndpointKind kind)
     {
         Configuration.Kind = kind;

--- a/src/Mocha/src/Mocha/Endpoints/Descriptors/ReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha/Endpoints/Descriptors/ReceiveEndpointDescriptor.cs
@@ -40,28 +40,22 @@ public abstract class ReceiveEndpointDescriptor<T>(IMessagingConfigurationContex
     /// <returns>The descriptor instance for method chaining.</returns>
     public IReceiveEndpointDescriptor<T> Consumer(Type consumerType)
     {
+        ArgumentNullException.ThrowIfNull(consumerType);
         Configuration.ConsumerIdentities.Add(consumerType);
         return this;
     }
 
-    /// <summary>
-    /// Binds all handlers for the specified message type to this receive endpoint.
-    /// </summary>
-    /// <typeparam name="TMessage">The message type to receive.</typeparam>
-    /// <returns>The descriptor instance for method chaining.</returns>
+    /// <inheritdoc />
     public IReceiveEndpointDescriptor<T> Receives<TMessage>()
     {
         Configuration.ReceivedMessageTypes.Add(typeof(TMessage));
         return this;
     }
 
-    /// <summary>
-    /// Binds all handlers for the specified message type to this receive endpoint.
-    /// </summary>
-    /// <param name="messageType">The message type to receive.</param>
-    /// <returns>The descriptor instance for method chaining.</returns>
+    /// <inheritdoc />
     public IReceiveEndpointDescriptor<T> Receives(Type messageType)
     {
+        ArgumentNullException.ThrowIfNull(messageType);
         Configuration.ReceivedMessageTypes.Add(messageType);
         return this;
     }

--- a/src/Mocha/src/Mocha/ThrowHelper.cs
+++ b/src/Mocha/src/Mocha/ThrowHelper.cs
@@ -30,6 +30,11 @@ internal static class ThrowHelper
     public static Exception RouteNotInitialized()
         => new InvalidOperationException("Route is not initialized");
 
+    public static Exception NoHandlerForMessageType(Type messageType, string? endpointName)
+        => new InvalidOperationException(
+            $"No handler or consumer handles message type '{messageType.FullName}' "
+            + $"declared on receive endpoint '{endpointName}'.");
+
     public static Exception TransportConfigurationMissing()
         => new InvalidOperationException("Could not create configuration for transport");
 

--- a/src/Mocha/src/Mocha/Transport/MessagingTransport.Lifecyle.cs
+++ b/src/Mocha/src/Mocha/Transport/MessagingTransport.Lifecyle.cs
@@ -46,39 +46,31 @@ public abstract partial class MessagingTransport
             //  TODO maybe we should move this to endpoint initialize - not sure yet
             foreach (var handlerType in endpointConfiguration.ConsumerIdentities)
             {
-                var consumer = context.Consumers.FirstOrDefault(h => h.Identity == handlerType);
-
-                if (consumer is not null)
-                {
-                    var routes = context.Router.GetInboundByConsumer(consumer);
-                    var applied = false;
-                    foreach (var route in routes)
-                    {
-                        if (route.Endpoint is null)
-                        {
-                            route.ConnectEndpoint(context, endpoint);
-                            applied = true;
-                        }
-                    }
-
-                    // in this case the user has explicilty mapped this consumer to multiple
-                    // endpoints and we are currently missing an additional route
-                    if (!applied)
-                    {
-                        var route = new InboundRoute();
-                        var configuration = new InboundRouteConfiguration
-                        {
-                            MessageType = route.MessageType,
-                            Consumer = consumer
-                        };
-                        route.Initialize(context, configuration);
-                        route.ConnectEndpoint(context, endpoint);
-                    }
-                }
-                else
-                {
-                    throw new InvalidOperationException(
+                var consumer = context.Consumers.FirstOrDefault(h => h.Identity == handlerType)
+                    ?? throw new InvalidOperationException(
                         $"Handler type {handlerType.FullName} not found for endpoint {Configuration.Name}");
+
+                foreach (var route in context.Router.GetInboundByConsumer(consumer))
+                {
+                    BindRouteToEndpoint(context, route, endpoint);
+                }
+            }
+
+            foreach (var messageRuntimeType in endpointConfiguration.ReceivedMessageTypes)
+            {
+                var matched = context.Router.InboundRoutes
+                    .Where(r => r.Kind is Subscribe or Send or Request
+                                && r.MessageType?.RuntimeType == messageRuntimeType)
+                    .ToList();
+
+                if (matched.Count == 0)
+                {
+                    throw ThrowHelper.NoHandlerForMessageType(messageRuntimeType, endpointConfiguration.Name);
+                }
+
+                foreach (var route in matched)
+                {
+                    BindRouteToEndpoint(context, route, endpoint);
                 }
             }
         }
@@ -128,6 +120,27 @@ public abstract partial class MessagingTransport
         MarkInitialized();
 
         OnAfterInitialized(context);
+    }
+
+    private static void BindRouteToEndpoint(
+        IMessagingSetupContext context, InboundRoute route, ReceiveEndpoint endpoint)
+    {
+        if (route.Endpoint is null)
+        {
+            route.ConnectEndpoint(context, endpoint);
+        }
+        else if (route.Endpoint != endpoint)
+        {
+            var clone = new InboundRoute();
+            clone.Initialize(context, new InboundRouteConfiguration
+            {
+                MessageType = route.MessageType,
+                Consumer = route.Consumer,
+                Kind = route.Kind
+            });
+            clone.ConnectEndpoint(context, endpoint);
+        }
+        // else: already on this endpoint -> idempotent skip
     }
 
     protected virtual void OnBeforeInitialize(IMessagingSetupContext context) { }

--- a/src/Mocha/src/Mocha/Transport/MessagingTransport.Lifecyle.cs
+++ b/src/Mocha/src/Mocha/Transport/MessagingTransport.Lifecyle.cs
@@ -123,7 +123,9 @@ public abstract partial class MessagingTransport
     }
 
     private static void BindRouteToEndpoint(
-        IMessagingSetupContext context, InboundRoute route, ReceiveEndpoint endpoint)
+        IMessagingSetupContext context,
+        InboundRoute route,
+        ReceiveEndpoint endpoint)
     {
         if (route.Endpoint is null)
         {
@@ -139,11 +141,13 @@ public abstract partial class MessagingTransport
         // The route is bound to another endpoint, so fan it out by adding an equivalent route to
         // this endpoint. Skip when an equivalent route is already present so binding the same
         // message type or consumer across three or more endpoints stays idempotent.
+        // Conditions are not part of the equivalence check, so two routes for the same consumer
+        // and message type that differ only by condition will not both be fanned out.
         foreach (var existing in context.Router.GetInboundByEndpoint(endpoint))
         {
             if (existing.Consumer == route.Consumer
                 && existing.Kind == route.Kind
-                && Equals(existing.MessageType, route.MessageType))
+                && existing.MessageType == route.MessageType)
             {
                 return;
             }

--- a/src/Mocha/src/Mocha/Transport/MessagingTransport.Lifecyle.cs
+++ b/src/Mocha/src/Mocha/Transport/MessagingTransport.Lifecyle.cs
@@ -128,19 +128,36 @@ public abstract partial class MessagingTransport
         if (route.Endpoint is null)
         {
             route.ConnectEndpoint(context, endpoint);
+            return;
         }
-        else if (route.Endpoint != endpoint)
+
+        if (route.Endpoint == endpoint)
         {
-            var clone = new InboundRoute();
-            clone.Initialize(context, new InboundRouteConfiguration
-            {
-                MessageType = route.MessageType,
-                Consumer = route.Consumer,
-                Kind = route.Kind
-            });
-            clone.ConnectEndpoint(context, endpoint);
+            return;
         }
-        // else: already on this endpoint -> idempotent skip
+
+        // The route is bound to another endpoint, so fan it out by adding an equivalent route to
+        // this endpoint. Skip when an equivalent route is already present so binding the same
+        // message type or consumer across three or more endpoints stays idempotent.
+        foreach (var existing in context.Router.GetInboundByEndpoint(endpoint))
+        {
+            if (existing.Consumer == route.Consumer
+                && existing.Kind == route.Kind
+                && Equals(existing.MessageType, route.MessageType))
+            {
+                return;
+            }
+        }
+
+        var clone = new InboundRoute();
+        clone.Initialize(context, new InboundRouteConfiguration
+        {
+            MessageType = route.MessageType,
+            Consumer = route.Consumer,
+            Kind = route.Kind,
+            Condition = route.Condition
+        });
+        clone.ConnectEndpoint(context, endpoint);
     }
 
     protected virtual void OnBeforeInitialize(IMessagingSetupContext context) { }

--- a/src/Mocha/test/Mocha.Transport.InMemory.Tests/ReceivesTests.cs
+++ b/src/Mocha/test/Mocha.Transport.InMemory.Tests/ReceivesTests.cs
@@ -1,0 +1,197 @@
+using Microsoft.Extensions.DependencyInjection;
+using Mocha.TestHelpers;
+using Mocha.Transport.InMemory.Tests.Helpers;
+
+namespace Mocha.Transport.InMemory.Tests;
+
+public class ReceivesTests
+{
+    [Fact]
+    public void Receives_Should_BindHandlerToEndpoint_When_MessageTypeDeclared()
+    {
+        // arrange & act
+        var runtime = new ServiceCollection()
+            .AddMessageBus()
+            .AddEventHandler<OrderCreatedHandler>()
+            .AddInMemory(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareQueue("orders");
+                t.Endpoint("orders").Queue("orders")
+                    .Receives<OrderCreated>();
+            })
+            .BuildRuntime();
+        var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
+
+        // assert
+        var endpoint = transport.ReceiveEndpoints
+            .OfType<InMemoryReceiveEndpoint>()
+            .SingleOrDefault(e => e.Name == "orders");
+
+        Assert.NotNull(endpoint);
+        var routes = runtime.Router.InboundRoutes
+            .Where(r => r.MessageType?.RuntimeType == typeof(OrderCreated))
+            .ToList();
+        Assert.All(routes, r => Assert.Equal(endpoint, r.Endpoint));
+    }
+
+    [Fact]
+    public void Receives_Should_BindAllHandlers_When_MultipleHandlersForSameType()
+    {
+        // arrange & act
+        var runtime = new ServiceCollection()
+            .AddMessageBus()
+            .AddEventHandler<OrderCreatedHandler>()
+            .AddEventHandler<OrderCreatedHandler2>()
+            .AddInMemory(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareQueue("orders");
+                t.Endpoint("orders").Queue("orders")
+                    .Receives<OrderCreated>();
+            })
+            .BuildRuntime();
+        var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
+
+        // assert
+        var endpoint = transport.ReceiveEndpoints
+            .OfType<InMemoryReceiveEndpoint>()
+            .Single(e => e.Name == "orders");
+
+        var routes = runtime.Router.InboundRoutes
+            .Where(r => r.MessageType?.RuntimeType == typeof(OrderCreated))
+            .ToList();
+        Assert.Equal(2, routes.Count);
+        Assert.All(routes, r => Assert.Equal(endpoint, r.Endpoint));
+    }
+
+    [Fact]
+    public void Receives_Should_FanOutToBothQueues_When_SameTypeDeclaredOnTwoEndpoints()
+    {
+        // arrange & act
+        var runtime = new ServiceCollection()
+            .AddMessageBus()
+            .AddEventHandler<OrderCreatedHandler>()
+            .AddInMemory(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareQueue("orders-primary");
+                t.DeclareQueue("orders-backup");
+                t.Endpoint("primary").Queue("orders-primary")
+                    .Receives<OrderCreated>();
+                t.Endpoint("backup").Queue("orders-backup")
+                    .Receives<OrderCreated>();
+            })
+            .BuildRuntime();
+        var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
+
+        // assert
+        var primaryEndpoint = transport.ReceiveEndpoints
+            .OfType<InMemoryReceiveEndpoint>()
+            .Single(e => e.Name == "primary");
+        var backupEndpoint = transport.ReceiveEndpoints
+            .OfType<InMemoryReceiveEndpoint>()
+            .Single(e => e.Name == "backup");
+
+        var routes = runtime.Router.InboundRoutes
+            .Where(r => r.MessageType?.RuntimeType == typeof(OrderCreated))
+            .ToList();
+        Assert.Equal(2, routes.Count);
+        Assert.Contains(routes, r => r.Endpoint == primaryEndpoint);
+        Assert.Contains(routes, r => r.Endpoint == backupEndpoint);
+    }
+
+    [Fact]
+    public void Receives_Should_Throw_When_NoHandlerRegistered()
+    {
+        // arrange & act & assert
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new ServiceCollection()
+                .AddMessageBus()
+                .AddInMemory(t =>
+                {
+                    t.BindHandlersExplicitly();
+                    t.DeclareQueue("orders");
+                    t.Endpoint("orders").Queue("orders")
+                        .Receives<OrderCreated>();
+                })
+                .BuildRuntime());
+
+        Assert.Contains("No handler or consumer handles message type", exception.Message);
+        Assert.Contains(typeof(OrderCreated).FullName!, exception.Message);
+        Assert.Contains("orders", exception.Message);
+    }
+
+    [Fact]
+    public void Consumer_Should_BindToBothEndpoints_When_MappedToTwoEndpoints()
+    {
+        // arrange & act
+        var runtime = new ServiceCollection()
+            .AddMessageBus()
+            .AddConsumer<TestOrderConsumer>()
+            .AddInMemory(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareQueue("orders-a");
+                t.DeclareQueue("orders-b");
+                t.Endpoint("endpoint-a").Queue("orders-a")
+                    .Consumer<TestOrderConsumer>();
+                t.Endpoint("endpoint-b").Queue("orders-b")
+                    .Consumer<TestOrderConsumer>();
+            })
+            .BuildRuntime();
+        var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
+
+        // assert
+        var endpointA = transport.ReceiveEndpoints
+            .OfType<InMemoryReceiveEndpoint>()
+            .Single(e => e.Name == "endpoint-a");
+        var endpointB = transport.ReceiveEndpoints
+            .OfType<InMemoryReceiveEndpoint>()
+            .Single(e => e.Name == "endpoint-b");
+
+        var routes = runtime.Router.InboundRoutes
+            .Where(r => r.Consumer?.Identity == typeof(TestOrderConsumer))
+            .ToList();
+        Assert.Equal(2, routes.Count);
+        Assert.Contains(routes, r => r.Endpoint == endpointA);
+        Assert.Contains(routes, r => r.Endpoint == endpointB);
+    }
+
+    [Fact]
+    public async Task Receives_Should_DeliverMessages_When_Published()
+    {
+        // arrange
+        var recorder = new MessageRecorder();
+        var services = new ServiceCollection();
+        services.AddSingleton(recorder);
+        var provider = await services
+            .AddMessageBus()
+            .AddEventHandler<OrderCreatedHandler>()
+            .AddInMemory(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareQueue("orders");
+                t.Endpoint("orders").Queue("orders")
+                    .Receives<OrderCreated>();
+            })
+            .BuildServiceProvider();
+
+        var bus = provider.GetRequiredService<IMessageBus>();
+
+        // act
+        await bus.PublishAsync(new OrderCreated { OrderId = "123" }, CancellationToken.None);
+        var received = await recorder.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // assert
+        Assert.True(received);
+        Assert.Single(recorder.Messages);
+        var message = Assert.IsType<OrderCreated>(recorder.Messages.First());
+        Assert.Equal("123", message.OrderId);
+    }
+}
+
+public sealed class TestOrderConsumer : IConsumer<OrderCreated>
+{
+    public ValueTask ConsumeAsync(IConsumeContext<OrderCreated> context) => default;
+}

--- a/src/Mocha/test/Mocha.Transport.InMemory.Tests/ReceivesTests.cs
+++ b/src/Mocha/test/Mocha.Transport.InMemory.Tests/ReceivesTests.cs
@@ -32,7 +32,8 @@ public class ReceivesTests
         var routes = runtime.Router.InboundRoutes
             .Where(r => r.MessageType?.RuntimeType == typeof(OrderCreated))
             .ToList();
-        Assert.All(routes, r => Assert.Equal(endpoint, r.Endpoint));
+        var route = Assert.Single(routes);
+        Assert.Equal(endpoint, route.Endpoint);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.InMemory.Tests/ReceivesTests.cs
+++ b/src/Mocha/test/Mocha.Transport.InMemory.Tests/ReceivesTests.cs
@@ -189,6 +189,89 @@ public class ReceivesTests
         var message = Assert.IsType<OrderCreated>(recorder.Messages.First());
         Assert.Equal("123", message.OrderId);
     }
+
+    [Fact]
+    public void Receives_Should_NotCreateDuplicateRoutes_When_SameTypeDeclaredOnThreeEndpoints()
+    {
+        // arrange & act
+        var runtime = new ServiceCollection()
+            .AddMessageBus()
+            .AddEventHandler<OrderCreatedHandler>()
+            .AddInMemory(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareQueue("orders-1");
+                t.DeclareQueue("orders-2");
+                t.DeclareQueue("orders-3");
+                t.Endpoint("e1").Queue("orders-1").Receives<OrderCreated>();
+                t.Endpoint("e2").Queue("orders-2").Receives<OrderCreated>();
+                t.Endpoint("e3").Queue("orders-3").Receives<OrderCreated>();
+            })
+            .BuildRuntime();
+
+        // assert
+        var routes = runtime.Router.InboundRoutes
+            .Where(r => r.MessageType?.RuntimeType == typeof(OrderCreated))
+            .ToList();
+        Assert.Equal(3, routes.Count);
+        Assert.Equal(3, routes.Select(r => r.Endpoint).Distinct().Count());
+    }
+
+    [Fact]
+    public void Receives_Should_PreserveCondition_When_FannedOut()
+    {
+        // arrange & act
+        var runtime = new ServiceCollection()
+            .AddMessageBus()
+            .AddEventHandler<OrderCreatedHandler>()
+            .AddInMemory(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareQueue("orders-primary");
+                t.DeclareQueue("orders-backup");
+                t.Endpoint("primary").Queue("orders-primary").Receives<OrderCreated>();
+                t.Endpoint("backup").Queue("orders-backup").Receives<OrderCreated>();
+            })
+            .BuildRuntime();
+
+        // assert
+        var routes = runtime.Router.InboundRoutes
+            .Where(r => r.MessageType?.RuntimeType == typeof(OrderCreated))
+            .ToList();
+        Assert.Equal(2, routes.Count);
+        Assert.Same(routes[0].Condition, routes[1].Condition);
+    }
+
+    [Fact]
+    public async Task Receives_Should_DeliverToBothQueues_When_FannedOut()
+    {
+        // arrange
+        var recorder = new MessageRecorder();
+        var services = new ServiceCollection();
+        services.AddSingleton(recorder);
+        var provider = await services
+            .AddMessageBus()
+            .AddEventHandler<OrderCreatedHandler>()
+            .AddInMemory(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareQueue("orders-primary");
+                t.DeclareQueue("orders-backup");
+                t.Endpoint("primary").Queue("orders-primary").Receives<OrderCreated>();
+                t.Endpoint("backup").Queue("orders-backup").Receives<OrderCreated>();
+            })
+            .BuildServiceProvider();
+
+        var bus = provider.GetRequiredService<IMessageBus>();
+
+        // act
+        await bus.PublishAsync(new OrderCreated { OrderId = "123" }, CancellationToken.None);
+        var received = await recorder.WaitAsync(TimeSpan.FromSeconds(5), expectedCount: 2);
+
+        // assert
+        Assert.True(received);
+        Assert.Equal(2, recorder.Messages.Count);
+    }
 }
 
 public sealed class TestOrderConsumer : IConsumer<OrderCreated>

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/Behaviors/ExplicitTopologyTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/Behaviors/ExplicitTopologyTests.cs
@@ -89,6 +89,44 @@ public class ExplicitTopologyTests
         Assert.Equal("ORD-TOPO", message.OrderId);
     }
 
+    [Fact]
+    public async Task PublishAsync_Should_RouteToQueue_When_ExplicitTopologyDeclared_UsingReceives()
+    {
+        // arrange
+        var capture = new OrderCapture();
+        await using var db = await _fixture.CreateDatabaseAsync();
+        await using var bus = await new ServiceCollection()
+            .AddSingleton(capture)
+            .AddMessageBus()
+            .AddConsumer<OrderSpyConsumer>()
+            .AddPostgres(t =>
+            {
+                t.ConnectionString(db.ConnectionString);
+                t.BindHandlersExplicitly();
+                t.DeclareTopic("custom-topic");
+                t.DeclareQueue("custom-q");
+                t.DeclareSubscription("custom-topic", "custom-q");
+
+                t.Endpoint("custom-ep").Queue("custom-q")
+                    .Receives<OrderCreated>();
+
+                t.DispatchEndpoint("custom-dispatch").ToTopic("custom-topic").Publish<OrderCreated>();
+            })
+            .BuildTestBusAsync();
+
+        using var scope = bus.Provider.CreateScope();
+        var messageBus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+
+        // act
+        await messageBus.PublishAsync(new OrderCreated { OrderId = "ORD-RCV" }, CancellationToken.None);
+
+        // assert
+        Assert.True(await capture.WaitAsync(s_timeout), "Consumer on custom-q did not receive the published message");
+
+        var message = Assert.Single(capture.Messages);
+        Assert.Equal("ORD-RCV", message.OrderId);
+    }
+
     public sealed class OrderCapture
     {
         private readonly SemaphoreSlim _semaphore = new(0);

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Behaviors/ExplicitTopologyTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Behaviors/ExplicitTopologyTests.cs
@@ -89,6 +89,44 @@ public class ExplicitTopologyTests
         Assert.Equal("ORD-TOPO", message.OrderId);
     }
 
+    [Fact]
+    public async Task PublishAsync_Should_RouteToQueue_When_ExplicitTopologyDeclared_UsingReceives()
+    {
+        // arrange
+        var capture = new OrderCapture();
+        await using var vhost = await _fixture.CreateVhostAsync();
+        await using var bus = await new ServiceCollection()
+            .AddSingleton(vhost.ConnectionFactory)
+            .AddSingleton(capture)
+            .AddMessageBus()
+            .AddConsumer<OrderSpyConsumer>()
+            .AddRabbitMQ(t =>
+            {
+                t.BindHandlersExplicitly();
+                t.DeclareExchange("custom-ex");
+                t.DeclareQueue("custom-q");
+                t.DeclareBinding("custom-ex", "custom-q");
+
+                t.Endpoint("custom-ep").Queue("custom-q")
+                    .Receives<OrderCreated>();
+
+                t.DispatchEndpoint("custom-dispatch").ToExchange("custom-ex").Publish<OrderCreated>();
+            })
+            .BuildTestBusAsync();
+
+        using var scope = bus.Provider.CreateScope();
+        var messageBus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+
+        // act
+        await messageBus.PublishAsync(new OrderCreated { OrderId = "ORD-RCV" }, CancellationToken.None);
+
+        // assert
+        Assert.True(await capture.WaitAsync(s_timeout), "Consumer on custom-q did not receive the published message");
+
+        var message = Assert.Single(capture.Messages);
+        Assert.Equal("ORD-RCV", message.OrderId);
+    }
+
     public sealed class OrderCapture
     {
         private readonly SemaphoreSlim _semaphore = new(0);

--- a/website-next/content/docs/mocha/routing-and-endpoints.md
+++ b/website-next/content/docs/mocha/routing-and-endpoints.md
@@ -306,6 +306,36 @@ builder.Services
 
 Both handlers now consume from the same `combined-orders` queue. Without explicit binding, they would each get their own endpoint.
 
+### Binding by message type
+
+You can also bind handlers to an endpoint by declaring which message types the endpoint receives. This connects all handlers for that message type to the endpoint:
+
+```csharp
+builder.Services
+    .AddMessageBus()
+    .AddEventHandler<OrderPlacedHandler>()
+    .AddEventHandler<OrderAuditHandler>()
+    .AddRabbitMQ(transport =>
+    {
+        transport.BindHandlersExplicitly();
+
+        transport.Endpoint("all-orders")
+            .Receives<OrderPlaced>();
+    });
+```
+
+Both `OrderPlacedHandler` and `OrderAuditHandler` now receive from the `all-orders` endpoint. This is topology-first design: you declare what messages an endpoint handles, and Mocha wires up all registered handlers.
+
+Use `.Handler<T>()` when you know which handler types to bind. Use `.Receives<T>()` when you care about the message type and want all handlers for that type automatically connected. The same endpoint can use both approaches:
+
+```csharp
+transport.Endpoint("orders")
+    .Receives<OrderPlaced>()
+    .Handler<OrderAuditHandler>();
+```
+
+If a message type is declared with `.Receives<T>()` but no handler is registered, Mocha throws an exception at startup.
+
 ## Named endpoints vs. handler claims
 
 You can configure per-endpoint settings in two ways: through a named endpoint, or through `transport.Handler<T>()` which derives the endpoint name from conventions.


### PR DESCRIPTION
- Added `Receives<TMessage>()` and `Receives(Type messageType)` methods to endpoint descriptors for binding handlers by message type.
- Updated `MessagingTransport` to utilize the new binding methods and throw exceptions when no handler is registered for a message type.
- Introduced tests to validate the new binding behavior and error handling.
- Updated documentation to reflect the new binding approach for message types.
