### PR TITLE
Stabilize `@defer`/`@stream` snapshots with canonical envelope

### DIFF
--- a/src/CookieCrumble/src/CookieCrumble.HotChocolate/Extensions/SnapshotExtensions.cs
+++ b/src/CookieCrumble/src/CookieCrumble.HotChocolate/Extensions/SnapshotExtensions.cs
@@ -24,34 +24,6 @@ public static class SnapshotExtensions
             postFix,
             formatter: CoreFormatters.PlainText);
 
-    /// <summary>
-    /// Matches a snapshot of an execution result, merging an incrementally delivered
-    /// (<c>@defer</c>/<c>@stream</c>) response into its final aggregated form. The snapshot
-    /// is identical whether the transport delivered the response across several payloads or
-    /// as a single bundled payload, so it does not depend on delivery timing.
-    /// </summary>
-    public static void MatchAggregatedSnapshot(
-        this IExecutionResult? value,
-        string? postFix = null)
-        => Snapshot.Match(
-            value,
-            postFix,
-            formatter: SnapshotValueFormatters.ExecutionResultAggregated);
-
-    /// <summary>
-    /// Markdown counterpart of <see cref="MatchAggregatedSnapshot"/>: matches a markdown
-    /// snapshot of an execution result, merging an incrementally delivered
-    /// (<c>@defer</c>/<c>@stream</c>) response into its final aggregated form so the snapshot
-    /// does not depend on whether the transport delivered it incrementally or bundled.
-    /// </summary>
-    public static void MatchAggregatedMarkdownSnapshot(
-        this IExecutionResult? value,
-        object? postFix = null,
-        string? extension = null)
-        => Snapshot.Create(postFix?.ToString(), extension)
-            .Add(value, formatter: SnapshotValueFormatters.ExecutionResultAggregated)
-            .MatchMarkdown();
-
     public static Snapshot AddResult(
         this Snapshot snapshot,
         IExecutionResult result,

--- a/src/CookieCrumble/src/CookieCrumble.HotChocolate/Formatters/ExecutionResultSnapshotValueFormatter.cs
+++ b/src/CookieCrumble/src/CookieCrumble.HotChocolate/Formatters/ExecutionResultSnapshotValueFormatter.cs
@@ -43,12 +43,29 @@ internal sealed class ExecutionResultSnapshotValueFormatter
         snapshot.AppendLine();
     }
 
+    private static Task FormatStreamAsync(IBufferWriter<byte> snapshot, IResponseStream stream)
+        // Only @defer/@stream responses carry the incremental-delivery envelope. Other
+        // streams (subscriptions, batches) are sequences of independent results and are
+        // written out verbatim, one payload after another.
+        => stream.Kind is ExecutionResultKind.DeferredResult
+            ? FormatIncrementalAsync(snapshot, stream)
+            : FormatEventStreamAsync(snapshot, stream);
+
+    private static async Task FormatEventStreamAsync(IBufferWriter<byte> snapshot, IResponseStream stream)
+    {
+        await foreach (var result in stream.ReadResultsAsync().ConfigureAwait(false))
+        {
+            snapshot.Append(result.ToJson());
+            snapshot.AppendLine();
+        }
+    }
+
     // Reconstructs a single, delivery-order-independent view of an incrementally
     // delivered (@defer/@stream) response: the initial payload's non-protocol
     // fields plus the `pending`, `incremental`, and `completed` entries collected
     // across every payload and ordered by `id`. The snapshot is identical whether
     // the transport bundled the response into one payload or split it across several.
