### PR TITLE
Stabilize Postgres reconnect test against reconnect timing race

### DIFF
--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/ResilientNpgsqlConnectionTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/ResilientNpgsqlConnectionTests.cs
@@ -101,7 +101,19 @@ public class ResilientNpgsqlConnectionTests : IClassFixture<PostgreSqlResource>
     public async Task Reconnect_Should_ReconnectWhenConnectionIsClosed()
     {
         // Arrange
-        Func<CancellationToken, ValueTask> onConnect = _ => ValueTask.CompletedTask;
+        var onConnectCalled = 0;
+        var reconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        ValueTask onConnect(CancellationToken _)
+        {
+            // Initialize connects once; the reconnect after the drop is the second connect.
+            if (++onConnectCalled == 2)
+            {
+                reconnected.TrySetResult();
+            }
+
+            return ValueTask.CompletedTask;
+        }
         Func<CancellationToken, ValueTask> onDisconnect = _ => ValueTask.CompletedTask;
 
         var resilientNpgsqlConnection =
@@ -114,9 +126,8 @@ public class ResilientNpgsqlConnectionTests : IClassFixture<PostgreSqlResource>
         await connection!.CloseAsync();
 
         // Assert
-        SpinWait.SpinUntil(
-            () => connection != resilientNpgsqlConnection.Connection,
-            TimeSpan.FromSeconds(1));
+        await reconnected.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
         Assert.NotEqual(connection, resilientNpgsqlConnection.Connection);
     }
 


### PR DESCRIPTION
## Summary
- `Reconnect_Should_ReconnectWhenConnectionIsClosed` waited a fixed 1 second (`SpinWait.SpinUntil`) for the background reconnect to swap in a new connection, then asserted unconditionally. Under CI load the reconnect can exceed that window, producing an intermittent `Assert.NotEqual` failure.
- Replaced the fixed-timeout wait with a deterministic await on a `TaskCompletionSource` signalled by the reconnect's `onConnect` callback (10s ceiling), mirroring the sibling `Reconnect_Should_CallOnDisconnect_When_ConnectionIsClosed` test. `Connection` is assigned before `onConnect` is awaited, so the new connection is guaranteed to be in place when the assertion runs.

## Test plan
- Built `HotChocolate.Subscriptions.Postgres.Tests` and ran the affected test 10× locally on net10.0: 10/10 passed.
- The wait now keys off the actual reconnect event rather than a fixed timeout, removing the timing race on every target framework.
