### PR TITLE
Add directives on directive definitions to the mutable type system

### DIFF
--- a/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SchemaFormatter.cs
+++ b/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SchemaFormatter.cs
@@ -485,27 +485,31 @@ public static class SchemaFormatter
             IDirectiveDefinition mutableDirective,
             VisitorContext context)
         {
-            VisitInputFields(mutableDirective.Arguments, context);
-            var arguments = (List<InputValueDefinitionNode>)context.Result!;
-
             VisitDirectives(mutableDirective.Directives, context);
             var directives = (List<DirectiveNode>)context.Result!;
 
             directives = ApplyDeprecatedDirective(mutableDirective, directives);
 
-            context.Result = IsTypeExtension(mutableDirective)
-                ? new DirectiveExtensionNode(
+            if (IsTypeExtension(mutableDirective))
+            {
+                context.Result = new DirectiveExtensionNode(
                     null,
                     new NameNode(mutableDirective.Name),
-                    directives)
-                : (IDefinitionNode)new DirectiveDefinitionNode(
-                    null,
-                    new NameNode(mutableDirective.Name),
-                    CreateDescription(mutableDirective.Description),
-                    mutableDirective.IsRepeatable,
-                    arguments,
-                    directives,
-                    mutableDirective.Locations.ToNameNodes());
+                    directives);
+                return;
+            }
+
+            VisitInputFields(mutableDirective.Arguments, context);
+            var arguments = (List<InputValueDefinitionNode>)context.Result!;
+
+            context.Result = new DirectiveDefinitionNode(
+                null,
+                new NameNode(mutableDirective.Name),
+                CreateDescription(mutableDirective.Description),
+                mutableDirective.IsRepeatable,
+                arguments,
+                directives,
+                mutableDirective.Locations.ToNameNodes());
         }
 
         public override void VisitOutputFields(
@@ -605,7 +609,8 @@ public static class SchemaFormatter
             IDeprecationProvider canBeDeprecated,
             List<DirectiveNode> directives)
         {
-            if (canBeDeprecated.IsDeprecated)
+            if (canBeDeprecated.IsDeprecated
+                && !directives.Any(d => d.Name.Value == DirectiveNames.Deprecated.Name))
             {
                 var deprecateDirective = CreateDeprecatedDirective(canBeDeprecated.DeprecationReason);
 

--- a/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SchemaFormatter.cs
+++ b/src/HotChocolate/Core/src/Types.Abstractions/Serialization/SchemaFormatter.cs
@@ -493,8 +493,12 @@ public static class SchemaFormatter
 
             directives = ApplyDeprecatedDirective(mutableDirective, directives);
 
-            context.Result =
-                new DirectiveDefinitionNode(
+            context.Result = IsTypeExtension(mutableDirective)
+                ? new DirectiveExtensionNode(
+                    null,
+                    new NameNode(mutableDirective.Name),
+                    directives)
+                : (IDefinitionNode)new DirectiveDefinitionNode(
                     null,
                     new NameNode(mutableDirective.Name),
                     CreateDescription(mutableDirective.Description),

--- a/src/HotChocolate/Mutable/src/Types.Mutable/BuiltIns/DeprecatedMutableDirectiveDefinition.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/BuiltIns/DeprecatedMutableDirectiveDefinition.cs
@@ -10,7 +10,8 @@ public sealed class DeprecatedMutableDirectiveDefinition : MutableDirectiveDefin
         Locations = DirectiveLocation.FieldDefinition
             | DirectiveLocation.ArgumentDefinition
             | DirectiveLocation.InputFieldDefinition
-            | DirectiveLocation.EnumValue;
+            | DirectiveLocation.EnumValue
+            | DirectiveLocation.DirectiveDefinition;
     }
 
     public MutableInputFieldDefinition Reason => Arguments[DirectiveNames.Deprecated.Arguments.Reason];

--- a/src/HotChocolate/Mutable/src/Types.Mutable/Extensions/DirectiveLocationExtensions.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/Extensions/DirectiveLocationExtensions.cs
@@ -81,6 +81,10 @@ internal static class DirectiveLocationExtensions
            {
                DirectiveLocation.InputFieldDefinition,
                Language.DirectiveLocation.InputFieldDefinition
+           },
+           {
+               DirectiveLocation.DirectiveDefinition,
+               Language.DirectiveLocation.DirectiveDefinition
            }
        };
 
@@ -162,6 +166,10 @@ internal static class DirectiveLocationExtensions
             {
                 Language.DirectiveLocation.InputFieldDefinition,
                 DirectiveLocation.InputFieldDefinition
+            },
+            {
+                Language.DirectiveLocation.DirectiveDefinition,
+                DirectiveLocation.DirectiveDefinition
             }
         };
 
@@ -269,6 +277,12 @@ internal static class DirectiveLocationExtensions
             == DirectiveLocation.InputFieldDefinition)
         {
             yield return DirectiveLocation.InputFieldDefinition;
+        }
+
+        if ((locations & DirectiveLocation.DirectiveDefinition)
+            == DirectiveLocation.DirectiveDefinition)
+        {
+            yield return DirectiveLocation.DirectiveDefinition;
         }
     }
 

