### PR TITLE
Stabilize Mocha outbox registration test against EF provider warning

### DIFF
--- a/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/OutboxServiceRegistrationTests.cs
+++ b/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/OutboxServiceRegistrationTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -76,7 +77,8 @@ public sealed class OutboxServiceRegistrationTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddDbContext<TestDbContext>(o => o.UseNpgsql(ConnectionString));
+        services.AddDbContext<TestDbContext>(o => o.UseNpgsql(ConnectionString)
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)));
 
         // Use a resilient signal to prevent ObjectDisposedException when
         // EF Core shares the internal service provider (and interceptors)


### PR DESCRIPTION
## Summary
- `OutboxServiceRegistrationTests` built its `DbContext` without suppressing EF Core's `ManyServiceProvidersCreatedWarning`, unlike the sibling integration test classes in the same assembly. EF Core escalates that warning to an exception once more than 20 internal service providers accumulate in its process-wide cache, so the test threw non-deterministically depending on test ordering and parallelism (it failed one CI run, then passed on re-run).
- Add `.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))` to the test's `AddDbContext` call, matching the pattern already used by `PostgresOutboxIntegrationTests` and `PostgresSchedulingIntegrationTests`.

## Test plan
- `dotnet build src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests` → 0 warnings, 0 errors
- `dotnet test --filter-class ...OutboxServiceRegistrationTests` → 4/4 passed
