### PR TITLE
Reference net11-bundled packages only on net8.0/net9.0/net10.0

### DIFF
--- a/src/GreenDonut/src/GreenDonut/GreenDonut.csproj
+++ b/src/GreenDonut/src/GreenDonut/GreenDonut.csproj
@@ -13,8 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Caching/src/Caching.Core/HotChocolate.Caching.Core.csproj
+++ b/src/HotChocolate/Caching/src/Caching.Core/HotChocolate.Caching.Core.csproj
@@ -24,6 +24,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Http.Headers" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 

--- a/src/HotChocolate/Core/src/Execution.Abstractions/HotChocolate.Execution.Abstractions.csproj
+++ b/src/HotChocolate/Core/src/Execution.Abstractions/HotChocolate.Execution.Abstractions.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="System.IO.Pipelines" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/HotChocolate/Core/src/Execution.Configuration.Abstractions/HotChocolate.Execution.Configuration.Abstractions.csproj
+++ b/src/HotChocolate/Core/src/Execution.Configuration.Abstractions/HotChocolate.Execution.Configuration.Abstractions.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\Abstractions\HotChocolate.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/HotChocolate/Core/src/Execution.Pipeline/HotChocolate.Execution.Pipeline.csproj
+++ b/src/HotChocolate/Core/src/Execution.Pipeline/HotChocolate.Execution.Pipeline.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\Validation\HotChocolate.Validation.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/HotChocolate/Core/src/Subscriptions.InMemory/HotChocolate.Subscriptions.InMemory.csproj
+++ b/src/HotChocolate/Core/src/Subscriptions.InMemory/HotChocolate.Subscriptions.InMemory.csproj
@@ -8,7 +8,7 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/HotChocolate/Core/src/Subscriptions.Redis/HotChocolate.Subscriptions.Redis.csproj
+++ b/src/HotChocolate/Core/src/Subscriptions.Redis/HotChocolate.Subscriptions.Redis.csproj
@@ -17,8 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="StackExchange.Redis" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Core/src/Subscriptions.Serializers.Newtonsoft/HotChocolate.Subscriptions.Serializers.Newtonsoft.csproj
+++ b/src/HotChocolate/Core/src/Subscriptions.Serializers.Newtonsoft/HotChocolate.Subscriptions.Serializers.Newtonsoft.csproj
@@ -17,8 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Core/src/Types/HotChocolate.Types.csproj
+++ b/src/HotChocolate/Core/src/Types/HotChocolate.Types.csproj
@@ -53,6 +53,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 

--- a/src/HotChocolate/Core/src/Validation/HotChocolate.Validation.csproj
+++ b/src/HotChocolate/Core/src/Validation/HotChocolate.Validation.csproj
@@ -21,7 +21,7 @@
     <InternalsVisibleTo Include="HotChocolate.CostAnalysis" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/HotChocolate/Fusion/src/Fusion.Execution.Types/HotChocolate.Fusion.Execution.Types.csproj
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution.Types/HotChocolate.Fusion.Execution.Types.csproj
@@ -13,9 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="System.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/HotChocolate.Fusion.Execution.csproj
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/HotChocolate.Fusion.Execution.csproj
@@ -21,11 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="System.Net.ServerSentEvents" Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/PersistedOperations/src/PersistedOperations.Pipeline/HotChocolate.PersistedOperations.Pipeline.csproj
+++ b/src/HotChocolate/PersistedOperations/src/PersistedOperations.Pipeline/HotChocolate.PersistedOperations.Pipeline.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\PersistedOperations.Abstractions\HotChocolate.PersistedOperations.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/HotChocolate/Utilities/src/Utilities/HotChocolate.Utilities.csproj
+++ b/src/HotChocolate/Utilities/src/Utilities/HotChocolate.Utilities.csproj
@@ -33,7 +33,7 @@
     <ProjectReference Include="..\Utilities.Tasks\HotChocolate.Utilities.Tasks.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/Mocha/src/Mocha.Abstractions/Mocha.Abstractions.csproj
+++ b/src/Mocha/src/Mocha.Abstractions/Mocha.Abstractions.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Mocha/src/Mocha.Mediator/Mocha.Mediator.csproj
+++ b/src/Mocha/src/Mocha.Mediator/Mocha.Mediator.csproj
@@ -12,8 +12,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Mocha/src/Mocha.Threading/Mocha.Threading.csproj
+++ b/src/Mocha/src/Mocha.Threading/Mocha.Threading.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Mocha.Threading</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/Mocha/src/Mocha/Mocha.csproj
+++ b/src/Mocha/src/Mocha/Mocha.csproj
@@ -6,13 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" />
     <PackageReference Include="Npgsql" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="Polly" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/StrawberryShake/Client/src/Core/StrawberryShake.Core.csproj
+++ b/src/StrawberryShake/Client/src/Core/StrawberryShake.Core.csproj
@@ -13,7 +13,7 @@
     <InternalsVisibleTo Include="StrawberryShake.Core.Tests" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 

--- a/src/StrawberryShake/Client/src/Transport.Http/StrawberryShake.Transport.Http.csproj
+++ b/src/StrawberryShake/Client/src/Transport.Http/StrawberryShake.Transport.Http.csproj
@@ -10,8 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/StrawberryShake/Client/src/Transport.WebSockets/StrawberryShake.Transport.WebSockets.csproj
+++ b/src/StrawberryShake/Client/src/Transport.WebSockets/StrawberryShake.Transport.WebSockets.csproj
@@ -11,7 +11,7 @@
     <InternalsVisibleTo Include="StrawberryShake.Transport.WebSockets.Tests" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Several `Microsoft.Extensions.*` packages (`DependencyInjection.Abstractions`, `Options`, `Primitives`, `Logging.Abstractions`, `Hosting.Abstractions`) are now part of the .NET 11 shared framework. When a project is built single-target net11 (e.g. the Nitro CLI AOT release publish), NuGet package pruning raises `NU1510` for the now-redundant direct references, failing the build under `TreatWarningsAsErrors`.
- These references are now conditioned to `net8.0`/`net9.0`/`net10.0` (the TFMs that still need them) so they are dropped on net11, where the framework provides them. The normal multi-target build was unaffected because pruning only triggers when it applies to every target.
- Mirrors the existing `System.Net.ServerSentEvents` and `System.IO.Pipelines` handling.

## Test plan

- Reproduced the failing Nitro CLI net11/linux-musl-x64 restore — now clean (0 `NU1510`).
- Swept all 53 framework-package-referencing projects across net8/9/10/11: 0 `NU1510` remaining.
- Built the affected projects single-target net11 and multi-target — all succeed.