--- a/src/HotChocolate/Mutable/src/Types.Mutable/Extensions/FeatureCollectionExtensions.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/Extensions/FeatureCollectionExtensions.cs
@@ -5,11 +5,11 @@ namespace HotChocolate.Types.Mutable;
 public static class FeatureCollectionExtensions
 {
     /// <summary>
-    /// Marks a type definition as a type extension by setting the
+    /// Marks a type or directive definition as a type extension by setting the
     /// <see cref="TypeExtensionMarker"/> feature, which is consumed by
     /// the canonical SDL formatter to emit the type using <c>extend</c> syntax.
     /// </summary>
     public static void MarkAsExtension<T>(this T type)
-        where T : ITypeDefinition, IFeatureProvider
+        where T : ITypeSystemMember, IFeatureProvider
         => type.Features.Set(TypeExtensionMarker.Instance);
 }

--- a/src/HotChocolate/Mutable/src/Types.Mutable/MutableDirectiveDefinition.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/MutableDirectiveDefinition.cs
@@ -15,6 +15,8 @@ public class MutableDirectiveDefinition
     , IFeatureProvider
 {
     private InputFieldDefinitionCollection? _arguments;
+    private bool _isDeprecated;
+    private DirectiveCollection? _directives;
 
     /// <summary>
     /// Represents a GraphQL directive definition.
@@ -43,6 +45,36 @@ public class MutableDirectiveDefinition
     /// The description of the directive.
     /// </value>
     public string? Description { get; set; }
+
+    /// <inheritdoc cref="IDeprecationProvider.IsDeprecated" />
+    public bool IsDeprecated
+    {
+        get => _isDeprecated;
+        set
+        {
+            _isDeprecated = value;
+
+            if (!value)
+            {
+                DeprecationReason = null;
+            }
+        }
+    }
+
+    /// <inheritdoc cref="IDeprecationProvider.DeprecationReason" />
+    public string? DeprecationReason
+    {
+        get;
+        set
+        {
+            field = value;
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                _isDeprecated = true;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether this directive type is a spec directive.
@@ -85,6 +117,12 @@ public class MutableDirectiveDefinition
 
     public SchemaCoordinate Coordinate
         => new(Name, ofDirective: true);
+
+    public DirectiveCollection Directives
+        => _directives ??= [];
+
+    IReadOnlyDirectiveCollection IDirectivesProvider.Directives
+        => _directives as IReadOnlyDirectiveCollection ?? EmptyCollections.Directives;
 
     public Type RuntimeType => typeof(object);
 

--- a/src/HotChocolate/Mutable/src/Types.Mutable/Serialization/SchemaParser.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/Serialization/SchemaParser.cs
@@ -55,6 +55,7 @@ public static class SchemaParser
         BuildTypes(schema, document, skippedNodes);
         BuildDirectiveTypes(schema, document, skippedNodes);
         ExtendTypes(schema, document, skippedNodes);
+        ExtendDirectiveTypes(schema, document, skippedNodes);
         BuildAndExtendSchema(schema, document, skippedNodes);
     }
 
@@ -192,6 +193,14 @@ public static class SchemaParser
                     default:
                         throw new InvalidOperationException();
                 }
+            }
+
+            if (definition is DirectiveExtensionNode directiveExt
+                && !schema.DirectiveDefinitions.ContainsName(directiveExt.Name.Value))
+            {
+                var directiveType = new MutableDirectiveDefinition(directiveExt.Name.Value);
+                directiveType.MarkAsExtension();
+                schema.DirectiveDefinitions.Add(directiveType);
             }
         }
     }
