### PR TITLE
Reference System.Net.ServerSentEvents only on net8.0/net9.0

### DIFF
--- a/src/HotChocolate/AspNetCore/src/Transport.Http/HotChocolate.Transport.Http.csproj
+++ b/src/HotChocolate/AspNetCore/src/Transport.Http/HotChocolate.Transport.Http.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="System.IO.Hashing" />
-    <PackageReference Include="System.Net.ServerSentEvents" />
+    <PackageReference Include="System.Net.ServerSentEvents" Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/HotChocolate.Fusion.Execution.csproj
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/HotChocolate.Fusion.Execution.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="System.IO.Hashing" />
-    <PackageReference Include="System.Net.ServerSentEvents" />
+    <PackageReference Include="System.Net.ServerSentEvents" Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- `System.Net.ServerSentEvents` (the `SseParser` API) was introduced as a standalone package in .NET 9 but is in-box in the net10.0 shared framework. Referencing it unconditionally tripped `NU1510` ("will not be pruned … likely unnecessary"), which broke the Nitro CLI AOT publish in the Release workflow — that path forces a single-targeted net10.0 restore (`-p:TargetFrameworks=net10.0`) under `TreatWarningsAsErrors`.
- PR CI never caught it: it restores multi-TFM (net8.0;net9.0;net10.0), where the package is genuinely required for the lower TFMs, so `NU1510` is not emitted; and it doesn't build the Nitro CLI binary at all.
- Gate the package reference to net8.0/net9.0 in both consumers (`Transport.Http`, `Fusion.Execution`); on net10.0 the in-box type is used.

## Test plan
- Single-TFM net10.0 build of both projects now succeeds — no `NU1510`, and compiles against the in-box type.
- net8.0/net9.0 builds still resolve and use the package.
- Per-TFM restore matrix clean for both projects across net8.0, net9.0, and net10.0 (previously net10.0 → `NU1510`).
