### PR TITLE
Add directives on directive definitions to the Language layer

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -205,6 +205,7 @@ rearchitected
 reencode
 refetched
 relayjs
+reparsed
 repaste
 replit
 reprojected

--- a/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SchemaDebugFormatter.cs
+++ b/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SchemaDebugFormatter.cs
@@ -75,6 +75,7 @@ public static class SchemaDebugFormatter
                 : new StringValueNode(directiveDefinition.Description),
             directiveDefinition.IsRepeatable,
             directiveDefinition.Arguments.Select(Format).ToArray(),
+            [],
             DirectiveLocationUtils.AsEnumerable(directiveDefinition.Locations).Select(Format).ToArray());
 
     public static FieldDefinitionNode Format(IOutputFieldDefinition field)

--- a/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SchemaFormatter.cs
+++ b/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SchemaFormatter.cs
@@ -495,6 +495,7 @@ public static class SchemaFormatter
                     CreateDescription(mutableDirective.Description),
                     mutableDirective.IsRepeatable,
                     arguments,
+                    [],
                     mutableDirective.Locations.ToNameNodes());
         }
 

--- a/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SemanticNonNullSchemaRewriter.cs
+++ b/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SemanticNonNullSchemaRewriter.cs
@@ -347,6 +347,7 @@ internal static class SemanticNonNullSchemaRewriter
             description: null,
             isRepeatable: false,
             arguments: new[] { argument },
+            directives: [],
             locations: new[] { new NameNode("FIELD_DEFINITION") });
     }
 }

--- a/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/CompositeSchemaBuilder.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/CompositeSchemaBuilder.cs
@@ -162,6 +162,7 @@ internal static class CompositeSchemaBuilder
                         null,
                         [])
                 },
+                [],
                 new HotChocolate.Language.NameNode[] { new("INLINE_FRAGMENT"), new("FRAGMENT_SPREAD") });
 
             directiveTypes.Add(CreateDirectiveType(deferDirectiveNode));

--- a/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/CompositeSchemaContext.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/CompositeSchemaContext.cs
@@ -296,6 +296,7 @@ internal sealed class CompositeSchemaBuilderContext : ICompositeSchemaBuilderCon
                     null,
                     [])
             ],
+            [],
             [
                 new NameNode(HotChocolate.Language.DirectiveLocation.Field.Value),
                 new NameNode(HotChocolate.Language.DirectiveLocation.FragmentSpread.Value),
@@ -339,6 +340,7 @@ internal sealed class CompositeSchemaBuilderContext : ICompositeSchemaBuilderCon
                     null,
                     Array.Empty<DirectiveNode>())
             ],
+            [],
             [
                 new NameNode(HotChocolate.Language.DirectiveLocation.Field.Value),
                 new NameNode(HotChocolate.Language.DirectiveLocation.FragmentSpread.Value),
@@ -382,6 +384,7 @@ internal sealed class CompositeSchemaBuilderContext : ICompositeSchemaBuilderCon
                     null,
                     Array.Empty<DirectiveNode>())
             ],
+            [],
             [
                 new NameNode(HotChocolate.Language.DirectiveLocation.Scalar.Value)
             ]);
@@ -405,6 +408,7 @@ internal sealed class CompositeSchemaBuilderContext : ICompositeSchemaBuilderCon
             new NameNode(DirectiveNames.OneOf.Name),
             new StringValueNode("The `@oneOf` directive is used within the type system definition language to indicate that an Input Object is a OneOf Input Object."),
             isRepeatable: false,
+            [],
             [],
             [
                 new NameNode(HotChocolate.Language.DirectiveLocation.InputObject.Value)

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/DirectiveDefinitionNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/DirectiveDefinitionNode.cs
@@ -28,6 +28,9 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     /// <param name="arguments">
     /// The arguments of the directive-
     /// </param>
+    /// <param name="directives">
+    /// The directives that are annotated to this directive definition.
+    /// </param>
     /// <param name="locations">
     /// The locations to which the directive can be annotated.
     /// </param>
@@ -37,6 +40,7 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
         StringValueNode? description,
         bool isRepeatable,
         IReadOnlyList<InputValueDefinitionNode> arguments,
+        IReadOnlyList<DirectiveNode> directives,
         IReadOnlyList<NameNode> locations)
     {
         Location = location;
@@ -44,6 +48,7 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
         Description = description;
         IsRepeatable = isRepeatable;
         Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        Directives = directives ?? throw new ArgumentNullException(nameof(directives));
         Locations = locations ?? throw new ArgumentNullException(nameof(locations));
     }
 
@@ -74,6 +79,11 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     public IReadOnlyList<InputValueDefinitionNode> Arguments { get; }
 
     /// <summary>
+    /// Gets the directives that are annotated to this directive definition.
+    /// </summary>
+    public IReadOnlyList<DirectiveNode> Directives { get; }
+
+    /// <summary>
     /// Gets the locations to which this directive can be annotated to.
     /// </summary>
     public IReadOnlyList<NameNode> Locations { get; }
@@ -91,6 +101,11 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
         foreach (var argument in Arguments)
         {
             yield return argument;
+        }
+
+        foreach (var directive in Directives)
+        {
+            yield return directive;
         }
 
         foreach (var location in Locations)
@@ -131,7 +146,7 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     /// Returns the new node with the new <paramref name="location" />.
     /// </returns>
     public DirectiveDefinitionNode WithLocation(Location? location)
-        => new(location, Name, Description, IsRepeatable, Arguments, Locations);
+        => new(location, Name, Description, IsRepeatable, Arguments, Directives, Locations);
 
     /// <summary>
     /// Creates a new node from the current instance and replaces the
@@ -144,7 +159,7 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     /// Returns the new node with the new <paramref name="name" />.
     /// </returns>
     public DirectiveDefinitionNode WithName(NameNode name)
-        => new(Location, name, Description, IsRepeatable, Arguments, Locations);
+        => new(Location, name, Description, IsRepeatable, Arguments, Directives, Locations);
 
     /// <summary>
     /// Creates a new node from the current instance and replaces the
@@ -157,7 +172,7 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     /// Returns the new node with the new <paramref name="description" />.
     /// </returns>
     public DirectiveDefinitionNode WithDescription(StringValueNode? description)
-        => new(Location, Name, description, IsRepeatable, Arguments, Locations);
+        => new(Location, Name, description, IsRepeatable, Arguments, Directives, Locations);
 
     /// <summary>
     /// Creates a new node from the current instance and replaces the