@@ -942,6 +951,42 @@ public static class SchemaParser
             }
 
             type.Locations |= parsedLocation.MapLocation();
+        }
+    }
+
+    private static void ExtendDirectiveTypes(
+        MutableSchemaDefinition schema,
+        DocumentNode document,
+        HashSet<ISyntaxNode> skip)
+    {
+        foreach (var definition in document.Definitions)
+        {
+            if (skip.Contains(definition))
+            {
+                continue;
+            }
+
+            if (definition is DirectiveExtensionNode directiveExt)
+            {
+                ExtendDirectiveType(
+                    schema,
+                    schema.DirectiveDefinitions[directiveExt.Name.Value],
+                    directiveExt);
+            }
+        }
+    }
+
+    private static void ExtendDirectiveType(
+        MutableSchemaDefinition schema,
+        MutableDirectiveDefinition type,
+        DirectiveExtensionNode node)
+    {
+        MergeDirectives(schema, type.Directives, node.Directives, $"@{type.Name}");
+
+        if (IsDeprecated(type.Directives, out var reason))
+        {
+            type.IsDeprecated = true;
+            type.DeprecationReason = reason;
         }
     }
 

--- a/src/HotChocolate/Mutable/src/Types.Mutable/Serialization/SchemaParser.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/Serialization/SchemaParser.cs
@@ -893,6 +893,14 @@ public static class SchemaParser
         type.Description = node.Description?.Value;
         type.IsRepeatable = node.IsRepeatable;
 
+        BuildDirectiveCollection(schema, type.Directives, node.Directives);
+
+        if (IsDeprecated(type.Directives, out var deprecationReason))
+        {
+            type.IsDeprecated = true;
+            type.DeprecationReason = deprecationReason;
+        }
+
         foreach (var argumentNode in node.Arguments)
         {
             var builtArgumentType = schema.Types.BuildType(argumentNode.Type);

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/MutableDirectiveDefinitionTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/MutableDirectiveDefinitionTests.cs
@@ -1,0 +1,49 @@
+namespace HotChocolate.Types.Mutable;
+
+public class MutableDirectiveDefinitionTests
+{
+    [Fact]
+    public void SetDeprecationReason_Should_MarkAsDeprecated()
+    {
+        // arrange
+        var directiveDefinition = new MutableDirectiveDefinition("foo");
+
+        // act
+        directiveDefinition.DeprecationReason = "Use bar.";
+
+        // assert
+        Assert.True(directiveDefinition.IsDeprecated);
+        Assert.Equal("Use bar.", directiveDefinition.DeprecationReason);
+    }
+
+    [Fact]
+    public void IsDeprecated_Should_ClearDeprecationReason_When_SetToFalse()
+    {
+        // arrange
+        var directiveDefinition = new MutableDirectiveDefinition("foo")
+        {
+            DeprecationReason = "Use bar."
+        };
+
+        // act
+        directiveDefinition.IsDeprecated = false;
+
+        // assert
+        Assert.False(directiveDefinition.IsDeprecated);
+        Assert.Null(directiveDefinition.DeprecationReason);
+    }
+
+    [Fact]
+    public void Directives_Should_ContainAddedDirective()
+    {
+        // arrange
+        var metaDefinition = new MutableDirectiveDefinition("meta");
+        var directiveDefinition = new MutableDirectiveDefinition("foo");
+
+        // act
+        directiveDefinition.Directives.Add(new Directive(metaDefinition));
+
+        // assert
+        Assert.True(directiveDefinition.Directives.ContainsName("meta"));
+    }
+}

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/MutableDirectiveDefinitionTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/MutableDirectiveDefinitionTests.cs
@@ -46,4 +46,17 @@ public class MutableDirectiveDefinitionTests
         // assert
         Assert.True(directiveDefinition.Directives.ContainsName("meta"));
     }
