### PR TITLE
Pin coverage upload action to patched fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
           "./output/download/**/*.cobertura.xml"
 
       - name: Upload coverage to GitHub
-        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
+        uses: ChilliCream/upload-code-coverage@c4b498aa6251701297737919a9b879eaac3f41b4 # fork: scope PR lookup to base repo (upstream #14)
         timeout-minutes: 10
         with:
           file: ./output/merged.cobertura.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -143,7 +143,7 @@ jobs:
           "./output/download/**/*.cobertura.xml"
 
       - name: Upload coverage to GitHub
-        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
+        uses: ChilliCream/upload-code-coverage@c4b498aa6251701297737919a9b879eaac3f41b4 # fork: scope PR lookup to base repo (upstream #14)
         timeout-minutes: 10
         with:
           file: ./output/merged.cobertura.xml


### PR DESCRIPTION
## Summary
- Re-pins the coverage upload step in both workflows from `actions/upload-code-coverage@v1` to our patched fork `ChilliCream/upload-code-coverage@c4b498aa`. Upstream's push-event PR lookup (`gh pr list --head <branch>`) matches cross-repo PRs by head-branch name, so an open fork PR whose head branch is named `main` was hijacking every push-to-`main` upload: coverage got filed under that PR instead of the `main` branch, leaving the baseline empty and PR comments showing "Coverage data for the main branch is not yet available."
- The fork scopes that lookup to head branches in the base repository (owner *and* name), so default-branch pushes record the `main` baseline correctly.
- Reported upstream as `actions/upload-code-coverage#14`; revert to the official action once that lands.

## Test plan
- Verified the scoped `gh pr list … --jq` (filtering `headRepositoryOwner.login` + `headRepository.name` to the base repo) returns empty for the offending fork PR, so `ref` is used instead of a PR number.
- Patched `action.yml` parses as valid YAML; the fork is the same composite action (bash + `python3` + `gh`), pinned by commit SHA.
- Post-merge: the next `coverage.yml` run on `main` should log `pr_number` empty + `ref: refs/heads/main` and register the baseline; subsequent PRs should then show `main` coverage.