@@ -170,7 +185,7 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     /// Returns the new node with the new <paramref name="repeatable" />.
     /// </returns>
     public DirectiveDefinitionNode AsRepeatable(bool repeatable = true)
-        => new(Location, Name, Description, repeatable, Arguments, Locations);
+        => new(Location, Name, Description, repeatable, Arguments, Directives, Locations);
 
     /// <summary>
     /// Creates a new node from the current instance and replaces the
@@ -183,7 +198,20 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     /// Returns the new node with the new <paramref name="arguments" />.
     /// </returns>
     public DirectiveDefinitionNode WithArguments(IReadOnlyList<InputValueDefinitionNode> arguments)
-        => new(Location, Name, Description, IsRepeatable, arguments, Locations);
+        => new(Location, Name, Description, IsRepeatable, arguments, Directives, Locations);
+
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the
+    /// <see cref="Directives" /> with <paramref name="directives" />.
+    /// </summary>
+    /// <param name="directives">
+    /// The directives that shall be used to replace the current directives.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="directives" />.
+    /// </returns>
+    public DirectiveDefinitionNode WithDirectives(IReadOnlyList<DirectiveNode> directives)
+        => new(Location, Name, Description, IsRepeatable, Arguments, directives, Locations);
 
     /// <summary>
     /// Creates a new node from the current instance and replaces the
@@ -196,5 +224,5 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     /// Returns the new node with the new <paramref name="locations" />.
     /// </returns>
     public DirectiveDefinitionNode WithLocations(IReadOnlyList<NameNode> locations)
-        => new(Location, Name, Description, IsRepeatable, Arguments, locations);
+        => new(Location, Name, Description, IsRepeatable, Arguments, Directives, locations);
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/DirectiveDefinitionNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/DirectiveDefinitionNode.cs
@@ -28,6 +28,38 @@ public sealed class DirectiveDefinitionNode : ITypeSystemDefinitionNode, IHasNam
     /// <param name="arguments">
     /// The arguments of the directive-
     /// </param>
+    /// <param name="locations">
+    /// The locations to which the directive can be annotated.
+    /// </param>
+    public DirectiveDefinitionNode(
+        Location? location,
+        NameNode name,
+        StringValueNode? description,
+        bool isRepeatable,
+        IReadOnlyList<InputValueDefinitionNode> arguments,
+        IReadOnlyList<NameNode> locations)
+        : this(location, name, description, isRepeatable, arguments, [], locations)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="DirectiveDefinitionNode"/>.
+    /// </summary>
+    /// <param name="location">
+    /// The location of the syntax node within the original source text.
+    /// </param>
+    /// <param name="name">
+    /// The name that this syntax node holds.
+    /// </param>
+    /// <param name="description">
+    /// The description of the directive.
+    /// </param>
+    /// <param name="isRepeatable">
+    /// Defines that the directive is repeatable and can be applied multiple times.
+    /// </param>
+    /// <param name="arguments">
+    /// The arguments of the directive-
+    /// </param>
     /// <param name="directives">
     /// The directives that are annotated to this directive definition.
     /// </param>

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/DirectiveExtensionNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/DirectiveExtensionNode.cs
@@ -1,0 +1,108 @@
+using HotChocolate.Language.Utilities;
+
+namespace HotChocolate.Language;
+
+/// <summary>
+/// Directive extensions are used to represent a directive definition which has been
+/// extended from some original directive definition. For example, this might be used
+/// to annotate an existing directive definition with applied directives.
+/// https://spec.graphql.org/draft/#sec-Directive-Extensions
+/// </summary>
+public sealed class DirectiveExtensionNode : NamedSyntaxNode, ITypeSystemExtensionNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="DirectiveExtensionNode"/>.
+    /// </summary>
+    /// <param name="location">
+    /// The location of the syntax node within the original source text.
+    /// </param>
+    /// <param name="name">
+    /// The name of the directive definition that is extended.
+    /// </param>
+    /// <param name="directives">
+    /// The applied directives.
+    /// </param>
+    public DirectiveExtensionNode(
+        Location? location,
+        NameNode name,
+        IReadOnlyList<DirectiveNode> directives)
+        : base(location, name, directives)
+    {
+    }
+
+    /// <inheritdoc />
+    public override SyntaxKind Kind => SyntaxKind.DirectiveExtension;
+
+    /// <inheritdoc />
+    public override IEnumerable<ISyntaxNode> GetNodes()
+    {
+        yield return Name;
+
+        foreach (var directive in Directives)
+        {
+            yield return directive;
+        }
+    }
+
+    /// <summary>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </summary>
+    /// <returns>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </returns>
+    public override string ToString() => SyntaxPrinter.Print(this, true);
+
+    /// <summary>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </summary>
+    /// <param name="indented">
+    /// A value that indicates whether the GraphQL output should be formatted,
+    /// which includes indenting nested GraphQL tokens, adding
+    /// new lines, and adding white space between property names and values.
+    /// </param>
+    /// <returns>
+    /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
+    /// </returns>
+    public override string ToString(bool indented) => SyntaxPrinter.Print(this, indented);
+
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the
+    /// <see cref="Location" /> with <paramref name="location" />.
+    /// </summary>
+    /// <param name="location">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="location" />.
+    /// </returns>
+    public DirectiveExtensionNode WithLocation(Location? location)
+        => new(location, Name, Directives);
+
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the
+    /// <see cref="NamedSyntaxNode.Name" /> with <paramref name="name" />.
+    /// </summary>
+    /// <param name="name">
+    /// The name that shall be used to replace the current name.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="name" />.
+    /// </returns>
+    public DirectiveExtensionNode WithName(NameNode name)
+        => new(Location, name, Directives);
+
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the
+    /// <see cref="NamedSyntaxNode.Directives" /> with <paramref name="directives" />.
+    /// </summary>
+    /// <param name="directives">
+    /// The directives that shall be used to replace the current
+    /// <see cref="NamedSyntaxNode.Directives" />.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="directives" />.
+    /// </returns>
+    public DirectiveExtensionNode WithDirectives(
+        IReadOnlyList<DirectiveNode> directives)
+        => new(Location, Name, directives);
+}

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/DirectiveLocation.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/DirectiveLocation.cs
@@ -106,6 +106,8 @@ public sealed class DirectiveLocation : IEquatable<DirectiveLocation?>
 
     public static DirectiveLocation InputFieldDefinition { get; } = new("INPUT_FIELD_DEFINITION");
 
