### PR TITLE
fix: preserve dependencies and named status when re-registering an already-initialized type

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -255,13 +255,21 @@ internal sealed class TypeInitializer
 
     internal bool CompleteTypeName(RegisteredType registeredType)
     {
+        // PrepareForCompletion wires the type-reference resolver / global components / IsOfType
+        // onto the RegisteredType and must run even for an already-named registration; otherwise a
+        // later TryGetType/GetType against this RegisteredType during completion would throw
+        // NotYetReady. Only the name-completion + status transition is guarded, so an already-named
+        // type is not completed twice (which would trip the MarkNamed status assertion).
         registeredType.PrepareForCompletion(
             _typeReferenceResolver,
             _globalComps,
             _isOfType);
 
-        registeredType.Type.CompleteName(registeredType);
-        registeredType.Status = TypeStatus.Named;
+        if (registeredType.Status < TypeStatus.Named)
+        {
+            registeredType.Type.CompleteName(registeredType);
+            registeredType.Status = TypeStatus.Named;
+        }
 
         if (registeredType.IsNamedType || registeredType.IsDirectiveType)
         {

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeRegistrar.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeRegistrar.cs
@@ -173,6 +173,15 @@ internal sealed partial class TypeRegistrar : ITypeRegistrar
             {
                 typeSystemObject.Initialize(registeredType);
             }
+            else
+            {
+                if (typeSystemObject.IsNamed)
+                {
+                    registeredType.Status = TypeStatus.Named;
+                }
+
+                typeSystemObject.RegisterDependencies(registeredType);
+            }
 
             if (!isInferred)
             {

--- a/src/HotChocolate/Core/src/Types/Types/TypeSystemObject.cs
+++ b/src/HotChocolate/Core/src/Types/Types/TypeSystemObject.cs
@@ -114,6 +114,10 @@ public abstract class TypeSystemObject : ITypeSystemMember, IFeatureProvider
         MarkInitialized();
     }
 
+    internal virtual void RegisterDependencies(ITypeDiscoveryContext context)
+    {
+    }
+
     /// <summary>
     /// If this type has a dynamic type it will be completed in this step.
     /// </summary>

--- a/src/HotChocolate/Core/src/Types/Types/TypeSystemObjectBase~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/TypeSystemObjectBase~1.cs
@@ -47,6 +47,14 @@ public abstract class TypeSystemObject<TConfiguration> : TypeSystemObject
         MarkInitialized();
     }
 
+    internal sealed override void RegisterDependencies(ITypeDiscoveryContext context)
+    {
+        if (Configuration is { } configuration)
+        {
+            RegisterConfigurationDependencies(context, configuration);
+        }
+    }
+
     protected abstract TConfiguration CreateConfiguration(
         ITypeDiscoveryContext context);
 


### PR DESCRIPTION
## Summary

When the same `TypeSystemObject` instance is registered more than once and is already initialized on the later registration, the new `RegisteredType` was left without its configuration dependencies and without the object's `Named` status. Under concurrent schema builds this makes type-completion ordering non-deterministic and can fail to resolve a transitively-discovered input type:

```
SchemaException: Unable to resolve type reference `SortInputType<T> (Input)`.
(HotChocolate.Types.ObjectTypeExtension)
```

## Root cause

In `TypeRegistrar`, registration runs `typeSystemObject.Initialize(registeredType)` only when the object is **not** yet initialized. `Initialize` is what calls `RegisterConfigurationDependencies` and marks the object named. When an already-initialized instance is re-registered (e.g. a `SortInputType<T>` reached transitively via a parameterless `UseSorting()` / `UseFiltering()` on a collection field, discovered through more than one path), the `else` case did nothing:

- the new `RegisteredType` got **no dependency edges**, and
- its `Status` stayed below `Named` even though the object was already named.

Type-completion readiness is computed from those dependency edges and the `Type.GetHashCode()`-influenced (architecture-dependent) processing order. With the edges missing, a dependent `ObjectTypeExtension` (the `Query` type) can be completed before the `SortInputType<T>` it needs is resolvable, throwing the `SchemaException`. It surfaces when many types are loaded and several schemas are built **concurrently** in one process (observed deterministically on x64; not on arm64).

## Fix

- `TypeRegistrar`: when an already-initialized `TypeSystemObject` is re-registered, propagate its `Named` status to the new `RegisteredType` and re-register its configuration dependencies via a new `RegisterDependencies` hook.
- `TypeSystemObject` / `TypeSystemObject<TConfiguration>`: add the `RegisterDependencies` hook, delegating to the existing `RegisterConfigurationDependencies` (the same path `Initialize` uses).
- `TypeInitializer.CompleteTypeName`: guard the naming step so an already-`Named` type is not completed twice (it would otherwise re-run `CompleteName` and trip the `MarkNamed` status assertion).

No public API change; the change is internal to type discovery/initialization.

## Evidence

Controlled A/B on a large real schema (~116 integration tests building the same schema concurrently, x64), swapping only `HotChocolate.Types.dll`:

- stock build (no fix): 4/4 runs fail, always `Unable to resolve SortInputType<…>`
- patched build (this change): 4/4 runs pass, 0 errors

## Reproduction

The failure requires a confluence: a large loaded type population, a transitively-discovered `SortInputType<T>` via parameterless sorting, and **concurrent schema builds** in one process (so registrations interleave). A minimal single-build test does not reproduce it; a faithful repro needs N parallel `BuildSchemaAsync()` of the same schema on x64. Happy to iterate on a test harness if you'd prefer one included in this PR.
