### PR TITLE
Replace Codecov with GitHub native code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        informational: true
-    patch:
-      default:
-        informational: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,9 @@ jobs:
     name: Upload Coverage
     needs: library-tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
     steps:
       - name: Download all coverage artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -310,16 +313,30 @@ jobs:
           path: ./output/download
           pattern: coverage-*
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - name: Install .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: 10.x
+
+      - name: Install dotnet-coverage
+        run: |
+          dotnet tool install --global dotnet-coverage --version 18.8.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Merge coverage reports
+        run: >
+          dotnet-coverage merge
+          --output ./output/merged.cobertura.xml
+          --output-format cobertura
+          "./output/download/**/*.cobertura.xml"
+
+      - name: Upload coverage to GitHub
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
         timeout-minutes: 10
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: graphql-platform
-          files: "./output/download/coverage-*/*.cobertura.xml"
-          disable_search: true
-          flags: unittests
-          fail_ci_if_error: true
+          file: ./output/merged.cobertura.xml
+          language: "C#"
+          label: code-coverage/dotnet
 
   validate-nitro-client:
     name: Validate Nitro Client

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -115,6 +115,9 @@ jobs:
     name: Upload Coverage
     needs: library-tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
     steps:
       - name: Download all coverage artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -122,13 +125,27 @@ jobs:
           path: ./output/download
           pattern: coverage-*
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - name: Install .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: 10.x
+
+      - name: Install dotnet-coverage
+        run: |
+          dotnet tool install --global dotnet-coverage --version 18.8.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Merge coverage reports
+        run: >
+          dotnet-coverage merge
+          --output ./output/merged.cobertura.xml
+          --output-format cobertura
+          "./output/download/**/*.cobertura.xml"
+
+      - name: Upload coverage to GitHub
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
         timeout-minutes: 10
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: graphql-platform
-          files: "./output/download/coverage-*/*.cobertura.xml"
-          disable_search: true
-          flags: unittests
-          fail_ci_if_error: true
+          file: ./output/merged.cobertura.xml
+          language: "C#"
+          label: code-coverage/dotnet


### PR DESCRIPTION
## Summary
- Replaces the Codecov upload in both CI workflows (`ci.yml` for PRs, `coverage.yml` for `main`) with GitHub's native code coverage: the per-project Cobertura reports are merged with `dotnet-coverage merge` and the single result is uploaded via `actions/upload-code-coverage` (SHA-pinned), with `code-quality: write` scoped to the `upload-coverage` job.
- Deletes `.github/codecov.yml` and drops the `CODECOV_TOKEN` usage. The test matrix and coverage collection are unchanged.
- Fork-PR coverage is intentionally not carried over: GitHub's native feature does not support PRs from forks yet (acknowledged upstream as a roadmap item).

## Test plan
- Validated the merge locally against a real `coverage.yml` run's 125 `coverage-*` artifacts: `dotnet-coverage 18.8.0 merge … -f cobertura` produced one valid Cobertura report (150 packages, 13,642 classes, line-rate ~0.49).
- Workflows pass YAML parsing and actionlint (the `code-quality` permission-scope warning is a known actionlint gap for this preview feature).
- After merge, requires "Code Quality" enabled on the repo; then the `Upload Coverage` job should be green and `github-code-quality[bot]` should post a coverage summary on PRs. The `CODECOV_TOKEN` secret can then be deleted.