+
+    [Fact]
+    public void BuiltInDeprecatedDirective_Should_DeclareDirectiveDefinitionLocation()
+    {
+        // arrange
+        var schema = new MutableSchemaDefinition();
+
+        // act
+        var deprecated = BuiltIns.Deprecated.Create(schema);
+
+        // assert
+        Assert.True(deprecated.Locations.HasFlag(DirectiveLocation.DirectiveDefinition));
+    }
 }

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaParserTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaParserTests.cs
@@ -800,4 +800,26 @@ public class SchemaParserTests
             DirectiveLocation.DirectiveDefinition,
             schema.DirectiveDefinitions["meta"].Locations);
     }
+
+    [Fact]
+    public void Parse_Should_ReadDirectivesOnDirectiveDefinition()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+
+            directive @foo @meta(value: "a") @deprecated(reason: "Use bar") on OBJECT
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        var directiveDefinition = schema.DirectiveDefinitions["foo"];
+        Assert.True(directiveDefinition.Directives.ContainsName("meta"));
+        Assert.True(directiveDefinition.IsDeprecated);
+        Assert.Equal("Use bar", directiveDefinition.DeprecationReason);
+        Assert.True(directiveDefinition.Directives.ContainsName("deprecated"));
+    }
 }

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaParserTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaParserTests.cs
@@ -785,4 +785,19 @@ public class SchemaParserTests
         Assert.Equal("Use newId", field.DeprecationReason);
         Assert.True(field.Directives.ContainsName("deprecated"));
     }
+
+    [Fact]
+    public void Parse_Should_MapDirectiveDefinitionLocation_When_DirectiveDeclaresIt()
+    {
+        // arrange
+        const string sdl = "directive @meta on DIRECTIVE_DEFINITION";
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        Assert.Equal(
+            DirectiveLocation.DirectiveDefinition,
+            schema.DirectiveDefinitions["meta"].Locations);
+    }
 }

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaParserTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaParserTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using HotChocolate.Features;
 using HotChocolate.Types.Mutable.Serialization;
 
 namespace HotChocolate.Types.Mutable;
@@ -821,5 +822,89 @@ public class SchemaParserTests
         Assert.True(directiveDefinition.IsDeprecated);
         Assert.Equal("Use bar", directiveDefinition.DeprecationReason);
         Assert.True(directiveDefinition.Directives.ContainsName("deprecated"));
+    }
+
+    [Fact]
+    public void Parse_Should_MergeDirectives_When_DirectiveExtensionTargetsExistingDefinition()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+
+            directive @foo on OBJECT
+
+            extend directive @foo @meta(value: "a")
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        Assert.True(schema.DirectiveDefinitions["foo"].Directives.ContainsName("meta"));
+    }
+
+    [Fact]
+    public void Parse_Should_MarkDirectiveDefinitionAsDeprecated_When_ExtensionAppliesDeprecated()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @foo on OBJECT
+
+            extend directive @foo @deprecated(reason: "Use bar")
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        var directiveDefinition = schema.DirectiveDefinitions["foo"];
+        Assert.True(directiveDefinition.IsDeprecated);
+        Assert.Equal("Use bar", directiveDefinition.DeprecationReason);
+        Assert.True(directiveDefinition.Directives.ContainsName("deprecated"));
+    }
+
+    [Fact]
+    public void Parse_Should_Throw_When_DirectiveExtensionAppliesNonRepeatableDirectiveAlreadyApplied()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+
+            directive @foo @meta(value: "a") on OBJECT
+
+            extend directive @foo @meta(value: "b")
+            """;
+
+        // act
+        static void Action() => SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        Assert.Equal(
+            "The non-repeatable directive '@meta' was already applied to '@foo' "
+            + "and cannot be applied again by an extension.",
+            Assert.Throws<SchemaInitializationException>(Action).Message);
+    }
+
+    [Fact]
+    public void Parse_Should_CreateDirectiveDefinition_When_ExtensionTargetsUnknownDirective()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+
+            extend directive @foo @meta(value: "a")
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        var directiveDefinition = schema.DirectiveDefinitions["foo"];
+        Assert.True(directiveDefinition.Directives.ContainsName("meta"));
+        Assert.NotNull(directiveDefinition.Features.Get<TypeExtensionMarker>());
     }
 }

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/ToStringTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/ToStringTests.cs
@@ -151,4 +151,27 @@ public class ToStringTests
                 field: String
                 """);
     }