+    public static DirectiveLocation DirectiveDefinition { get; } = new("DIRECTIVE_DEFINITION");
+
     public static bool IsValidName(string value)
         => s_cache.ContainsKey(value);
 
@@ -137,5 +139,6 @@ public sealed class DirectiveLocation : IEquatable<DirectiveLocation?>
         yield return EnumValue;
         yield return InputObject;
         yield return InputFieldDefinition;
+        yield return DirectiveDefinition;
     }
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxEqualityComparer.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxEqualityComparer.cs
@@ -176,6 +176,7 @@ internal sealed class SyntaxEqualityComparer(bool ignoreDescriptions = false) : 
             && (ignoreDescriptions || SyntaxComparer.BySyntax.Equals(x.Description, y.Description))
             && x.IsRepeatable.Equals(y.IsRepeatable)
             && Equals(x.Arguments, y.Arguments)
+            && Equals(x.Directives, y.Directives)
             && Equals(x.Locations, y.Locations);
 
     private bool Equals(DirectiveNode x, DirectiveNode y)
@@ -646,6 +647,12 @@ internal sealed class SyntaxEqualityComparer(bool ignoreDescriptions = false) : 
         {
             var argument = node.Arguments[i];
             hashCode.Add(GetHashCode(argument));
+        }
+
+        for (var i = 0; i < node.Directives.Count; i++)
+        {
+            var directive = node.Directives[i];
+            hashCode.Add(GetHashCode(directive));
         }
 
         for (var i = 0; i < node.Locations.Count; i++)

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxEqualityComparer.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxEqualityComparer.cs
@@ -160,6 +160,9 @@ internal sealed class SyntaxEqualityComparer(bool ignoreDescriptions = false) : 
             case SyntaxKind.SchemaCoordinate:
                 return Equals((SchemaCoordinateNode)x, (SchemaCoordinateNode)y);
 
+            case SyntaxKind.DirectiveExtension:
+                return Equals((DirectiveExtensionNode)x, (DirectiveExtensionNode)y);
+
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -178,6 +181,10 @@ internal sealed class SyntaxEqualityComparer(bool ignoreDescriptions = false) : 
             && Equals(x.Arguments, y.Arguments)
             && Equals(x.Directives, y.Directives)
             && Equals(x.Locations, y.Locations);
+
+    private bool Equals(DirectiveExtensionNode x, DirectiveExtensionNode y)
+        => Equals(x.Name, y.Name)
+            && Equals(x.Directives, y.Directives);
 
     private bool Equals(DirectiveNode x, DirectiveNode y)
         => Equals(x.Name, y.Name) && Equals(x.Arguments, y.Arguments);
@@ -621,6 +628,9 @@ internal sealed class SyntaxEqualityComparer(bool ignoreDescriptions = false) : 
             case SyntaxKind.SchemaCoordinate:
                 return GetHashCode((SchemaCoordinateNode)obj);
 
+            case SyntaxKind.DirectiveExtension:
+                return GetHashCode((DirectiveExtensionNode)obj);
+
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -659,6 +669,21 @@ internal sealed class SyntaxEqualityComparer(bool ignoreDescriptions = false) : 
         {
             var location = node.Locations[i];
             hashCode.Add(GetHashCode(location));
+        }
+
+        return hashCode.ToHashCode();
+    }
+
+    private int GetHashCode(DirectiveExtensionNode node)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(node.Kind);
+        hashCode.Add(GetHashCode(node.Name));
+
+        for (var i = 0; i < node.Directives.Count; i++)
+        {
+            var directive = node.Directives[i];
+            hashCode.Add(GetHashCode(directive));
         }
 
         return hashCode.ToHashCode();

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxKind.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxKind.cs
@@ -45,5 +45,6 @@ public enum SyntaxKind
     InputObjectTypeExtension,
     DirectiveDefinition,
     FloatValue,
-    SchemaCoordinate
+    SchemaCoordinate,
+    DirectiveExtension
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.SchemaSyntax.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.SchemaSyntax.cs
@@ -429,6 +429,8 @@ public sealed partial class SyntaxSerializer
             WriteArgumentDefinitions(node.Arguments, writer);
         }
 
+        WriteDirectives(node.Directives, writer);
+
         writer.WriteSpace();
 
         if (node.IsRepeatable)

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.SchemaSyntax.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.SchemaSyntax.cs
@@ -451,6 +451,20 @@ public sealed partial class SyntaxSerializer
             writer);
     }
 
+    private void VisitDirectiveExtension(
+        DirectiveExtensionNode node,
+        ISyntaxWriter writer)
+    {
+        writer.Write(Keywords.Extend);
+        writer.WriteSpace();
+        writer.Write(Keywords.Directive);
+        writer.WriteSpace();
+        writer.Write('@');
+        writer.WriteName(node.Name);
+
+        WriteDirectives(node.Directives, writer);
+    }
+
     private void VisitArgumentValueDefinition(
         InputValueDefinitionNode node,
         ISyntaxWriter writer)

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.cs
@@ -131,6 +131,9 @@ public sealed partial class SyntaxSerializer
             case SyntaxKind.InputObjectTypeExtension:
                 VisitInputObjectTypeExtension((InputObjectTypeExtensionNode)node, writer);
                 break;
+            case SyntaxKind.DirectiveExtension:
+                VisitDirectiveExtension((DirectiveExtensionNode)node, writer);
+                break;
             case SyntaxKind.SchemaCoordinate:
                 VisitSchemaCoordinate((SchemaCoordinateNode)node, writer);
                 break;
@@ -217,6 +220,9 @@ public sealed partial class SyntaxSerializer
                 break;
             case SyntaxKind.InputObjectTypeExtension:
                 VisitInputObjectTypeExtension((InputObjectTypeExtensionNode)node, writer);
+                break;
+            case SyntaxKind.DirectiveExtension:
+                VisitDirectiveExtension((DirectiveExtensionNode)node, writer);
                 break;
             default:
                 ThrowHelper.NodeKindIsNotSupported(node.Kind);

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Directives.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Directives.cs
@@ -31,6 +31,7 @@ public ref partial struct Utf8GraphQLParser
             TakeDescription(),
             isRepeatable,
             arguments,
+            s_emptyDirectives,
             locations
         );
     }

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Directives.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Directives.cs
@@ -17,6 +17,8 @@ public ref partial struct Utf8GraphQLParser
         var arguments =
             ParseArgumentDefinitions();
 
+        var directives = ParseDirectives(true);
+
         var isRepeatable = SkipRepeatableKeyword();
         ExpectOnKeyword();
 
