### PR TITLE
Fix QueryContext selector dropping fields under variable @include/@skip

### DIFF
--- a/src/HotChocolate/Core/src/Execution.Projections/Extensions/HotChocolateExecutionSelectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution.Projections/Extensions/HotChocolateExecutionSelectionExtensions.cs
@@ -78,16 +78,22 @@ public static class HotChocolateExecutionSelectionExtensions
         this Selection selection,
         ulong includeFlags)
     {
-        var isConditional = selection.IsConditional;
-
         // we first check if we already have an expression for this selection,
-        // this would be the cheapest way to get the expression.
-        if (!isConditional && TryGetExpression<TValue>(selection, out var expression))
+        // this would be the cheapest way to get the expression. A cached expression is
+        // only ever stored when the projected selection set (at any depth) contained no
+        // conditional (@include/@skip) selection, so it is independent of the runtime
+        // include flags and always safe to reuse here.
+        if (TryGetExpression<TValue>(selection, out var expression))
         {
             return expression;
         }
 
-        // if we do not have an expression we need to create one.
+        // we do not know up front whether the projection depends on the runtime include
+        // flags (a conditional selection can sit arbitrarily deep in the selection set),
+        // so we build the expression while tracking whether any conditional selection
+        // participated and only cache the result when none did.
+        var tracker = new SelectionExpressionBuilder.ConditionalTracker();
+
         // we first check what kind of field selection we have,
         // connection, collection or single field.
         var flags = selection.Field.Flags;
@@ -99,15 +105,10 @@ public static class HotChocolateExecutionSelectionExtensions
             var count = GetConnectionSelections(selection, buffer);
             for (var i = 0; i < count; i++)
             {
-                builder.Add(
-                    isConditional
-                        ? buffer[i].GetExpression<TValue>(includeFlags)
-                        : buffer[i].GetOrCreateExpression<TValue>());
+                builder.Add(buffer[i].BuildExpression<TValue>(includeFlags, tracker));
             }
             ArrayPool<Selection>.Shared.Return(buffer);
-            return isConditional
-                ? selection.GetExpression<TValue>(builder)
-                : selection.GetOrCreateExpression<TValue>(builder);
+            return selection.CacheIfStable(builder.TryCompile<TValue>()!, tracker);
         }
 
         if ((flags & CoreFieldFlags.CollectionSegment) == CoreFieldFlags.CollectionSegment)
@@ -117,28 +118,19 @@ public static class HotChocolateExecutionSelectionExtensions
             var count = GetCollectionSelections(selection, buffer);
             for (var i = 0; i < count; i++)
             {
-                builder.Add(
-                    isConditional
-                        ? buffer[i].GetExpression<TValue>(includeFlags)
-                        : buffer[i].GetOrCreateExpression<TValue>());
+                builder.Add(buffer[i].BuildExpression<TValue>(includeFlags, tracker));
             }
             ArrayPool<Selection>.Shared.Return(buffer);
-            return isConditional
-                ? selection.GetExpression<TValue>(builder)
-                : selection.GetOrCreateExpression<TValue>(builder);
+            return selection.CacheIfStable(builder.TryCompile<TValue>()!, tracker);
         }
 
         if ((flags & CoreFieldFlags.GlobalIdNodeField) == CoreFieldFlags.GlobalIdNodeField
             || (flags & CoreFieldFlags.GlobalIdNodesField) == CoreFieldFlags.GlobalIdNodesField)
         {
-            return isConditional
-                ? selection.GetNodeExpression<TValue>(includeFlags)
-                : selection.GetOrCreateNodeExpression<TValue>();
+            return selection.CacheIfStable(selection.BuildNodeExpression<TValue>(includeFlags, tracker), tracker);
         }
 
