### PR TITLE
Add Mocha Demo example projects to All.slnx

### DIFF
--- a/src/All.slnx
+++ b/src/All.slnx
@@ -347,6 +347,12 @@
     <Project Path="HotChocolate/Utilities/test/Utilities.Tests/HotChocolate.Utilities.Tests.csproj" />
   </Folder>
   <Folder Name="/Mocha/" />
+  <Folder Name="/Mocha/examples/" />
+  <Folder Name="/Mocha/examples/Demo/">
+    <Project Path="Mocha/examples/Demo/Demo.Catalog/Demo.Catalog.csproj" />
+    <Project Path="Mocha/examples/Demo/Demo.Contracts/Demo.Contracts.csproj" />
+    <Project Path="Mocha/examples/Demo/Demo.ServiceDefaults/Demo.ServiceDefaults.csproj" />
+  </Folder>
   <Folder Name="/Mocha/src/">
     <Project Path="Mocha/src/Mocha.Abstractions/Mocha.Abstractions.csproj" />
     <Project Path="Mocha/src/Mocha.Analyzers/Mocha.Analyzers.csproj" />


### PR DESCRIPTION
## Summary

- `All.slnx` included `Demo.Catalog.Tests` but not the `Demo.Catalog` example project it references (nor that project's example-tree dependencies), so the IDE couldn't resolve `HotChocolate.Demo.Catalog.dll` and the test project surfaced "Metadata file could not be found" errors.
- Adds the reference closure under a new `/Mocha/examples/Demo/` solution folder: `Demo.Catalog`, `Demo.Contracts`, and `Demo.ServiceDefaults`.
- Leaves out `Demo.AppHost`/`Demo.Billing`/`Demo.Shipping` — they aren't referenced by the test, and `Demo.AppHost` would pull the Aspire workload into the whole-repo build.

## Test plan

- `dotnet build src/Mocha/test/Demo.Catalog.Tests/Demo.Catalog.Tests.csproj` succeeds with 0 warnings / 0 errors and emits `HotChocolate.Demo.Catalog.dll`.
- `dotnet sln src/All.slnx list` parses cleanly and lists the three added projects.