-    private static async Task FormatStreamAsync(
+    private static async Task FormatIncrementalAsync(
         IBufferWriter<byte> snapshot,
         IResponseStream stream)
     {

--- a/src/CookieCrumble/src/CookieCrumble.HotChocolate/Formatters/ExecutionResultSnapshotValueFormatter.cs
+++ b/src/CookieCrumble/src/CookieCrumble.HotChocolate/Formatters/ExecutionResultSnapshotValueFormatter.cs
@@ -4,10 +4,11 @@ using System.Text.Json.Nodes;
 using CookieCrumble.Formatters;
 using HotChocolate;
 using HotChocolate.Execution;
+using static CookieCrumble.HotChocolate.Formatters.StableSnapshotHelpers;
 
 namespace CookieCrumble.HotChocolate.Formatters;
 
-internal sealed class ExecutionResultSnapshotValueFormatter(bool alwaysAggregate = false)
+internal sealed class ExecutionResultSnapshotValueFormatter
     : SnapshotValueFormatter<IExecutionResult>
 {
     protected override void Format(IBufferWriter<byte> snapshot, IExecutionResult value)
@@ -18,7 +19,7 @@ internal sealed class ExecutionResultSnapshotValueFormatter(bool alwaysAggregate
         }
         else
         {
-            FormatStreamAsync(snapshot, (IResponseStream)value, alwaysAggregate).Wait();
+            FormatStreamAsync(snapshot, (IResponseStream)value).Wait();
         }
     }
 
@@ -34,7 +35,7 @@ internal sealed class ExecutionResultSnapshotValueFormatter(bool alwaysAggregate
         {
             snapshot.Append("```text");
             snapshot.AppendLine();
-            FormatStreamAsync(snapshot, (IResponseStream)value, alwaysAggregate).Wait();
+            FormatStreamAsync(snapshot, (IResponseStream)value).Wait();
         }
 
         snapshot.AppendLine();
@@ -42,65 +43,231 @@ internal sealed class ExecutionResultSnapshotValueFormatter(bool alwaysAggregate
         snapshot.AppendLine();
     }
 
+    // Reconstructs a single, delivery-order-independent view of an incrementally
+    // delivered (@defer/@stream) response: the initial payload's non-protocol
+    // fields plus the `pending`, `incremental`, and `completed` entries collected
+    // across every payload and ordered by `id`. The snapshot is identical whether
+    // the transport bundled the response into one payload or split it across several.
     private static async Task FormatStreamAsync(
         IBufferWriter<byte> snapshot,
-        IResponseStream stream,
-        bool alwaysAggregate)
+        IResponseStream stream)
     {
-        var docs = new List<JsonDocument>();
-        JsonResultPatcher? patcher = null;
-        var first = true;
+        var documents = new List<JsonDocument>();
+        var accumulator = new StreamAccumulator();
 
         try
         {
-            await foreach (var queryResult in stream.ReadResultsAsync().ConfigureAwait(false))
+            await foreach (var result in stream.ReadResultsAsync().ConfigureAwait(false))
             {
-                if (first)
-                {
-                    first = false;
-
-                    // When aggregating, the initial payload seeds the patcher regardless of
-                    // whether more payloads follow. This normalizes a response delivered as a
-                    // single bundled payload to the same merged form as an incrementally
-                    // delivered one, so the snapshot is independent of delivery batching.
-                    if (alwaysAggregate || (queryResult.HasNext ?? false))
-                    {
-                        var doc = JsonDocument.Parse(queryResult.ToJson());
-                        docs.Add(doc);
-
-                        patcher = new JsonResultPatcher();
-                        patcher.SetResponse(doc);
-                        continue;
-                    }
-                }
-
-                if (patcher is null)
-                {
-                    snapshot.Append(queryResult.ToJson());
-                    snapshot.AppendLine();
-                }
-                else
-                {
-                    var doc = JsonDocument.Parse(queryResult.ToJson());
-                    docs.Add(doc);
-
-                    patcher.ApplyPatch(doc);
-                }
+                var document = JsonDocument.Parse(result.ToJson());
+                documents.Add(document);
+                accumulator.AddPayload(document.RootElement);
             }
 
-            if (patcher is not null)
-            {
-                patcher.WriteResponse(snapshot);
-                snapshot.AppendLine();
-            }
+            await using var writer = new Utf8JsonWriter(snapshot, IndentedWriterOptions);
+            WriteEnvelope(writer, accumulator);
+            writer.Flush();
+            snapshot.AppendLine();
         }
         finally
         {
-            foreach (var doc in docs)
+            foreach (var document in documents)
             {
-                doc.Dispose();
+                document.Dispose();
             }
         }
+    }
+
+    private static void WriteEnvelope(Utf8JsonWriter writer, StreamAccumulator accumulator)
+    {
+        writer.WriteStartObject();
+
+        // The initial payload's non-protocol fields (`data`, `errors`, `extensions`) in
+        // their original order; the incremental-delivery fields are rebuilt below.
+        if (accumulator.InitialPayload is { ValueKind: JsonValueKind.Object } initial)
+        {
+            foreach (var property in initial.EnumerateObject())
+            {
+                if (IsStreamField(property.Name))
+                {
+                    continue;
+                }
+
+                writer.WritePropertyName(property.Name);
+                property.Value.WriteTo(writer);
+            }
+        }
+
+        WritePending(writer, accumulator.PendingById);
+        WriteIncremental(writer, accumulator.IncrementalEntries);
+        WriteCompleted(writer, accumulator.CompletedEntries);
+
+        writer.WriteBoolean("hasNext", false);
+
+        writer.WriteEndObject();
+    }
+
+    private static void WritePending(
+        Utf8JsonWriter writer,
+        Dictionary<string, PendingEntry> pendingById)
+    {
+        if (pendingById.Count == 0)
+        {
+            return;
+        }
+
+        var pending = pendingById.Values.ToList();
+        pending.Sort(static (x, y) => CompareIds(x.Id, y.Id));
+
+        writer.WritePropertyName("pending");
+        writer.WriteStartArray();
+
+        foreach (var entry in pending)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("id", entry.Id);
+            writer.WritePropertyName("path");
+            entry.Path.WriteTo(writer);
+
+            if (!string.IsNullOrEmpty(entry.Label))
+            {
+                writer.WriteString("label", entry.Label);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static void WriteIncremental(
+        Utf8JsonWriter writer,
+        List<IncrementalEntry> entries)
+    {
+        if (entries.Count == 0)
+        {
+            return;
+        }
+
+        // Group by `id` so a stream delivered across several payloads collapses into a
+        // single entry, independent of how many frames the transport used.
+        var order = new List<string>();
+        var byId = new Dictionary<string, List<IncrementalEntry>>();
+
+        foreach (var entry in entries)
+        {
+            if (!byId.TryGetValue(entry.Id, out var group))
+            {
+                group = [];
+                byId.Add(entry.Id, group);
+                order.Add(entry.Id);
+            }
+
+            group.Add(entry);
+        }
+
+        order.Sort(CompareIds);
+
+        writer.WritePropertyName("incremental");
+        writer.WriteStartArray();
+
+        foreach (var id in order)
+        {
+            var group = byId[id];
+
+            writer.WriteStartObject();
+            writer.WriteString("id", id);
+
+            if (group.FirstOrDefault(e => e.SubPath is not null)?.SubPath is { } subPath)
+            {
+                writer.WritePropertyName("subPath");
+                subPath.WriteTo(writer);
+            }
+
+            if (group.Any(e => e.Items is not null))
+            {
+                writer.WritePropertyName("items");
+                writer.WriteStartArray();
+                foreach (var entry in group)
+                {
+                    if (entry.Items is { } items)
+                    {
+                        foreach (var item in items.EnumerateArray())
+                        {
+                            item.WriteTo(writer);
+                        }
+                    }
+                }
+                writer.WriteEndArray();
+            }
+            else if (group.FirstOrDefault(e => e.Data is not null)?.Data is { } data)
+            {
+                writer.WritePropertyName("data");
+                data.WriteTo(writer);
+            }
+
+            WriteMergedErrors(writer, group);
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static void WriteCompleted(
+        Utf8JsonWriter writer,
+        List<CompletedEntry> entries)
+    {
+        if (entries.Count == 0)
+        {
+            return;
+        }
+
+        var completed = entries.ToList();
+        completed.Sort(static (x, y) => CompareIds(x.Id, y.Id));
+
+        writer.WritePropertyName("completed");
+        writer.WriteStartArray();
+
+        foreach (var entry in completed)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("id", entry.Id);
+
+            if (entry.Errors is { } errors)
+            {
+                writer.WritePropertyName("errors");
+                errors.WriteTo(writer);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static void WriteMergedErrors(Utf8JsonWriter writer, List<IncrementalEntry> group)
+    {
+        if (!group.Any(e => e.Errors is not null))
+        {
+            return;
+        }
+
+        writer.WritePropertyName("errors");
+        writer.WriteStartArray();
+
+        foreach (var entry in group)
+        {
+            if (entry.Errors is { } errors)
+            {
+                foreach (var error in errors.EnumerateArray())
+                {
+                    error.WriteTo(writer);
+                }
+            }
+        }
+
+        writer.WriteEndArray();
     }
 }
 

--- a/src/CookieCrumble/src/CookieCrumble.HotChocolate/Formatters/ExecutionResultSnapshotValueFormatter.cs
+++ b/src/CookieCrumble/src/CookieCrumble.HotChocolate/Formatters/ExecutionResultSnapshotValueFormatter.cs
@@ -69,30 +69,21 @@ internal sealed class ExecutionResultSnapshotValueFormatter
         IBufferWriter<byte> snapshot,
         IResponseStream stream)
     {
-        var documents = new List<JsonDocument>();
         var accumulator = new StreamAccumulator();
 
-        try
+        // StreamAccumulator deep-clones every element it retains, so each parsed
+        // document is only needed for the duration of its AddPayload call and can be
+        // disposed immediately afterwards.
+        await foreach (var result in stream.ReadResultsAsync().ConfigureAwait(false))
         {
-            await foreach (var result in stream.ReadResultsAsync().ConfigureAwait(false))
-            {
-                var document = JsonDocument.Parse(result.ToJson());
-                documents.Add(document);
-                accumulator.AddPayload(document.RootElement);
-            }
+            using var document = JsonDocument.Parse(result.ToJson());
+            accumulator.AddPayload(document.RootElement);
+        }
 
-            await using var writer = new Utf8JsonWriter(snapshot, IndentedWriterOptions);
-            WriteEnvelope(writer, accumulator);
-            writer.Flush();
-            snapshot.AppendLine();
-        }
-        finally
-        {
-            foreach (var document in documents)
-            {
-                document.Dispose();
-            }
-        }
+        await using var writer = new Utf8JsonWriter(snapshot, IndentedWriterOptions);
+        WriteEnvelope(writer, accumulator);
+        writer.Flush();
+        snapshot.AppendLine();
     }
 
     private static void WriteEnvelope(Utf8JsonWriter writer, StreamAccumulator accumulator)

--- a/src/CookieCrumble/src/CookieCrumble.HotChocolate/Formatters/SnapshotValueFormatters.cs
+++ b/src/CookieCrumble/src/CookieCrumble.HotChocolate/Formatters/SnapshotValueFormatters.cs
@@ -10,9 +10,6 @@ public static class SnapshotValueFormatters
     public static ISnapshotValueFormatter ExecutionResult { get; } =
         new ExecutionResultSnapshotValueFormatter();
 
-    public static ISnapshotValueFormatter ExecutionResultAggregated { get; } =
-        new ExecutionResultSnapshotValueFormatter(alwaysAggregate: true);
-
     public static ISnapshotValueFormatter ExecutionResultStable { get; } =
         new StableExecutionResultSnapshotValueFormatter();
 

--- a/src/HotChocolate/Core/test/Execution.Tests/DeferReferenceTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/DeferReferenceTests.cs
@@ -34,7 +34,7 @@ public class DeferReferenceTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     /// <summary>
@@ -232,7 +232,7 @@ public class DeferReferenceTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     // ========================================================================
@@ -430,7 +430,7 @@ public class DeferReferenceTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     /// <summary>
@@ -513,7 +513,7 @@ public class DeferReferenceTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     // ========================================================================
@@ -670,7 +670,7 @@ public class DeferReferenceTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     /// <summary>

--- a/src/HotChocolate/Core/test/Execution.Tests/DeferTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/DeferTests.cs
@@ -25,7 +25,7 @@ public class DeferTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class DeferTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class DeferTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class DeferTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     [Fact]
@@ -176,7 +176,7 @@ public class DeferTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class DeferTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public class DeferTests
                 .Build(),
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     [Fact]
@@ -349,7 +349,7 @@ public class DeferTests
                 .Build(),
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     [Fact]
@@ -382,7 +382,7 @@ public class DeferTests
                 .Build(),
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedMarkdownSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchMarkdownSnapshot();
     }
 
     private class StateRequestInterceptor : DefaultHttpRequestInterceptor

--- a/src/HotChocolate/Core/test/Execution.Tests/StreamTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/StreamTests.cs
@@ -30,7 +30,7 @@ public class StreamTests
             }",
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchSnapshot();
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class StreamTests
             }",
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchSnapshot();
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class StreamTests
             }",
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchSnapshot();
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class StreamTests
             }",
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchSnapshot();
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public class StreamTests
             """,
             TestContext.Current.CancellationToken);
 
-        Assert.IsType<ResponseStream>(result).MatchAggregatedSnapshot();
+        Assert.IsType<ResponseStream>(result).MatchSnapshot();
     }
 
     [Fact]

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.Deduplicates_List_Fields_In_Initial_Payload.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.Deduplicates_List_Fields_In_Initial_Payload.md
@@ -6,20 +6,75 @@
     "hero": {
       "friends": [
         {
-          "id": "friend-1",
-          "name": "Han"
+          "id": "friend-1"
         },
         {
-          "id": "friend-2",
-          "name": "Leia"
+          "id": "friend-2"
         },
         {
-          "id": "friend-3",
-          "name": "C-3PO"
+          "id": "friend-3"
         }
       ]
     }
-  }
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": [
+        "hero",
+        "friends",
+        0
+      ]
+    },
+    {
+      "id": "3",
+      "path": [
+        "hero",
+        "friends",
+        1
+      ]
+    },
+    {
+      "id": "4",
+      "path": [
+        "hero",
+        "friends",
+        2
+      ]
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "name": "Han"
+      }
+    },
+    {
+      "id": "3",
+      "data": {
+        "name": "Leia"
+      }
+    },
+    {
+      "id": "4",
+      "data": {
+        "name": "C-3PO"
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    },
+    {
+      "id": "3"
+    },
+    {
+      "id": "4"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.Defer_Fragment_With_Error.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.Defer_Fragment_With_Error.md
@@ -4,10 +4,40 @@
 {
   "data": {
     "hero": {
-      "id": "hero-1",
-      "errorField": null
+      "id": "hero-1"
     }
-  }
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": [
+        "hero"
+      ]
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "errorField": null
+      },
+      "errors": [
+        {
+          "message": "resolver error",
+          "path": [
+            "hero",
+            "errorField"
+          ]
+        }
+      ]
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.Defer_Fragment_With_Errors_On_Top_Level_Query_Field.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.Defer_Fragment_With_Errors_On_Top_Level_Query_Field.md
@@ -2,9 +2,39 @@
 
 ```text
 {
-  "data": {
-    "a": null
-  }
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "a": null
+      },
+      "errors": [
+        {
+          "message": "Cannot return null for non-nullable field.",
+          "path": [
+            "a",
+            "nonNullErrorField"
+          ],
+          "extensions": {
+            "code": "HC0018"
+          }
+        }
+      ]
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.Emits_Children_Of_Empty_Defer_Fragment.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.Emits_Children_Of_Empty_Defer_Fragment.md
@@ -4,10 +4,31 @@
 {
   "data": {
     "hero": {
-      "id": "hero-1",
-      "name": "Luke"
+      "id": "hero-1"
     }
-  }
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": [
+        "hero"
+      ]
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "name": "Luke"
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.InlineFragment_Defer_With_TypeCondition.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferReferenceTests.InlineFragment_Defer_With_TypeCondition.md
@@ -4,10 +4,31 @@
 {
   "data": {
     "hero": {
-      "id": "hero-1",
-      "name": "Luke"
+      "id": "hero-1"
     }
-  }
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": [
+        "hero"
+      ]
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "name": "Luke"
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.Ensure_GlobalState_Is_Passed_To_DeferContext_Single_Defer.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.Ensure_GlobalState_Is_Passed_To_DeferContext_Single_Defer.md
@@ -3,10 +3,30 @@
 ```text
 {
   "data": {
-    "ensureState": {
-      "state": "state 123"
+    "ensureState": {}
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": [
+        "ensureState"
+      ]
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "state": "state 123"
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.Ensure_GlobalState_Is_Passed_To_DeferContext_Single_Defer_2.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.Ensure_GlobalState_Is_Passed_To_DeferContext_Single_Defer_2.md
@@ -2,11 +2,29 @@
 
 ```text
 {
-  "data": {
-    "ensureState": {
-      "state": "state 123"
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": []
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "ensureState": {
+          "state": "state 123"
+        }
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.Ensure_GlobalState_Is_Passed_To_DeferContext_Stacked_Defer.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.Ensure_GlobalState_Is_Passed_To_DeferContext_Stacked_Defer.md
@@ -2,11 +2,42 @@
 
 ```text
 {
-  "data": {
-    "ensureState": {
-      "state": "state 123"
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    },
+    {
+      "id": "3",
+      "path": [
+        "ensureState"
+      ]
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "ensureState": {}
+      }
+    },
+    {
+      "id": "3",
+      "data": {
+        "state": "state 123"
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    },
+    {
+      "id": "3"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.Ensure_GlobalState_Is_Passed_To_DeferContext_Stacked_Defer_2.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.Ensure_GlobalState_Is_Passed_To_DeferContext_Stacked_Defer_2.md
@@ -2,13 +2,58 @@
 
 ```text
 {
-  "data": {
-    "e": {
-      "more": {
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    },
+    {
+      "id": "3",
+      "path": [
+        "e"
+      ]
+    },
+    {
+      "id": "4",
+      "path": [
+        "e",
+        "more"
+      ]
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "e": {}
+      }
+    },
+    {
+      "id": "3",
+      "data": {
+        "more": {}
+      }
+    },
+    {
+      "id": "4",
+      "data": {
         "stuff": "state 123"
       }
     }
-  }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    },
+    {
+      "id": "3"
+    },
+    {
+      "id": "4"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.FragmentSpread_Defer.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.FragmentSpread_Defer.md
@@ -2,11 +2,29 @@
 
 ```text
 {
-  "data": {
-    "person": {
-      "id": "UGVyc29uOjE="
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": []
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "person": {
+          "id": "UGVyc29uOjE="
+        }
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.FragmentSpread_Defer_Label_Set_To_abc.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.FragmentSpread_Defer_Label_Set_To_abc.md
@@ -2,11 +2,30 @@
 
 ```text
 {
-  "data": {
-    "person": {
-      "id": "UGVyc29uOjE="
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": [],
+      "label": "abc"
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "person": {
+          "id": "UGVyc29uOjE="
+        }
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.FragmentSpread_Defer_Nested.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.FragmentSpread_Defer_Nested.md
@@ -2,12 +2,44 @@
 
 ```text
 {
-  "data": {
-    "person": {
-      "id": "UGVyc29uOjE=",
-      "name": "Pascal"
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    },
+    {
+      "id": "3",
+      "path": [
+        "person"
+      ]
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "person": {
+          "id": "UGVyc29uOjE="
+        }
+      }
+    },
+    {
+      "id": "3",
+      "data": {
+        "name": "Pascal"
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    },
+    {
+      "id": "3"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.InlineFragment_Defer.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.InlineFragment_Defer.md
@@ -2,11 +2,29 @@
 
 ```text
 {
-  "data": {
-    "person": {
-      "id": "UGVyc29uOjE="
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": []
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "person": {
+          "id": "UGVyc29uOjE="
+        }
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.InlineFragment_Defer_Label_Set_To_abc.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.InlineFragment_Defer_Label_Set_To_abc.md
@@ -2,11 +2,30 @@
 
 ```text
 {
-  "data": {
-    "person": {
-      "id": "UGVyc29uOjE="
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": [],
+      "label": "abc"
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "person": {
+          "id": "UGVyc29uOjE="
+        }
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.InlineFragment_Defer_Nested.md
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/DeferTests.InlineFragment_Defer_Nested.md
@@ -2,12 +2,44 @@
 
 ```text
 {
-  "data": {
-    "person": {
-      "id": "UGVyc29uOjE=",
-      "name": "Pascal"
+  "data": {},
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    },
+    {
+      "id": "3",
+      "path": [
+        "person"
+      ]
     }
-  }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "person": {
+          "id": "UGVyc29uOjE="
+        }
+      }
+    },
+    {
+      "id": "3",
+      "data": {
+        "name": "Pascal"
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    },
+    {
+      "id": "3"
+    }
+  ],
+  "hasNext": false
 }
 
 ```

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream.snap
@@ -13,7 +13,26 @@
       {
         "id": "UGVyc29uOjQ="
       }
-    ],
-    "wait": true
-  }
+    ]
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "wait": true
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_InitialCount_Exceeds_Total_Count.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_InitialCount_Exceeds_Total_Count.snap
@@ -13,7 +13,26 @@
       {
         "id": "UGVyc29uOjQ="
       }
-    ],
-    "wait": true
-  }
+    ]
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "wait": true
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_InitialCount_Set_To_1.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_InitialCount_Set_To_1.snap
@@ -13,7 +13,26 @@
       {
         "id": "UGVyc29uOjQ="
       }
-    ],
-    "wait": true
-  }
+    ]
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "wait": true
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_Label_Set_To_abc.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_Label_Set_To_abc.snap
@@ -13,7 +13,26 @@
       {
         "id": "UGVyc29uOjQ="
       }
-    ],
-    "wait": true
-  }
+    ]
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": []
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "wait": true
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    }
+  ],
+  "hasNext": false
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_Nested_Defer.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_Nested_Defer.snap
@@ -2,11 +2,45 @@
   "data": {
     "personNodes": {
       "nodes": [
-        {
-          "name": "Pascal"
-        }
+        {}
       ]
+    }
+  },
+  "pending": [
+    {
+      "id": "2",
+      "path": []
     },
-    "wait": true
-  }
+    {
+      "id": "3",
+      "path": [
+        "personNodes",
+        "nodes",
+        0
+      ]
+    }
+  ],
+  "incremental": [
+    {
+      "id": "2",
+      "data": {
+        "wait": true
+      }
+    },
+    {
+      "id": "3",
+      "data": {
+        "name": "Pascal"
+      }
+    }
+  ],
+  "completed": [
+    {
+      "id": "2"
+    },
+    {
+      "id": "3"
+    }
+  ],
+  "hasNext": false
 }


### PR DESCRIPTION
## Summary
- `@defer`/`@stream` snapshots rendered differently depending on how the transport batched the response (one bundled payload vs. several), making them nondeterministic — the cause of an intermittent snapshot mismatch.
- Reworks the CookieCrumble `ExecutionResultSnapshotValueFormatter` to reconstruct a single, delivery-order-independent incremental-delivery envelope (`data` plus `pending`/`incremental`/`completed` gathered across all payloads and ordered by `id`), so the snapshot is identical whether the response was bundled or split.
- The snapshots now actually show incremental delivery — deferred errors, `label`s, paths, and field deduplication are all visible, which the previous merged form silently dropped.
- Removes the now-redundant `MatchAggregatedSnapshot`/`MatchAggregatedMarkdownSnapshot` and the `ExecutionResultAggregated` formatter; migrates the defer/stream tests to `MatchSnapshot`/`MatchMarkdownSnapshot` and re-records 20 snapshots. `StableExecutionResultSnapshotValueFormatter` is left untouched.

## Test plan
- Full `HotChocolate.Execution.Tests` green on net9.0 (614 passed, 1 skipped).
- Ran `DeferTests`, `DeferReferenceTests`, and `StreamTests` repeatedly across separate process launches on net8.0, net9.0, and net10.0 — 0 failures (previously ~40–65% flaky per run on every framework).
