### PR TITLE
Stabilize `@defer` overlap HTTP tests with instant initial fields

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/DeferOverHttpTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/DeferOverHttpTests.cs
@@ -1169,7 +1169,6 @@ public class DeferOverHttpTests(TestServerFactory serverFactory) : ServerTestBas
                 {
                     product {
                         name
-                        description
                     }
                     ... @defer(label: "foo") {
                         product {
@@ -1205,7 +1204,7 @@ public class DeferOverHttpTests(TestServerFactory serverFactory) : ServerTestBas
                 ---
                 Content-Type: application/json; charset=utf-8
 
-                {"data":{"product":{"name":"Abc","description":"Abc desc"}},"hasNext":true}
+                {"data":{"product":{"name":"Abc"}},"hasNext":true}
                 ---
                 Content-Type: application/json; charset=utf-8
 
@@ -1230,7 +1229,6 @@ public class DeferOverHttpTests(TestServerFactory serverFactory) : ServerTestBas
                 {
                     product {
                         name
-                        description
                     }
                     ... @defer(label: "foo") {
                         product {
@@ -1258,7 +1256,7 @@ public class DeferOverHttpTests(TestServerFactory serverFactory) : ServerTestBas
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         Assert.Contains(
-            "\"data\":{\"product\":{\"name\":\"Abc\",\"description\":\"Abc desc\"}}",
+            "\"data\":{\"product\":{\"name\":\"Abc\"}},\"hasNext\":true",
             content,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -1283,7 +1281,6 @@ public class DeferOverHttpTests(TestServerFactory serverFactory) : ServerTestBas
                 {
                     product {
                         name
-                        description
                     }
                     ... @defer(label: "foo") {
                         product {
@@ -1315,7 +1312,7 @@ public class DeferOverHttpTests(TestServerFactory serverFactory) : ServerTestBas
             .Add(content, "Response")
             .MatchInline(
                 """
-                {"data":{"product":{"name":"Abc","description":"Abc desc"}},"hasNext":true}
+                {"data":{"product":{"name":"Abc"}},"hasNext":true}
                 {"incremental":[{"data":{"product":{"name":"Abc","description":"Abc desc","reviews":[{"rating":5}]}},"path":[],"label":"foo"}],"hasNext":false}
 
                 """);


### PR DESCRIPTION
## Summary
- `DeferOverHttpTests.Defer_Overlap_*_Legacy_Format` flaked because the initial selection included `description`, whose 1000 ms resolver delay raced the deferred fragment's payload — the engine non-deterministically bundled the initial and deferred `@defer` payloads into one instead of two. The xUnit 3 / Microsoft Testing Platform migration shifted scheduling and exposed this pre-existing race.
- Aligned the overlap tests with the pattern used by every other (non-flaky) defer test: the initial selection now contains only the instant `name` field, while the slow `description` field stays inside the `@defer` fragment. The initial payload flushes immediately and the deferred payload reliably lags, so delivery is deterministically two parts.
- No resolver delays were changed. Only the initial-payload snapshots were updated (they drop `description`); the merged incremental payloads are unchanged, so the legacy merge/dedup behavior is still covered via the `name` overlap.

## Test plan
- Ran the three overlap tests 20× in a loop: green every iteration.
- Ran the full `DeferOverHttpTests` class (63 tests): all pass.