-        return isConditional
-            ? selection.GetExpression<TValue>(includeFlags)
-            : selection.GetOrCreateExpression<TValue>();
+        return selection.CacheIfStable(selection.BuildExpression<TValue>(includeFlags, tracker), tracker);
     }
 
     private static bool TryGetExpression<TValue>(
@@ -215,22 +207,24 @@ file static class Extensions
 
     extension(Selection selection)
     {
-        public Expression<Func<TValue, TValue>> GetOrCreateExpression<TValue>()
-            => selection.Features.GetOrSetSafe(() => s_builder.BuildExpression<TValue>(selection));
+        public Expression<Func<TValue, TValue>> BuildExpression<TValue>(
+            ulong includeFlags,
+            SelectionExpressionBuilder.ConditionalTracker tracker)
+            => s_builder.BuildExpression<TValue>(selection, includeFlags, tracker);
 
-        public Expression<Func<TValue, TValue>> GetExpression<TValue>(ulong includeFlags)
-            => s_builder.BuildExpression<TValue>(selection, includeFlags);
+        public Expression<Func<TValue, TValue>> BuildNodeExpression<TValue>(
+            ulong includeFlags,
+            SelectionExpressionBuilder.ConditionalTracker tracker)
+            => s_builder.BuildNodeExpression<TValue>(selection, includeFlags, tracker);
 
-        public Expression<Func<TValue, TValue>> GetOrCreateExpression<TValue>(ISelectorBuilder expressionBuilder)
-            => selection.Features.GetOrSetSafe(() => expressionBuilder.TryCompile<TValue>()!);
-
-        public Expression<Func<TValue, TValue>> GetExpression<TValue>(ISelectorBuilder expressionBuilder)
-            => expressionBuilder.TryCompile<TValue>()!;
-
-        public Expression<Func<TValue, TValue>> GetOrCreateNodeExpression<TValue>()
-            => selection.Features.GetOrSetSafe(() => s_builder.BuildNodeExpression<TValue>(selection));
-
-        public Expression<Func<TValue, TValue>> GetNodeExpression<TValue>(ulong includeFlags)
-            => s_builder.BuildNodeExpression<TValue>(selection, includeFlags);
+        // Cache the built expression for reuse only when it does not depend on the runtime
+        // include flags (i.e. no conditional @include/@skip selection participated). A
+        // conditional projection must be rebuilt per request from the current flags.
+        public Expression<Func<TValue, TValue>> CacheIfStable<TValue>(
+            Expression<Func<TValue, TValue>> expression,
+            SelectionExpressionBuilder.ConditionalTracker tracker)
+            => tracker.IsConditional
+                ? expression
+                : selection.Features.GetOrSetSafe(() => expression);
     }
 }

