### PR TITLE
Stabilize Fusion execution-timeout test against cold-start flake

### DIFF
--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/CancellationTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/CancellationTests.cs
@@ -36,6 +36,18 @@ public class CancellationTests : FusionTestBase
             }
             """);
 
+        // Warm up the gateway so the executor build and request-pipeline JIT happen
+        // outside the tight execution timeout below, leaving the 250ms budget to
+        // measure the subgraph delay rather than first-request cold start. The
+        // introspection field resolves on the gateway and never reaches the subgraph,
+        // so it records no interaction.
+        using (await client.PostAsync(
+            new OperationRequest("{ __typename }"),
+            new Uri("http://localhost:5000/graphql"),
+            TestContext.Current.CancellationToken))
+        {
+        }
+
         // act
         using var result = await client.PostAsync(
             request,

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/CancellationTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/CancellationTests.cs
@@ -39,14 +39,18 @@ public class CancellationTests : FusionTestBase
         // Warm up the gateway so the executor build and request-pipeline JIT happen
         // outside the tight execution timeout below, leaving the 250ms budget to
         // measure the subgraph delay rather than first-request cold start. The
-        // introspection field resolves on the gateway and never reaches the subgraph,
-        // so it records no interaction.
+        // `__typename` meta-field resolves on the gateway and never reaches the
+        // subgraph.
         using (await client.PostAsync(
             new OperationRequest("{ __typename }"),
             new Uri("http://localhost:5000/graphql"),
             TestContext.Current.CancellationToken))
         {
         }
+
+        // Discard any interactions recorded during warm-up so the snapshot reflects
+        // only the measured request.
+        gateway.Interactions.Clear();
 
         // act
         using var result = await client.PostAsync(


### PR DESCRIPTION
## Summary

- `CancellationTests.Request_Is_Running_Into_Execution_Timeout_While_Http_Request_In_Node_Is_Still_Ongoing` flaked under CI load: the snapshot dropped the `sourceSchemas[].interactions:` block whenever the 250ms execution timeout elapsed before the gateway dispatched to the subgraph.
- Root cause: `TimeoutMiddleware` sits above parsing, planning, and execution in the pipeline, so first-request cold start (planning plus JIT, inside the timed window) can consume the 250ms before `onBeforeSend` records the subgraph request, leaving no interaction to snapshot.
- Fix: warm the gateway with a `{ __typename }` request first. It resolves on the gateway, never reaches the subgraph, and records no interaction, so the executor build and pipeline JIT happen outside the tight timeout. The measured request then reliably records the interaction. The 250ms timeout and the committed snapshot are unchanged.

## Test plan

- Ran the full `CancellationTests` class (both methods across net8.0, net9.0, and net10.0): all pass.
- Ran the previously-failing test 5 times on net10.0: consistently green.
