### PR TITLE
Fix UseProjection over-projecting when the entity is a record

### DIFF
--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionScopeExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionScopeExtensions.cs
@@ -79,7 +79,17 @@ public static class QueryableProjectionScopeExtensions
     private static bool ShouldReuseExistingInstance(Type type)
         => type.GetConstructor(Type.EmptyTypes) is not null
             && type.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
-                .Any(t => t.GetParameters().Length > 0);
+                .Any(t =>
+                    t.GetParameters().Length > 0
+                    && !IsRecordCopyConstructor(t, type));
+
+    private static bool IsRecordCopyConstructor(ConstructorInfo constructor, Type declaringType)
+    {
+        var parameters = constructor.GetParameters();
+
+        return parameters.Length == 1
+            && parameters[0].ParameterType == declaringType;
+    }
 
     public static Expression CreateMemberInitLambda(this QueryableProjectionScope scope)
         => Expression.Lambda(scope.CreateMemberInit(), scope.Parameter);

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Tests/IntegrationTests.cs
@@ -752,6 +752,58 @@ public class IntegrationTests : IClassFixture<AuthorFixture>
         }
     }
 
+    [Fact]
+    public async Task UseProjection_Should_Project_Only_Selected_Columns_When_Entity_Is_Record()
+    {
+        // arrange
+        var fileName = Guid.NewGuid().ToString("N") + ".db";
+        var connectionString = "Data Source=" + fileName;
+        var sql = new List<string>();
+
+        try
+        {
+            await using (var seed = new RecordProjectionDbContext(
+                new DbContextOptionsBuilder<RecordProjectionDbContext>()
+                    .UseSqlite(connectionString)
+                    .Options))
+            {
+                await seed.Database.EnsureCreatedAsync(Xunit.TestContext.Current.CancellationToken);
+                seed.Products.Add(
+                    new RecordProjectionProduct { Id = 1, Name = "Product", Description = "Description" });
+                await seed.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+            }
+
+            var executor = await new ServiceCollection()
+                .AddDbContext<RecordProjectionDbContext>(
+                    b => b
+                        .UseSqlite(connectionString)
+                        .AddInterceptors(new SqlCapturingInterceptor(sql)))
+                .AddGraphQL()
+                .AddProjections()
+                .AddQueryType<RecordProjectionQuery>()
+                .BuildRequestExecutorAsync(cancellationToken: Xunit.TestContext.Current.CancellationToken);
+
+            // act
+            var result = await executor.ExecuteAsync(
+                "{ products { id } }",
+                Xunit.TestContext.Current.CancellationToken);
+
+            // assert
+            var operationResult = result.ExpectOperationResult();
+            Assert.Empty(operationResult.Errors);
+            string.Join("\n", sql).MatchInlineSnapshot(
+                """
+                SELECT "p"."Id"
+                FROM "Products" AS "p"
+                """);
+        }
+        finally
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            File.Delete(fileName);
+        }
+    }
+
     public class ConstructorInjectionQuery
     {
         [UseProjection]
@@ -804,6 +856,29 @@ public class IntegrationTests : IClassFixture<AuthorFixture>
         public int Id { get; set; }
 
         public int BlogId { get; set; }
+    }
+
+    public class RecordProjectionQuery
+    {
+        [UseProjection]
+        public IQueryable<RecordProjectionProduct> GetProducts(RecordProjectionDbContext context)
+            => context.Products;
+    }
+
+    public class RecordProjectionDbContext(
+        DbContextOptions<RecordProjectionDbContext> options)
+        : DbContext(options)
+    {
+        public DbSet<RecordProjectionProduct> Products => Set<RecordProjectionProduct>();
+    }
+
+    public record RecordProjectionProduct
+    {
+        public required int Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required string Description { get; init; }
     }
 
     public class SingleOrDefaultUser

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionComplexTypeTests.Create_Complex_Type.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionComplexTypeTests.Create_Complex_Type.snap
@@ -20,6 +20,6 @@ Result:
 
 SQL:
 ---------------
-SELECT "d"."Bar_Baz"
+SELECT "d"."Bar_Baz" AS "Baz"
 FROM "Data" AS "d"
 ---------------


### PR DESCRIPTION
## Summary

- `UseProjection` projected every mapped column when the entity type was a non-positional C# record, ignoring the GraphQL selection set.
- The instance-reuse heuristic added for EF constructor service injection treated the compiler-generated record copy constructor (`protected R(R original)`) as an injection constructor, turning the selector into an identity expression.
- `ShouldReuseExistingInstance` in `QueryableProjectionScopeExtensions` now excludes record copy constructors, mirroring the equivalent fix already made for `QueryContext` selectors in #9459.

## Test plan

- New regression test asserts the generated SQL selects only the requested column for a record entity (failed with `SELECT "p"."Id", "p"."Description", "p"."Name"` before the fix, now `SELECT "p"."Id"`).
- Data.EntityFramework.Tests, Data.Projections.Tests, and Data.Tests all pass, including the EF constructor-injection tests the heuristic was introduced for.

Closes #9886
