### PR TITLE
Stabilize StarWars subscription tests against CI timing flake

### DIFF
--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/StarWarsCodeFirst/StarWarsCodeFirstTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/StarWarsCodeFirst/StarWarsCodeFirstTests.cs
@@ -822,8 +822,6 @@ public class StarWarsCodeFirstTests(ITestOutputHelper output)
                 """,
                 TestContext.Current.CancellationToken);
 
-        // Get the enumerator before publishing so the consumer is registered
-        // and won't race with event dispatch.
         await using var enumerator = subscriptionResult.ReadResultsAsync().GetAsyncEnumerator(
             TestContext.Current.CancellationToken);
 
@@ -870,6 +868,9 @@ public class StarWarsCodeFirstTests(ITestOutputHelper output)
                 """,
                 TestContext.Current.CancellationToken);
 
+        await using var enumerator = subscriptionResult.ReadResultsAsync().GetAsyncEnumerator(
+            TestContext.Current.CancellationToken);
+
         await executor.ExecuteAsync(
             """
             mutation {
@@ -881,17 +882,10 @@ public class StarWarsCodeFirstTests(ITestOutputHelper output)
             """,
             TestContext.Current.CancellationToken);
 
-        OperationResult? eventResult = null;
-
-        using (var cts = new CancellationTokenSource(2000))
-        {
-            await foreach (var queryResult in
-                subscriptionResult.ReadResultsAsync().WithCancellation(cts.Token))
-            {
-                eventResult = queryResult;
-                break;
-            }
-        }
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(
+            TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken));
+        var eventResult = enumerator.Current;
 
         snapshot.Add(eventResult);
 
@@ -922,6 +916,9 @@ public class StarWarsCodeFirstTests(ITestOutputHelper output)
                 """,
                 TestContext.Current.CancellationToken);
 
+        await using var enumerator = subscriptionResult.ReadResultsAsync().GetAsyncEnumerator(
+            TestContext.Current.CancellationToken);
+
         await executor.ExecuteAsync(
             """
             mutation {
@@ -933,17 +930,10 @@ public class StarWarsCodeFirstTests(ITestOutputHelper output)
             """,
             TestContext.Current.CancellationToken);
 
-        OperationResult? eventResult = null;
-
-        using (var cts = new CancellationTokenSource(2000))
-        {
-            await foreach (var queryResult in
-                subscriptionResult.ReadResultsAsync().WithCancellation(cts.Token))
-            {
-                eventResult = queryResult;
-                break;
-            }
-        }
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(
+            TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken));
+        var eventResult = enumerator.Current;
 
         snapshot.Add(eventResult);
 
@@ -980,6 +970,9 @@ public class StarWarsCodeFirstTests(ITestOutputHelper output)
                     .Build(),
                 TestContext.Current.CancellationToken);
 
+        await using var enumerator = subscriptionResult.ReadResultsAsync().GetAsyncEnumerator(
+            TestContext.Current.CancellationToken);
+
         await executor.ExecuteAsync(
             """
             mutation {
@@ -991,17 +984,10 @@ public class StarWarsCodeFirstTests(ITestOutputHelper output)
             """,
             TestContext.Current.CancellationToken);
 
-        OperationResult? eventResult = null;
-
-        using (var cts = new CancellationTokenSource(2000))
-        {
-            await foreach (var queryResult in
-                subscriptionResult.ReadResultsAsync().WithCancellation(cts.Token))
-            {
-                eventResult = queryResult;
-                break;
-            }
-        }
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(
+            TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken));
+        var eventResult = enumerator.Current;
 
         snapshot.Add(eventResult);
 


### PR DESCRIPTION
## Summary

- Three `StarWarsCodeFirstTests` subscription tests (`SubscribeToReview_WithInlineFragment`, `SubscribeToReview_FragmentDefinition`, `SubscribeToReview_With_Variables`) flaked under the xUnit v3 / Microsoft Testing Platform runner, producing a `null` snapshot instead of the expected `onReview` payload ([example run](https://github.com/ChilliCream/graphql-platform/actions/runs/27502019580/job/81286513112)).
- They bounded the event wait with a 2000 ms `CancellationTokenSource`. Under CI thread-pool starvation the event isn't delivered in time, and `SubscriptionEnumerator.MoveNextAsync` swallows the resulting cancellation, so the read completes with no item and the snapshot mismatches `null`.
- Switched all three to the pattern already used by `SubscribeToReview`: acquire the result enumerator before publishing, then `MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30))` with `Assert.True`, so a genuine failure surfaces as a clear `TimeoutException` rather than a silent `null`. Also dropped the now-redundant explanatory comment so all four tests are uniform.

## Test plan

- `dotnet test src/HotChocolate/Core/test/Execution.Tests/HotChocolate.Execution.Tests.csproj --filter-method "*StarWarsCodeFirstTests.SubscribeToReview*"` → 12/12 passed across net8.0, net9.0, and net10.0.
