### PR TITLE
Stabilize executor eviction/swap tests against timeout flake

### DIFF
--- a/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorManagerTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorManagerTests.cs
@@ -36,7 +36,7 @@ public class RequestExecutorManagerTests
         // arrange
         var warmupResetEvent = new ManualResetEventSlim(true);
         var executorEvictedResetEvent = new ManualResetEventSlim(false);
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         var manager = new ServiceCollection()
             .AddGraphQL()
@@ -86,7 +86,7 @@ public class RequestExecutorManagerTests
         // arrange
         var warmups = 0;
         var executorEvictedResetEvent = new ManualResetEventSlim(false);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         var manager = new ServiceCollection()
             .AddGraphQL()

--- a/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorProxyTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorProxyTests.cs
@@ -32,7 +32,7 @@ public class RequestExecutorProxyTests
     {
         // arrange
         var executorUpdatedResetEvent = new ManualResetEventSlim(false);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var manager =
             new ServiceCollection()
                 .AddGraphQL()

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/FusionRequestExecutorProxyTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/FusionRequestExecutorProxyTests.cs
@@ -37,7 +37,7 @@ public class FusionRequestExecutorProxyTests : FusionTestBase
     {
         // arrange
         var executorUpdatedResetEvent = new ManualResetEventSlim(false);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         var configProvider = new TestFusionConfigurationProvider(
             CreateFusionConfiguration(


### PR DESCRIPTION
## Summary
- `RequestExecutorProxyTests.Ensure_Executor_Is_Correctly_Swapped_When_Evicted` intermittently failed in CI with `System.OperationCanceledException`. Its hard 5-second `CancellationTokenSource` deadline has to cover the whole `EvictExecutor()` → background schema rebuild → warmup → swap pipeline, which occasionally exceeds 5s under CI CPU contention.
- Raised that deadline to 30s, along with the identical deadlines in the sibling `FusionRequestExecutorProxyTests` swap-on-evict test and the two `RequestExecutorManagerTests` eviction/warmup tests, so a deadline only trips on a genuine hang rather than slow-but-progressing CI.
- This matches the more generous deadlines (30s/50s) already used for heavier eviction-rebuild tests in `RequestExecutorManagerTests`. Test-only change; no production code touched.

## Test plan
- `dotnet test src/HotChocolate/Core/test/Execution.Tests -- --filter-method "*RequestExecutorManagerTests*" --filter-method "*RequestExecutorProxyTests*"` → 12/12 pass
- `dotnet test src/HotChocolate/Fusion/test/Fusion.Execution.Tests -- --filter-method "*FusionRequestExecutorProxyTests*"` → 2/2 pass