@@ -31,7 +33,7 @@ public ref partial struct Utf8GraphQLParser
             TakeDescription(),
             isRepeatable,
             arguments,
-            s_emptyDirectives,
+            directives,
             locations
         );
     }

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Extensions.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Extensions.cs
@@ -17,6 +17,13 @@ public ref partial struct Utf8GraphQLParser
         {
             switch (_reader.Value[0])
             {
+                case (byte)'d':
+                    if (_reader.Value.SequenceEqual(GraphQLKeywords.Directive))
+                    {
+                        return ParseDirectiveExtension(in start);
+                    }
+                    break;
+
                 case (byte)'s':
                     if (_reader.Value.SequenceEqual(GraphQLKeywords.Schema))
                     {
@@ -63,6 +70,33 @@ public ref partial struct Utf8GraphQLParser
         }
 
         throw Unexpected(_reader.Kind);
+    }
+
+    /// <summary>
+    /// Parse directive extension.
+    /// <see cref="DirectiveExtensionNode" />:
+    /// * - extend directive @ Name Directives[Const]
+    /// </summary>
+    private DirectiveExtensionNode ParseDirectiveExtension(
+        in TokenInfo start)
+    {
+        MoveNext();
+
+        ExpectAt();
+        var name = ParseName();
+        var directives = ParseDirectives(true);
+        if (directives.Count == 0)
+        {
+            throw Unexpected(_reader.Kind);
+        }
+        var location = CreateLocation(in start);
+
+        return new DirectiveExtensionNode
+        (
+            location,
+            name,
+            directives
+        );
     }
 
     /// <summary>

--- a/src/HotChocolate/Language/src/Language.Visitors/DefaultSyntaxNavigator.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/DefaultSyntaxNavigator.cs
@@ -169,6 +169,7 @@ public class DefaultSyntaxNavigator : ISyntaxNavigator
                 or SyntaxKind.InterfaceTypeExtension
                 or SyntaxKind.UnionTypeExtension
                 or SyntaxKind.DirectiveDefinition
+                or SyntaxKind.DirectiveExtension
                 or SyntaxKind.FieldDefinition
                 or SyntaxKind.InputValueDefinition)
             {
@@ -194,10 +195,10 @@ public class DefaultSyntaxNavigator : ISyntaxNavigator
 
         var next = _coordinate[--p];
 
-        if (next is DirectiveDefinitionNode directiveDefinition)
+        if (next is DirectiveDefinitionNode or DirectiveExtensionNode)
         {
             directive = true;
-            type = directiveDefinition.Name;
+            type = ((IHasName)next).Name;
         }
         else if (next is ITypeSystemDefinitionNode or ITypeSystemExtensionNode
             && next is NamedSyntaxNode n)

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxRewriter~1.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxRewriter~1.cs
@@ -105,11 +105,13 @@ public class SyntaxRewriter<TContext> : ISyntaxRewriter<TContext>
         var name = RewriteNode(node.Name, context);
         var description = RewriteNodeOrDefault(node.Description, context);
         var arguments = RewriteList(node.Arguments, context);
+        var directives = RewriteList(node.Directives, context);
         var locations = RewriteList(node.Locations, context);
 
         if (!ReferenceEquals(name, node.Name)
             || !ReferenceEquals(description, node.Description)
             || !ReferenceEquals(arguments, node.Arguments)
+            || !ReferenceEquals(directives, node.Directives)
             || !ReferenceEquals(locations, node.Locations))
         {
             return new DirectiveDefinitionNode(
@@ -118,6 +120,7 @@ public class SyntaxRewriter<TContext> : ISyntaxRewriter<TContext>
                 description,
                 node.IsRepeatable,
                 arguments,
+                directives,
                 locations);
         }
 

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxRewriter~1.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxRewriter~1.cs
@@ -26,6 +26,7 @@ public class SyntaxRewriter<TContext> : ISyntaxRewriter<TContext>
             ArgumentNode n => RewriteArgument(n, context),
             BooleanValueNode n => RewriteBooleanValue(n, context),
             DirectiveDefinitionNode n => RewriteDirectiveDefinition(n, context),
+            DirectiveExtensionNode n => RewriteDirectiveExtension(n, context),
             DirectiveNode n => RewriteDirective(n, context),
             DocumentNode n => RewriteDocument(n, context),
             EnumTypeDefinitionNode n => RewriteEnumTypeDefinition(n, context),
@@ -122,6 +123,25 @@ public class SyntaxRewriter<TContext> : ISyntaxRewriter<TContext>
                 arguments,
                 directives,
                 locations);
+        }
+
+        return node;
+    }
+
+    protected virtual DirectiveExtensionNode? RewriteDirectiveExtension(
+        DirectiveExtensionNode node,
+        TContext context)
+    {
+        var name = RewriteNode(node.Name, context);
+        var directives = RewriteList(node.Directives, context);
+
+        if (!ReferenceEquals(name, node.Name)
+            || !ReferenceEquals(directives, node.Directives))
+        {
+            return new DirectiveExtensionNode(
+                node.Location,
+                name,
+                directives);
         }
 
         return node;

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxVisitor~1.VisitationMap.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxVisitor~1.VisitationMap.cs
@@ -90,6 +90,8 @@ public partial class SyntaxVisitor<TContext>
                 return VisitChildren((InputObjectTypeExtensionNode)node, context);
             case SyntaxKind.SchemaCoordinate:
                 return VisitChildren((SchemaCoordinateNode)node, context);
+            case SyntaxKind.DirectiveExtension:
+                return VisitChildren((DirectiveExtensionNode)node, context);
 
             default:
                 throw new NotSupportedException(node.GetType().FullName);
@@ -1159,6 +1161,29 @@ public partial class SyntaxVisitor<TContext>
             && Visit(node.ArgumentName, node, context).IsBreak())
         {
             return Break;
+        }
+
+        return DefaultAction;
+    }
+
+    protected virtual ISyntaxVisitorAction VisitChildren(
+        DirectiveExtensionNode node,
+        TContext context)
+    {
+        if (_options.VisitNames && Visit(node.Name, node, context).IsBreak())
+        {
+            return Break;
+        }
+
+        if (_options.VisitDirectives)
+        {
+            for (var i = 0; i < node.Directives.Count; i++)
+            {
+                if (Visit(node.Directives[i], node, context).IsBreak())
+                {
+                    return Break;
+                }
+            }
         }
 
         return DefaultAction;

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxVisitor~1.VisitationMap.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxVisitor~1.VisitationMap.cs
@@ -896,6 +896,17 @@ public partial class SyntaxVisitor<TContext>
             }
         }
 