+
+    [Fact]
+    public void Schema_With_DirectivesOnDirectiveDefinition_ToString()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @foo @meta(value: "a") on OBJECT
+
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        schema.ToString().MatchInlineSnapshot(
+            """
+            directive @foo @meta(value: "a") on OBJECT
+
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+            """);
+    }
 }

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/ToStringTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/ToStringTests.cs
@@ -174,4 +174,27 @@ public class ToStringTests
             directive @meta(value: String) on DIRECTIVE_DEFINITION
             """);
     }
+
+    [Fact]
+    public void Schema_With_DirectiveExtension_ToString()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+
+            extend directive @foo @meta(value: "a")
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        schema.ToString().MatchInlineSnapshot(
+            """
+            extend directive @foo @meta(value: "a")
+
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+            """);
+    }
 }

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/ToStringTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/ToStringTests.cs
@@ -197,4 +197,23 @@ public class ToStringTests
             directive @meta(value: String) on DIRECTIVE_DEFINITION
             """);
     }
+
+    [Fact]
+    public void Schema_With_DeprecatedDirectiveDefinition_ToString()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @foo @deprecated(reason: "x") on OBJECT
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        schema.ToString().MatchInlineSnapshot(
+            """
+            directive @foo @deprecated(reason: "x") on OBJECT
+            """);
+    }
 }

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/ToSyntaxNodeTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/ToSyntaxNodeTests.cs
@@ -178,6 +178,50 @@ public class ToSyntaxNodeTests
     }
 
     [Fact]
+    public void DirectiveType_With_Directives_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            directive @meta(value: String) on DIRECTIVE_DEFINITION
+
+            directive @foo @meta(value: "a") on FIELD
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = schema.DirectiveDefinitions["foo"].ToSyntaxNode();
+
+        // assert
+        Assert.IsType<DirectiveDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot(
+            """
+            directive @foo @meta(value: "a") on FIELD
+            """);
+    }
+
+    [Fact]
+    public void DirectiveType_Deprecated_ToSyntaxNode()
+    {
+        // arrange
+        // the deprecation state is set programmatically, so the formatter synthesizes @deprecated
+        var directiveDefinition = new MutableDirectiveDefinition("foo")
+        {
+            Locations = DirectiveLocation.Object,
+            DeprecationReason = "Use bar"
+        };
+
+        // act
+        var syntaxNode = directiveDefinition.ToSyntaxNode();
+
+        // assert
+        syntaxNode.ToString().MatchInlineSnapshot(
+            """
+            directive @foo @deprecated(reason: "Use bar") on OBJECT
+            """);
+    }
+
+    [Fact]
     public void ArgumentAssignment_ToSyntaxNode()
     {
         // arrange


### PR DESCRIPTION
## Summary

- Completes "directives on directive definitions" in the mutable type system (the schema model used by Fusion composition): `MutableDirectiveDefinition` now carries applied directives and deprecation state, and `SchemaParser` reads directives and `@deprecated` on directive definitions and applies `extend directive`.
- Round-trips the new surface through `ToSyntaxNode()` and `SchemaFormatter` (`ToString()`), including printing extension-marked definitions as `extend directive`, and maps `DIRECTIVE_DEFINITION` in the mutable location tables and on the built-in `@deprecated`.

## Test plan

- New unit tests in `Types.Mutable.Tests` cover the model state, location mapping, parser reads, `extend directive` (merge, deprecate, non-repeatable-duplicate, unknown-target creation), and round-trip printing; full project green (78 tests).
- Fusion regression check: `HotChocolate.Fusion.slnx` builds clean and `Fusion.Composition.Tests` passes (517 tests) with zero snapshot changes, confirming schemas that do not use the feature round-trip identically.

Part of the directives on directive definitions effort (#4625); third of three stacked PRs (Language, Core, and Mutable round-trip).
