### PR TITLE
Fix `Optional<T>` argument binding in source generator

### DIFF
--- a/src/HotChocolate/Core/src/Types.Analyzers/FileBuilders/TypeFileBuilderBase.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/FileBuilders/TypeFileBuilderBase.cs
@@ -1406,6 +1406,20 @@ public abstract class TypeFileBuilderBase(StringBuilder sb)
                 continue;
             }
 
+            // Optional<T> arguments bind through ArgumentOptional<T>, which coerces the inner T
+            // and preserves whether the argument was supplied. This mirrors the reflection-based
+            // binding in ArgumentParameterExpressionBuilder.
+            if (parameter.Kind is ResolverParameterKind.Argument or ResolverParameterKind.Unknown
+                && parameter.Type.IsOptional(out var optionalInnerType))
+            {
+                Writer.WriteIndentedLine(
+                    "var args{0} = context.ArgumentOptional<{1}>(\"{2}\");",
+                    i,
+                    ToFullyQualifiedString(optionalInnerType, resolverMethod, typeLookup),
+                    parameter.Key ?? parameter.Name);
+                continue;
+            }
+
             switch (parameter.Kind)
             {
                 case ResolverParameterKind.Parent:

--- a/src/HotChocolate/Core/src/Types.Analyzers/Helpers/SymbolExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Helpers/SymbolExtensions.cs
@@ -783,6 +783,19 @@ public static class SymbolExtensions
     public static bool IsSelection(this IParameterSymbol parameter)
         => parameter.Type.ToDisplayString() == WellKnownTypes.ISelection;
 
+    public static bool IsOptional(this ITypeSymbol type, [NotNullWhen(true)] out ITypeSymbol? innerType)
+    {
+        if (type is INamedTypeSymbol { IsGenericType: true, TypeArguments.Length: 1 } namedType
+            && namedType.ToDisplayString().StartsWith(WellKnownTypes.OptionalGeneric, StringComparison.Ordinal))
+        {
+            innerType = namedType.TypeArguments[0];
+            return true;
+        }
+
+        innerType = null;
+        return false;
+    }
+
     public static bool IsIsSelected(this IParameterSymbol parameter)
     {
         foreach (var attribute in parameter.GetAttributes())

--- a/src/HotChocolate/Core/src/Types.Analyzers/WellKnownTypes.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/WellKnownTypes.cs
@@ -33,6 +33,8 @@ public static class WellKnownTypes
     public const string FieldResolverDelegate = "HotChocolate.Resolvers.FieldResolverDelegate";
     public const string ResolverContext = "HotChocolate.Resolvers.IResolverContext";
     public const string ParameterBinding = "HotChocolate.Internal.IParameterBinding";
+    public const string Optional = "HotChocolate.Optional";
+    public const string OptionalGeneric = Optional + "<";
     public const string MemoryMarshal = "System.Runtime.InteropServices.MemoryMarshal";
     public const string Unsafe = "System.Runtime.CompilerServices.Unsafe";
     public const string Object = "System.Object";

--- a/src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests/IntegrationTests.cs
@@ -197,4 +197,56 @@ public class IntegrationTests
         Assert.DoesNotContain("\"errors\"", json);
         Assert.Matches("\"title\": \"[0-9a-f]{32}\"", json);
     }
+
+    [Fact]
+    public async Task Resolves_Optional_Argument_That_Has_A_Value()
+    {
+        // arrange
+        var executor = await new ServiceCollection()
+            .AddGraphQLServer()
+            .AddIntegrationTestTypes()
+            .AddPagingArguments()
+            .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // act
+        var result = await executor.ExecuteAsync(
+            """mutation { setOptionalValue(value: "abc") }""",
+            TestContext.Current.CancellationToken);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "setOptionalValue": "abc"
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Resolves_Optional_Argument_That_Has_No_Value()
+    {
+        // arrange
+        var executor = await new ServiceCollection()
+            .AddGraphQLServer()
+            .AddIntegrationTestTypes()
+            .AddPagingArguments()
+            .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // act
+        var result = await executor.ExecuteAsync(
+            "mutation { setOptionalValue }",
+            TestContext.Current.CancellationToken);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "setOptionalValue": "unset"
+              }
+            }
+            """);
+    }
 }

--- a/src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests/Types.cs
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests/Types.cs
@@ -128,6 +128,11 @@ public class Shape
 public static partial class Mutation
 {
     public static bool SaveShapes(IReadOnlyList<Shape> shapes) => true;
+
+    // An Optional<T> parameter is bound through the runtime parameter binding,
+    // which must coerce the inner type and honor whether the argument was provided.
+    public static string SetOptionalValue(Optional<string?> value)
+        => value.HasValue ? value.Value ?? "null" : "unset";
 }
 
 public class IsSelectedNode

--- a/src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests/__snapshots__/IntegrationTests.Schema_Snapshot.snap
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests/__snapshots__/IntegrationTests.Schema_Snapshot.snap
@@ -153,6 +153,7 @@ type Query {
 
 type Mutation {
   saveShapes(shapes: [ShapeInput!]!): Boolean!
+  setOptionalValue(value: String): String!
 }
 
 type Subscription {

--- a/src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests/__snapshots__/IntegrationTests.Schema_Snapshot_Without_ConnectionName_Inference.snap
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests/__snapshots__/IntegrationTests.Schema_Snapshot_Without_ConnectionName_Inference.snap
@@ -104,6 +104,7 @@ type Query {
 
 type Mutation {
   saveShapes(shapes: [ShapeInput!]!): Boolean!
+  setOptionalValue(value: String): String!
 }
 
 type Subscription {


### PR DESCRIPTION
## Summary
- Source-generated resolvers bound `Optional<T>` arguments via `ArgumentValue<Optional<T>>`, which tries to coerce the literal into the `Optional<T>` wrapper and fails with "Unable to convert the value of the argument". The reflection-based binding already routes `Optional<T>` to `ArgumentOptional<T>`; the generator now does the same, coercing the inner `T` and preserving whether the argument was supplied.
- AOT-safe: the inner type is known at generation time, so no runtime reflection is introduced into the source-gen path.

## Test plan
- Added integration tests executing a mutation with an `Optional<string?>` argument, covering both a supplied value and an omitted value (`HasValue == false`). Both failed with the reported error before the change and pass after.
- `dotnet test src/HotChocolate/Core/test/Types.Analyzers.Integration.Tests` (17/17) and `Types.Analyzers.Tests` snapshot suite (330/330) pass; updated two schema snapshots for the new test field.

Closes #9866
