### PR TITLE
Bump `codecov/codecov-action` from v5 to v7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
           pattern: coverage-*
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         timeout-minutes: 10
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -124,7 +124,7 @@ jobs:
           pattern: coverage-*
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         timeout-minutes: 10
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump the SHA-pinned `codecov/codecov-action` from v5 to v7.0.0 in both [ci.yml](https://github.com/ChilliCream/graphql-platform/blob/main/.github/workflows/ci.yml) and [coverage.yml](https://github.com/ChilliCream/graphql-platform/blob/main/.github/workflows/coverage.yml), keeping the digest pin (`fb8b3582c8e4def4969c97caa2f19720cb33a72f`).

## Test plan
- Coverage upload step runs as part of the existing CI/coverage workflows; no behavioral change beyond the action version.