+        if (_options.VisitDirectives)
+        {
+            for (var i = 0; i < node.Directives.Count; i++)
+            {
+                if (Visit(node.Directives[i], node, context).IsBreak())
+                {
+                    return Break;
+                }
+            }
+        }
+
         for (var i = 0; i < node.Locations.Count; i++)
         {
             if (Visit(node.Locations[i], node, context).IsBreak())

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxWalker.Enter.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxWalker.Enter.cs
@@ -89,6 +89,8 @@ public partial class SyntaxWalker
                 return Enter((InputObjectTypeExtensionNode)node, context);
             case SyntaxKind.SchemaCoordinate:
                 return Enter((SchemaCoordinateNode)node, context);
+            case SyntaxKind.DirectiveExtension:
+                return Enter((DirectiveExtensionNode)node, context);
             default:
                 throw new NotSupportedException(node.GetType().FullName);
         }
@@ -288,4 +290,9 @@ public partial class SyntaxWalker
        SchemaCoordinateNode node,
        object? context) =>
        DefaultAction;
+
+    protected virtual ISyntaxVisitorAction Enter(
+        DirectiveExtensionNode node,
+        object? context) =>
+        DefaultAction;
 }

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxWalker.Leave.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxWalker.Leave.cs
@@ -91,6 +91,8 @@ public partial class SyntaxWalker
                 return Leave((InputObjectTypeExtensionNode)node, context);
             case SyntaxKind.SchemaCoordinate:
                 return Leave((SchemaCoordinateNode)node, context);
+            case SyntaxKind.DirectiveExtension:
+                return Leave((DirectiveExtensionNode)node, context);
             default:
                 throw new NotSupportedException(node.GetType().FullName);
         }
@@ -289,4 +291,9 @@ public partial class SyntaxWalker
        SchemaCoordinateNode node,
        object? context) =>
        DefaultAction;
+
+    protected virtual ISyntaxVisitorAction Leave(
+        DirectiveExtensionNode node,
+        object? context) =>
+        DefaultAction;
 }

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxWalker~1.Enter.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxWalker~1.Enter.cs
@@ -91,6 +91,8 @@ public partial class SyntaxWalker<TContext>
                 return Enter((InputObjectTypeExtensionNode)node, context);
             case SyntaxKind.SchemaCoordinate:
                 return Enter((SchemaCoordinateNode)node, context);
+            case SyntaxKind.DirectiveExtension:
+                return Enter((DirectiveExtensionNode)node, context);
             default:
                 throw new NotSupportedException(node.GetType().FullName);
         }
@@ -290,4 +292,9 @@ public partial class SyntaxWalker<TContext>
        SchemaCoordinateNode node,
        object? context) =>
        DefaultAction;
+
+    protected virtual ISyntaxVisitorAction Enter(
+        DirectiveExtensionNode node,
+        TContext context) =>
+        DefaultAction;
 }

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxWalker~1.Leave.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxWalker~1.Leave.cs
@@ -91,6 +91,8 @@ public partial class SyntaxWalker<TContext>
                 return Leave((InputObjectTypeExtensionNode)node, context);
             case SyntaxKind.SchemaCoordinate:
                 return Leave((SchemaCoordinateNode)node, context);
+            case SyntaxKind.DirectiveExtension:
+                return Leave((DirectiveExtensionNode)node, context);
             default:
                 throw new NotSupportedException(node.GetType().FullName);
         }
@@ -289,4 +291,9 @@ public partial class SyntaxWalker<TContext>
        SchemaCoordinateNode node,
        TContext context) =>
        DefaultAction;
+
+    protected virtual ISyntaxVisitorAction Leave(
+        DirectiveExtensionNode node,
+        TContext context) =>
+        DefaultAction;
 }

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveDefinitionNodeTests.cs
@@ -515,6 +515,27 @@ public class DirectiveDefinitionNodeTests
     }
 
     [Fact]
+    public void CreateDirectiveDefinitionWithoutDirectives()
+    {
+        // arrange
+        var name = new NameNode("foo");
+        var locations = new List<NameNode> { new(DirectiveLocation.Object.ToString()) };
+
+        // act
+        var directiveDefinition =
+            new DirectiveDefinitionNode(
+                null,
+                name,
+                description: null,
+                isRepeatable: false,
+                arguments: [],
+                locations);
+
+        // assert
+        Assert.Empty(directiveDefinition.Directives);
+    }
+
+    [Fact]
     public void WithDirectives()
     {
         // arrange

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveDefinitionNodeTests.cs
@@ -22,6 +22,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable,
                 arguments,
+                [],
                 locations);
 
         // assert
@@ -51,6 +52,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable: true,
                 arguments,
+                [],
                 locations);
 
         // assert
@@ -79,6 +81,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable: true,
                 arguments,
+                [],
                 locations);
 
         // act
@@ -104,6 +107,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable: true,
                 arguments,
+                [],
                 locations);
 
         // act
@@ -124,7 +128,7 @@ public class DirectiveDefinitionNodeTests
 
         var directiveDefinition = new DirectiveDefinitionNode(
             null, name, description, true,
-            arguments, locations);
+            arguments, [], locations);
 
         // act
         directiveDefinition = directiveDefinition
@@ -156,7 +160,7 @@ public class DirectiveDefinitionNodeTests
 
         var directiveDefinition = new DirectiveDefinitionNode(
             null, name, description, true,
-            arguments, locations);
+            arguments, [], locations);
 
         // act
         directiveDefinition = directiveDefinition
@@ -182,6 +186,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable: true,
                 arguments,
+                [],
                 locations);
 
         // act
@@ -208,6 +213,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable: true,
                 arguments,
+                [],
                 locations);
 
         // act
@@ -233,6 +239,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable: false,
                 arguments,
+                [],
                 locations);
 
         // act
@@ -259,6 +266,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable: true,
                 arguments,
+                [],
                 locations);
 
         // assert
@@ -294,6 +302,7 @@ public class DirectiveDefinitionNodeTests
                 description,
                 isRepeatable: true,
                 arguments,
+                [],
                 locations);
 
         // assert