--- a/src/HotChocolate/Core/src/Execution.Projections/SelectionExpressionBuilder.cs
+++ b/src/HotChocolate/Core/src/Execution.Projections/SelectionExpressionBuilder.cs
@@ -53,12 +53,13 @@ internal sealed class SelectionExpressionBuilder
 
     public Expression<Func<TRoot, TRoot>> BuildExpression<TRoot>(
         Selection selection,
-        ulong includeFlags = 0)
+        ulong includeFlags = 0,
+        ConditionalTracker? tracker = null)
     {
         var rootType = typeof(TRoot);
         var parameter = Expression.Parameter(rootType, "root");
         var requirements = selection.DeclaringOperation.Schema.Features.GetRequired<FieldRequirementsMetadata>();
-        var context = new Context(parameter, rootType, requirements, new NullabilityInfoContext(), includeFlags);
+        var context = new Context(parameter, rootType, requirements, new NullabilityInfoContext(), includeFlags, tracker);
         var root = new TypeContainer();
 
         CollectTypes(context, selection, root);
@@ -75,12 +76,13 @@ internal sealed class SelectionExpressionBuilder
 
     public Expression<Func<TRoot, TRoot>> BuildNodeExpression<TRoot>(
         Selection selection,
-        ulong includeFlags = 0)
+        ulong includeFlags = 0,
+        ConditionalTracker? tracker = null)
     {
         var rootType = typeof(TRoot);
         var parameter = Expression.Parameter(rootType, "root");
         var requirements = selection.DeclaringOperation.Schema.Features.GetRequired<FieldRequirementsMetadata>();
-        var context = new Context(parameter, rootType, requirements, new NullabilityInfoContext(), includeFlags);
+        var context = new Context(parameter, rootType, requirements, new NullabilityInfoContext(), includeFlags, tracker);
         var root = new TypeContainer();
 
         var entityType = selection.DeclaringOperation
@@ -380,6 +382,15 @@ internal sealed class SelectionExpressionBuilder
     {
         foreach (var selection in selectionSet.Selections)
         {
+            // A conditional selection (@include/@skip) makes the resulting projection
+            // dependent on the runtime include flags, regardless of whether it ends up
+            // included or skipped for the current flags. Record this so the caller knows
+            // the built expression must not be cached and reused across requests.
+            if (selection.IsConditional)
+            {
+                context.Tracker?.MarkConditional();
+            }
+
             if (!selection.IsIncluded(context.IncludeFlags))
             {
                 continue;
@@ -619,12 +630,25 @@ internal sealed class SelectionExpressionBuilder
         return nullabilityInfo.WriteState == NullabilityState.Nullable;
     }
 
+    /// <summary>
+    /// Tracks whether a conditional (@include/@skip) selection participated while
+    /// building a selector expression. When it did, the resulting expression depends
+    /// on the request's runtime include flags and must not be cached for reuse.
+    /// </summary>
+    public sealed class ConditionalTracker
+    {
+        public bool IsConditional { get; private set; }
+
+        public void MarkConditional() => IsConditional = true;
+    }
+
     private readonly record struct Context(
         Expression Parent,
         Type ParentType,
         FieldRequirementsMetadata Requirements,
         NullabilityInfoContext NullabilityInfoContext,
-        ulong IncludeFlags)
+        ulong IncludeFlags,
+        ConditionalTracker? Tracker)
     {
         public TypeNode? GetRequirements(Selection selection)
         {

--- a/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
@@ -1101,6 +1101,42 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
     }
 
     [Fact]
+    public async Task QueryContext_Selector_Projects_Field_When_Variable_Include_Is_True()
+    {
+        // arrange
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddFiltering()
+            .AddSorting()
+            .AddProjections()
+            .AddQueryType<AsPredicateQuery>()
+            .BuildRequestExecutorAsync();
+
+        const string query =
+            """
+            query Test($withName: Boolean!) {
+                authorsData {
+                    name @include(if: $withName)
+                }
+            }
+            """;
+
+        // act
+        var result = await executor.ExecuteAsync(
+            OperationRequestBuilder.New()
+                .SetDocument(query)
+                .SetVariableValues(new Dictionary<string, object?> { ["withName"] = true })
+                .Build());
+
+        // assert
+        // A field included via a *variable* @include(if: $withName) must be projected and
+        // returned, just like a literal @include(if: true). Regression guard for #9880.
+        var operationResult = result.ExpectOperationResult();
+        Assert.True(operationResult.Errors is null or { Count: 0 });
+        Assert.Contains("Author1", operationResult.ToJson());
+    }
+
+    [Fact]
     public async Task QueryContext_Selector_Projects_Nested_Fields_When_Static_Include_Is_True()
     {
         // arrange


### PR DESCRIPTION
Fixes #9880.

## Problem

The `QueryContext<T>` selector drops a field from the projection when that field is gated by a **variable** `@include(if: $var)` / `@skip(if: $var)` directive — regardless of the variable's runtime value. The field is present in the response shape but comes back as the CLR default (`null`, `0`, empty array, …).

`@include`/`@skip` with **literal** boolean values work correctly (fixed in #9135); only the variable form is affected. Since clients such as Apollo almost always emit `@include(if: $someVar)` rather than a literal, real-world queries consistently hit this.

```graphql
query ($v: Boolean!) {       # $v = true
  items { id name @include(if: $v) }
}
# name is null, even though the source row has a value
```

Minimal reproduction: https://github.com/lemol/hotchocolate-querycontext-variable-include-repro

## Root cause

`HotChocolateExecutionSelectionExtensions.AsSelector` decided whether to bypass the cached selector and apply the runtime include flags based on `selection.IsConditional` — i.e. whether the **projected field itself** carries a directive. In practice the directive sits on a **child** field, so the projected field is never conditional, the cached `includeFlags = 0` expression is reused, and `CollectSelections` excludes the conditional child via `IsIncluded(0)`.

The `..._Respects_Variable_Include_Directive_Across_Requests` test added in #9135 used empty data for the `withName = true` case, so the dropped field never surfaced.

## Fix

Track whether any conditional selection participates while building the selector (`ConditionalTracker`, threaded through `SelectionExpressionBuilder` and marked in `CollectSelections`), and cache the built expression **only when none did**. Cached selectors therefore stay independent of the runtime include flags and are always safe to reuse; conditional projections are rebuilt per request from the current flags.

This is correct at any nesting depth (the tracker is marked wherever a conditional selection is collected in the subtree) and preserves caching for non-conditional operations.

## Tests

Adds `QueryContext_Selector_Projects_Field_When_Variable_Include_Is_True`, which selects a field via `@include(if: $withName)` with `$withName = true` over real data and asserts the field is projected and returned. It fails on `main` and passes with this change. The existing `QueryContext_Selector_*` tests and the full `HotChocolate.Data.Tests` suite continue to pass.