@@ -326,6 +335,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
         var b = new DirectiveDefinitionNode(
             TestLocations.Location1,
@@ -333,6 +343,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
         var c = new DirectiveDefinitionNode(
             TestLocations.Location1,
@@ -340,6 +351,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
 
         // act
@@ -381,6 +393,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
         var b = new DirectiveDefinitionNode(
             TestLocations.Location2,
@@ -388,6 +401,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
         var c = new DirectiveDefinitionNode(
             TestLocations.Location1,
@@ -395,6 +409,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
 
         // act
@@ -435,6 +450,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
         var b = new DirectiveDefinitionNode(
             TestLocations.Location2,
@@ -442,6 +458,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
         var c = new DirectiveDefinitionNode(
             TestLocations.Location1,
@@ -449,6 +466,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
         var d = new DirectiveDefinitionNode(
             TestLocations.Location2,
@@ -456,6 +474,7 @@ public class DirectiveDefinitionNodeTests
             null,
             true,
             arguments,
+            [],
             locations);
 
         // act
@@ -469,5 +488,73 @@ public class DirectiveDefinitionNodeTests
         Assert.NotEqual(aHash, cHash);
         Assert.Equal(cHash, dHash);
         Assert.NotEqual(aHash, dHash);
+    }
+
+    [Fact]
+    public void CreateDirectiveDefinitionWithDirectives()
+    {
+        // arrange
+        var name = new NameNode("foo");
+        var directives = new List<DirectiveNode> { new DirectiveNode("tag") };
+        var locations = new List<NameNode> { new(DirectiveLocation.Object.ToString()) };
+
+        // act
+        var directiveDefinition =
+            new DirectiveDefinitionNode(
+                null,
+                name,
+                description: null,
+                isRepeatable: false,
+                arguments: [],
+                directives,
+                locations);
+
+        // assert
+        Assert.Equal(directives, directiveDefinition.Directives);
+        Assert.Contains(directives[0], directiveDefinition.GetNodes());
+    }
+
+    [Fact]
+    public void WithDirectives()
+    {
+        // arrange
+        var name = new NameNode("foo");
+        var locations = new List<NameNode> { new(DirectiveLocation.Object.ToString()) };
+        var directiveDefinition = new DirectiveDefinitionNode(
+            null, name, null, false, [], [], locations);
+
+        // act
+        directiveDefinition = directiveDefinition
+            .WithDirectives([new DirectiveNode("tag")]);
+
+        // assert
+        Assert.Equal("tag", Assert.Single(directiveDefinition.Directives).Name.Value);
+    }
+
+    [Fact]
+    public void Equals_With_Different_Directives()
+    {
+        // arrange
+        var locations = new List<NameNode> { new(DirectiveLocation.Field.ToString()) };
+        var a = new DirectiveDefinitionNode(
+            null, new("aa"), null, true, [], [new DirectiveNode("a")], locations);
+        var b = new DirectiveDefinitionNode(
+            null, new("aa"), null, true, [], [new DirectiveNode("a")], locations);
+        var c = new DirectiveDefinitionNode(
+            null, new("aa"), null, true, [], [new DirectiveNode("b")], locations);
+
+        // act
+        var abResult = SyntaxComparer.BySyntax.Equals(a, b);
+        var acResult = SyntaxComparer.BySyntax.Equals(a, c);
+        var abHashEqual =
+            SyntaxComparer.BySyntax.GetHashCode(a) == SyntaxComparer.BySyntax.GetHashCode(b);
+        var acHashEqual =
+            SyntaxComparer.BySyntax.GetHashCode(a) == SyntaxComparer.BySyntax.GetHashCode(c);
+
+        // assert
+        Assert.True(abResult);
+        Assert.False(acResult);
+        Assert.True(abHashEqual);
+        Assert.False(acHashEqual);
     }
 }

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveExtensionNodeTests.cs
@@ -1,0 +1,84 @@
+namespace HotChocolate.Language.SyntaxTree;
+
+public class DirectiveExtensionNodeTests
+{
+    private readonly NameNode _name1 = new("name1");
+    private readonly NameNode _name2 = new("name2");
+    private readonly IReadOnlyList<DirectiveNode> _directives = [new DirectiveNode("tag")];
+
+    [Fact]
+    public void Create_DirectiveExtension()
+    {
+        // arrange
+        var name = new NameNode("foo");
+
+        // act
+        var extension = new DirectiveExtensionNode(
+            TestLocations.Location1, name, _directives);
+
+        // assert
+        Assert.Equal(SyntaxKind.DirectiveExtension, extension.Kind);
+        Assert.Equal(TestLocations.Location1, extension.Location);
+        Assert.Equal(name, extension.Name);
+        Assert.Equal(_directives, extension.Directives);
+    }
+
+    [Fact]
+    public void GetNodes_Returns_Name_And_Directives()
+    {
+        // arrange
+        var extension = new DirectiveExtensionNode(null, _name1, _directives);
+
+        // act
+        var nodes = extension.GetNodes().ToArray();
+
+        // assert
+        Assert.Collection(
+            nodes,
+            n => Assert.Equal(_name1, n),
+            n => Assert.Equal(_directives[0], n));
+    }
+
+    [Fact]
+    public void Equals_With_Different_Location()
+    {
+        // arrange
+        var a = new DirectiveExtensionNode(TestLocations.Location1, _name1, _directives);
+        var b = new DirectiveExtensionNode(TestLocations.Location2, _name1, _directives);
+        var c = new DirectiveExtensionNode(TestLocations.Location3, _name2, _directives);
+
+        // act
+        var abResult = SyntaxComparer.BySyntax.Equals(a, b);
+        var aaResult = SyntaxComparer.BySyntax.Equals(a, a);
+        var acResult = SyntaxComparer.BySyntax.Equals(a, c);
+        var aNullResult = SyntaxComparer.BySyntax.Equals(a, null);
+
+        // assert
+        Assert.True(abResult);
+        Assert.True(aaResult);
+        Assert.False(acResult);
+        Assert.False(aNullResult);
+    }
+
+    [Fact]
+    public void GetHashCode_With_Location()
+    {
+        // arrange
+        var a = new DirectiveExtensionNode(TestLocations.Location1, _name1, _directives);
+        var b = new DirectiveExtensionNode(TestLocations.Location2, _name1, _directives);
+        var c = new DirectiveExtensionNode(TestLocations.Location1, _name2, _directives);
+        var d = new DirectiveExtensionNode(TestLocations.Location2, _name2, _directives);
+
+        // act
+        var aHash = SyntaxComparer.BySyntax.GetHashCode(a);
+        var bHash = SyntaxComparer.BySyntax.GetHashCode(b);
+        var cHash = SyntaxComparer.BySyntax.GetHashCode(c);
+        var dHash = SyntaxComparer.BySyntax.GetHashCode(d);
+
+        // assert
+        Assert.Equal(aHash, bHash);
+        Assert.NotEqual(aHash, cHash);
+        Assert.Equal(cHash, dHash);
+        Assert.NotEqual(aHash, dHash);
+    }
+}

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
@@ -1068,4 +1068,18 @@ public class SchemaSyntaxPrinterTests
         // assert
         Assert.Equal(schema, result);
     }
+
+    [Fact]
+    public void Serialize_DirectiveExtensionDef_InOutShouldBeTheSame()
+    {
+        // arrange
+        const string schema = "extend directive @foo @a @b(c: 1)";
+        var document = Utf8GraphQLParser.Parse(schema);
+
+        // act
+        var result = document.ToString(indented: false);
+
+        // assert
+        Assert.Equal(schema, result);
+    }
 }

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
@@ -1053,4 +1053,19 @@ public class SchemaSyntaxPrinterTests
               | VARIABLE_DEFINITION
             """);
     }
+
+    [Fact]
+    public void Serialize_DirectiveDefWithDirectivesNoIndent_InOutShouldBeTheSame()
+    {
+        // arrange
+        const string schema =
+            "directive @foo(arg: Int) @tag(name: \"a\") repeatable on OBJECT";
+        var document = Utf8GraphQLParser.Parse(schema);
+
+        // act
+        var result = document.ToString(indented: false);
+
+        // assert
+        Assert.Equal(schema, result);
+    }
 }

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
@@ -1082,4 +1082,56 @@ public class SchemaSyntaxPrinterTests
         // assert
         Assert.Equal(schema, result);
     }
+
+    [Fact]
+    public void Serialize_DirectiveDefWithDirectivesAndExtensionNoIndent_InOutShouldBeTheSame()
+    {
+        // arrange
+        const string schema =
+            "directive @foo(arg: Int) @tag(name: \"a\") repeatable on OBJECT | DIRECTIVE_DEFINITION"
+            + " extend directive @foo @other";
+        var document = Utf8GraphQLParser.Parse(schema);
+
+        // act
+        var result = document.ToString(indented: false);
+
+        // assert
+        Assert.Equal(schema, result);
+    }
+
+    [Fact]
+    public void Serialize_DirectiveDefWithDirectivesAndExtension_OutHasIndentation()
+    {
+        // arrange
+        const string schema =
+            "\"the foo directive\" "
+            + "directive @foo(arg: Int) @tag(name: \"a\") @onDirective "
+            + "repeatable on OBJECT | DIRECTIVE_DEFINITION "
+            + "extend directive @foo @other";
+        var document = Utf8GraphQLParser.Parse(schema);
+
+        // act
+        var result = document.ToString();
+
+        // assert
+        result.MatchSnapshot();
+    }
+
+    [Fact]
+    public void Serialize_DirectiveDefWithDirectivesAndExtension_RoundTripsThroughParser()
+    {
+        // arrange
+        const string schema =
+            "\"the foo directive\" "
+            + "directive @foo(arg: Int) @tag(name: \"a\") @onDirective "
+            + "repeatable on OBJECT | DIRECTIVE_DEFINITION "
+            + "extend directive @foo @other";
+        var document = Utf8GraphQLParser.Parse(schema);
+
+        // act
+        var reparsed = Utf8GraphQLParser.Parse(document.ToString(indented: false));
+
+        // assert
+        Assert.True(SyntaxComparer.BySyntax.Equals(document, reparsed));
+    }
 }

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/__snapshots__/SchemaSyntaxPrinterTests.Serialize_DirectiveDefWithDirectivesAndExtension_OutHasIndentation.snap
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/__snapshots__/SchemaSyntaxPrinterTests.Serialize_DirectiveDefWithDirectivesAndExtension_OutHasIndentation.snap
@@ -1,0 +1,6 @@
+"the foo directive"
+directive @foo(arg: Int) @tag(name: "a") @onDirective repeatable on
+  | OBJECT
+  | DIRECTIVE_DEFINITION
+
+extend directive @foo @other

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/DirectiveParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/DirectiveParserTests.cs
@@ -65,6 +65,25 @@ public class DirectiveParserTests
     }
 
     [Fact]
+    public void ParseDirectiveDefinitionLocation()
+    {
+        // arrange
+        const string text = "directive @onDirective on DIRECTIVE_DEFINITION";
+        var parser = new Utf8GraphQLParser(Encoding.UTF8.GetBytes(text));
+
+        // act
+        var document = parser.Parse();
+
+        // assert
+        var directiveDefinition = document.Definitions
+            .OfType<DirectiveDefinitionNode>().FirstOrDefault();
+        Assert.NotNull(directiveDefinition);
+        Assert.Equal(
+            "DIRECTIVE_DEFINITION",
+            Assert.Single(directiveDefinition.Locations).Value);
+    }
+
+    [Fact]
     public void DirectiveOrderIsSignificant()
     {
         // arrange

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/DirectiveParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/DirectiveParserTests.cs
@@ -160,4 +160,37 @@ public class DirectiveParserTests
             d => Assert.Equal("a", d.Name.Value),
             d => Assert.Equal("b", d.Name.Value));
     }
+
+    [Fact]
+    public void ParseDirectiveExtension()
+    {
+        // arrange
+        const string text = "extend directive @foo @tag(name: \"a\")";
+        var parser = new Utf8GraphQLParser(Encoding.UTF8.GetBytes(text));
+
+        // act
+        var document = parser.Parse();
+
+        // assert
+        var extension = document.Definitions
+            .OfType<DirectiveExtensionNode>().FirstOrDefault();
+        Assert.NotNull(extension);
+        Assert.Equal("foo", extension.Name.Value);
+        var directive = Assert.Single(extension.Directives);
+        Assert.Equal("tag", directive.Name.Value);
+    }
+
+    [Fact]
+    public void ParseDirectiveExtensionWithoutDirectives()
+    {
+        // arrange
+        // per the grammar, Directives[Const] is required on a directive extension
+        const string text = "extend directive @foo";
+
+        // act
+        static void Action() => Utf8GraphQLParser.Parse(text);
+
+        // assert
+        Assert.Throws<SyntaxException>(Action);
+    }
 }

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/DirectiveParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/DirectiveParserTests.cs
@@ -120,4 +120,44 @@ public class DirectiveParserTests
         // assert
         document.MatchSnapshot();
     }
+
+    [Fact]
+    public void ParseDirectivesOnDirectiveDefinition()
+    {
+        // arrange
+        const string text =
+            "directive @foo(arg: Int) @tag(name: \"a\") repeatable on OBJECT";
+        var parser = new Utf8GraphQLParser(Encoding.UTF8.GetBytes(text));
+
+        // act
+        var document = parser.Parse();
+
+        // assert
+        var directiveDefinition = document.Definitions
+            .OfType<DirectiveDefinitionNode>().FirstOrDefault();
+        Assert.NotNull(directiveDefinition);
+        var directive = Assert.Single(directiveDefinition.Directives);
+        Assert.Equal("tag", directive.Name.Value);
+        Assert.True(directiveDefinition.IsRepeatable);
+    }
+
+    [Fact]
+    public void ParseDirectivesOnDirectiveDefinitionWithoutArguments()
+    {
+        // arrange
+        const string text = "directive @foo @a @b on FIELD";
+        var parser = new Utf8GraphQLParser(Encoding.UTF8.GetBytes(text));
+
+        // act
+        var document = parser.Parse();
+
+        // assert
+        var directiveDefinition = document.Definitions
+            .OfType<DirectiveDefinitionNode>().FirstOrDefault();
+        Assert.NotNull(directiveDefinition);
+        Assert.Collection(
+            directiveDefinition.Directives,
+            d => Assert.Equal("a", d.Name.Value),
+            d => Assert.Equal("b", d.Name.Value));
+    }
 }

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/KitchenSinkParserTests.ParseFacebookKitchenSinkSchema.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/KitchenSinkParserTests.ParseFacebookKitchenSinkSchema.snap
@@ -3099,6 +3099,7 @@ AST:
           "Directives": []
         }
       ],
+      "Directives": [],
       "Locations": [
         {
           "Kind": "Name",
@@ -3204,6 +3205,7 @@ AST:
           "Directives": []
         }
       ],
+      "Directives": [],
       "Locations": [
         {
           "Kind": "Name",
@@ -3309,6 +3311,7 @@ AST:
           "Directives": []
         }
       ],
+      "Directives": [],
       "Locations": [
         {
           "Kind": "Name",
@@ -3414,6 +3417,7 @@ AST:
           "Directives": []
         }
       ],
+      "Directives": [],
       "Locations": [
         {
           "Kind": "Name",

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxRewriterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxRewriterTests.cs
@@ -103,4 +103,22 @@ public class SyntaxRewriterTests
         DocumentNode? Fail() => (DocumentNode?)rewriter.Rewrite(schema, new NavigatorContext());
         Assert.Throws<SyntaxNodeCannotBeNullException>(Fail);
     }
+
+    [Fact]
+    public void Rewrite_DirectiveExtension_Directives()
+    {
+        // arrange
+        var document = Parse("extend directive @foo @a");
+
+        var rewriter = SyntaxRewriter.Create(
+            node => node is DirectiveNode directive
+                ? directive.WithName(directive.Name.WithValue("b"))
+                : node);
+
+        // act
+        document = (DocumentNode?)rewriter.Rewrite(document, null);
+
+        // assert
+        Assert.Equal("extend directive @foo @b", document?.ToString(indented: false));
+    }
 }

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxVisitorTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxVisitorTests.cs
@@ -38,4 +38,54 @@ public class SyntaxVisitorTests
             t => Assert.Equal("Foo.field", t),
             t => Assert.Equal("Foo.field(a:)", t));
     }
+
+    [Fact]
+    public void Visit_DirectiveExtension()
+    {
+        // arrange
+        var visited = new List<SyntaxKind>();
+        var document = Parse("extend directive @foo @tag");
+
+        var visitor = Create(
+            enter: node =>
+            {
+                visited.Add(node.Kind);
+                return SyntaxVisitor.Continue;
+            },
+            options: new() { VisitNames = true, VisitDirectives = true });
+
+        // act
+        visitor.Visit(document, null);
+
+        // assert
+        Assert.Contains(SyntaxKind.DirectiveExtension, visited);
+        Assert.Contains(SyntaxKind.Directive, visited);
+    }
+
+    [Fact]
+    public void Visit_DirectiveExtension_With_Navigator()
+    {
+        // arrange
+        var list = new List<string>();
+        var document = Parse("extend directive @foo @tag");
+
+        var visitor =
+            CreateWithNavigator<NavigatorContext>(
+                enter: (n, c) =>
+                {
+                    if (n is DirectiveNode)
+                    {
+                        list.Add(c.Navigator.CreateCoordinate().ToString());
+                    }
+
+                    return SyntaxVisitor.Continue;
+                },
+                options: new() { VisitNames = true, VisitDirectives = true });
+
+        // act
+        visitor.Visit(document, new NavigatorContext());
+
+        // assert
+        Assert.Equal("@foo", Assert.Single(list));
+    }
 }

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionFormatter.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionFormatter.cs
@@ -267,6 +267,7 @@ internal static class IntrospectionFormatter
             CreateDescription(directive.Description),
             directive.IsRepeatable ?? false,
             CreateInputValues(directive.Args),
+            [],
             locations
         );
     }


### PR DESCRIPTION
## Summary

Adds the `HotChocolate.Language` (AST/parser/printer/visitor) support for **directives on directive definitions** ([graphql/graphql-spec#1206](https://github.com/graphql/graphql-spec/pull/1206), issue #4625), the first of three stacked PRs. Purely additive to the syntax layer; no behavior change for documents that don't use the new syntax.

- `DirectiveDefinitionNode` gains a `Directives` collection (parsed between the argument definitions and the `repeatable` keyword, per the grammar) with constructor, `WithDirectives`, `GetNodes`, equality/hashing, and printing support.
- New `DirectiveExtensionNode` (`SyntaxKind.DirectiveExtension`) for `extend directive @foo @applied`, wired through the parser, printer, visitor, walkers, rewriter, and navigator.
- New `DIRECTIVE_DEFINITION` value on the string-based `Language.DirectiveLocation`.

## Test plan

- Parser tests: directives on definitions (with/without arguments, with `repeatable`), `extend directive` parsing, and the grammar's directives-required rule for extensions.
- Printer round-trip tests (indented + non-indented) and a parse→print→reparse equality test, plus an indented snapshot.
- Node equality/hashing and `GetNodes` coverage for both node types; visitor/rewriter/navigator-coordinate coverage for `DirectiveExtensionNode`.
- Full `HotChocolate.Language` suite green: 2703 passed, 0 failed (3 pre-existing skips) on net8.0/9.0/10.0.
