### PR TITLE
Handle nullable navigations in keyset pagination WHERE clause

### DIFF
--- a/src/GreenDonut/src/GreenDonut.Data.EntityFramework/Expressions/ExpressionHelpers.cs
+++ b/src/GreenDonut/src/GreenDonut.Data.EntityFramework/Expressions/ExpressionHelpers.cs
@@ -154,6 +154,7 @@ internal static class ExpressionHelpers
         Expression cursorExpr)
     {
         var keyExpr = ReplaceParameter(cursorKey.Expression, parameter);
+        keyExpr = LiftValueTypeIfNullable(keyExpr, keyIsNullable);
 
         // Access the value of the key if it is a nullable value type.
         var keyValueExpr = cursorKey.Expression.ReturnType.IsValueType && keyIsNullable
@@ -197,6 +198,7 @@ internal static class ExpressionHelpers
         Expression cursorExpr)
     {
         var keyExpr = ReplaceParameter(cursorKey.Expression, parameter);
+        keyExpr = LiftValueTypeIfNullable(keyExpr, keyIsNullable);
 
         // Access the value of the key if it is a nullable value type.
         var keyValueExpr =
@@ -255,6 +257,7 @@ internal static class ExpressionHelpers
         Expression cursorExpr)
     {
         var keyExpr = ReplaceParameter(cursorKey.Expression, parameter);
+        keyExpr = LiftValueTypeIfNullable(keyExpr, keyIsNullable);
 
         // Access the value of the key if it is a nullable value type.
         var keyValueExpr =
@@ -306,38 +309,37 @@ internal static class ExpressionHelpers
 
     private static bool IsNullable(LambdaExpression expression)
     {
-        if (expression.ReturnType.IsValueType)
+        // A nullable value-type return (for example an explicit cast to int?).
+        if (expression.ReturnType.IsValueType
+            && Nullable.GetUnderlyingType(expression.ReturnType) is not null)
         {
-            return Nullable.GetUnderlyingType(expression.ReturnType) is not null;
+            return true;
         }
 
-        var member = expression.Body switch
-        {
-            MemberExpression { Member: PropertyInfo or FieldInfo } m => m.Member,
-            BinaryExpression
-            {
-                NodeType: ExpressionType.Coalesce,
-                Right: MemberExpression { Member: PropertyInfo or FieldInfo } m
-            } => m.Member,
-            _ => null
-        };
+        var current = StripConvert(expression.Body);
 
-        if (member is not null)
+        // (a ?? b) is null only when the fallback b is null.
+        if (current is BinaryExpression { NodeType: ExpressionType.Coalesce, Right: var right })
         {
-            var state = member switch
-            {
-                PropertyInfo p => GetNullabilityInfoState(p),
-                FieldInfo f => GetNullabilityInfoState(f),
-                _ => throw new InvalidOperationException()
-            };
+            current = StripConvert(right);
+        }
 
-            return state switch
+        // The key value is nullable if the leaf or any intermediate navigation along
+        // the member-access path is nullable (for example x.Meter.Id is null when
+        // x.Meter is null).
+        while (current is MemberExpression { Member: PropertyInfo or FieldInfo } member)
+        {
+            if (IsMemberNullable(member))
             {
-                NullabilityState.Nullable => true,
-                // Unknown means the assembly was compiled without NRT annotations;
-                // treat as non-nullable (safe default).
-                _ => false
-            };
+                return true;
+            }
+
+            if (member.Expression is null)
+            {
+                break;
+            }
+
+            current = StripConvert(member.Expression);
         }
 
         // For computed key expressions (method calls, concatenation, etc.) we cannot inspect
@@ -622,6 +624,53 @@ internal static class ExpressionHelpers
         Expression<Func<T>> lambda = () => value;
         return lambda.Body;
     }
+
+    /// <summary>
+    /// Determines whether a member access can yield <c>null</c>: a value-type member
+    /// only when it is <see cref="Nullable{T}"/>, and a reference-type member according
+    /// to its nullable reference type annotation.
+    /// </summary>
+    private static bool IsMemberNullable(MemberExpression member)
+    {
+        if (member.Type.IsValueType)
+        {
+            return Nullable.GetUnderlyingType(member.Type) is not null;
+        }
+
+        // Unknown means the assembly was compiled without NRT annotations;
+        // treat as non-nullable (safe default).
+        return member.Member switch
+        {
+            PropertyInfo p => GetNullabilityInfoState(p) == NullabilityState.Nullable,
+            FieldInfo f => GetNullabilityInfoState(f) == NullabilityState.Nullable,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Removes any <see cref="ExpressionType.Convert"/> or
+    /// <see cref="ExpressionType.ConvertChecked"/> wrappers from an expression and
+    /// returns the underlying operand.
+    /// </summary>
+    private static Expression StripConvert(Expression expression)
+        => expression is UnaryExpression
+        {
+            NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked
+        } unary
+            ? StripConvert(unary.Operand)
+            : expression;
+
+    /// <summary>
+    /// Lifts a non-nullable value-type key (for example <c>int</c> for
+    /// <c>x.Meter.Id</c>) to its <see cref="Nullable{T}"/> form when the key is
+    /// nullable because of an intermediate navigation, so the key can be compared
+    /// against <c>null</c>. Keys that are already nullable or are reference types
+    /// are returned unchanged.
+    /// </summary>
+    private static Expression LiftValueTypeIfNullable(Expression keyExpr, bool keyIsNullable)
+        => keyIsNullable && keyExpr.Type.IsValueType && Nullable.GetUnderlyingType(keyExpr.Type) is null
+            ? Expression.Convert(keyExpr, typeof(Nullable<>).MakeGenericType(keyExpr.Type))
+            : keyExpr;
 
     private static Expression BuildEqualComparison(
         CursorKey cursorKey,

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/PagingHelperPostgreSqlNullableTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/PagingHelperPostgreSqlNullableTests.cs
@@ -316,12 +316,12 @@ public class PagingHelperPostgreSqlNullableTests(PostgreSqlResource resource)
     [Fact]
     public async Task Paging_NullableNavigation_ValueTypeLeaf_Pages_Across_Null_Boundary()
     {
-        // arrange
+        // Arrange
         var connectionString = CreateConnectionString();
         await SeedItemsAsync(connectionString);
         await using var context = new NullableTestsContext(Provider.PostgreSql, connectionString);
 
-        // act
+        // Act
         // Sort by a non-nullable value-type leaf (Detail.Number) behind a nullable
         // navigation; the second page is requested after a null-navigation boundary.
         var arguments = new PagingArguments(2) { NullOrdering = NullOrdering.NativeNullsLast };
@@ -336,7 +336,7 @@ public class PagingHelperPostgreSqlNullableTests(PostgreSqlResource resource)
             .ThenBy(x => x.Id)
             .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
 
-        // assert
+        // Assert
         Assert.Equal([1, 2], page1.Select(x => x.Id));
         Assert.Equal([3, 4], page2.Select(x => x.Id));
     }
@@ -344,12 +344,12 @@ public class PagingHelperPostgreSqlNullableTests(PostgreSqlResource resource)
     [Fact]
     public async Task Paging_NullableNavigation_ReferenceLeaf_Pages_Across_Null_Boundary()
     {
-        // arrange
+        // Arrange
         var connectionString = CreateConnectionString();
         await SeedItemsAsync(connectionString);
         await using var context = new NullableTestsContext(Provider.PostgreSql, connectionString);
 
-        // act
+        // Act
         // Sort by a non-nullable reference leaf (Detail.Name) behind a nullable
         // navigation; the second page is requested after a null-navigation boundary.
         var arguments = new PagingArguments(2) { NullOrdering = NullOrdering.NativeNullsLast };
@@ -364,7 +364,7 @@ public class PagingHelperPostgreSqlNullableTests(PostgreSqlResource resource)
             .ThenBy(x => x.Id)
             .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
 
-        // assert
+        // Assert
         Assert.Equal([1, 2], page1.Select(x => x.Id));
         Assert.Equal([3, 4], page2.Select(x => x.Id));
     }

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/PagingHelperPostgreSqlNullableTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/PagingHelperPostgreSqlNullableTests.cs
@@ -313,6 +313,62 @@ public class PagingHelperPostgreSqlNullableTests(PostgreSqlResource resource)
             (await Assert.ThrowsAsync<InvalidOperationException>(Act)).Message);
     }
 
+    [Fact]
+    public async Task Paging_NullableNavigation_ValueTypeLeaf_Pages_Across_Null_Boundary()
+    {
+        // arrange
+        var connectionString = CreateConnectionString();
+        await SeedItemsAsync(connectionString);
+        await using var context = new NullableTestsContext(Provider.PostgreSql, connectionString);
+
+        // act
+        // Sort by a non-nullable value-type leaf (Detail.Number) behind a nullable
+        // navigation; the second page is requested after a null-navigation boundary.
+        var arguments = new PagingArguments(2) { NullOrdering = NullOrdering.NativeNullsLast };
+        var page1 = await context.Items
+            .OrderBy(x => x.Detail!.Number)
+            .ThenBy(x => x.Id)
+            .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
+
+        arguments = arguments with { After = page1.CreateEndCursor() };
+        var page2 = await context.Items
+            .OrderBy(x => x.Detail!.Number)
+            .ThenBy(x => x.Id)
+            .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal([1, 2], page1.Select(x => x.Id));
+        Assert.Equal([3, 4], page2.Select(x => x.Id));
+    }
+
+    [Fact]
+    public async Task Paging_NullableNavigation_ReferenceLeaf_Pages_Across_Null_Boundary()
+    {
+        // arrange
+        var connectionString = CreateConnectionString();
+        await SeedItemsAsync(connectionString);
+        await using var context = new NullableTestsContext(Provider.PostgreSql, connectionString);
+
+        // act
+        // Sort by a non-nullable reference leaf (Detail.Name) behind a nullable
+        // navigation; the second page is requested after a null-navigation boundary.
+        var arguments = new PagingArguments(2) { NullOrdering = NullOrdering.NativeNullsLast };
+        var page1 = await context.Items
+            .OrderBy(x => x.Detail!.Name)
+            .ThenBy(x => x.Id)
+            .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
+
+        arguments = arguments with { After = page1.CreateEndCursor() };
+        var page2 = await context.Items
+            .OrderBy(x => x.Detail!.Name)
+            .ThenBy(x => x.Id)
+            .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal([1, 2], page1.Select(x => x.Id));
+        Assert.Equal([3, 4], page2.Select(x => x.Id));
+    }
+
     private static async Task SeedAsync(string connectionString)
     {
         await using var context = new NullableTestsContext(Provider.PostgreSql, connectionString);
@@ -356,6 +412,22 @@ public class PagingHelperPostgreSqlNullableTests(PostgreSqlResource resource)
                 Time = new TimeOnly(19, 40, 00),
                 String = "19:40:00"
             });
+
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedItemsAsync(string connectionString)
+    {
+        await using var context = new NullableTestsContext(Provider.PostgreSql, connectionString);
+        await context.Database.EnsureCreatedAsync();
+
+        // Only the first item has a navigation; the rest are null and sort last,
+        // so paging crosses a null-navigation boundary between page 1 and page 2.
+        context.Items.AddRange(
+            new Item { Id = 1, Detail = new Detail { Number = 10, Name = "a" } },
+            new Item { Id = 2 },
+            new Item { Id = 3 },
+            new Item { Id = 4 });
 
         await context.SaveChangesAsync();
     }

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/PagingHelperSqlServerNullableTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/PagingHelperSqlServerNullableTests.cs
@@ -266,6 +266,64 @@ public class PagingHelperSqlServerNullableTests(SqlServerResource resource)
         snapshot.MatchMarkdownSnapshot();
     }
 
+    [Fact]
+    public async Task Paging_NullableNavigation_ValueTypeLeaf_Pages_Across_Null_Boundary()
+    {
+        // arrange
+        var connectionString = CreateConnectionString();
+        await SeedItemsAsync(connectionString);
+        await using var context = new NullableTestsContext(Provider.SqlServer, connectionString);
+
+        // act
+        // Sort by a non-nullable value-type leaf (Detail.Number) behind a nullable
+        // navigation; with nulls first the second page is requested after a
+        // null-navigation boundary.
+        var arguments = new PagingArguments(2) { NullOrdering = NullOrdering.NativeNullsFirst };
+        var page1 = await context.Items
+            .OrderBy(x => x.Detail!.Number)
+            .ThenBy(x => x.Id)
+            .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
+
+        arguments = arguments with { After = page1.CreateEndCursor() };
+        var page2 = await context.Items
+            .OrderBy(x => x.Detail!.Number)
+            .ThenBy(x => x.Id)
+            .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal([2, 3], page1.Select(x => x.Id));
+        Assert.Equal([4, 1], page2.Select(x => x.Id));
+    }
+
+    [Fact]
+    public async Task Paging_NullableNavigation_ReferenceLeaf_Pages_Across_Null_Boundary()
+    {
+        // arrange
+        var connectionString = CreateConnectionString();
+        await SeedItemsAsync(connectionString);
+        await using var context = new NullableTestsContext(Provider.SqlServer, connectionString);
+
+        // act
+        // Sort by a non-nullable reference leaf (Detail.Name) behind a nullable
+        // navigation; with nulls first the second page is requested after a
+        // null-navigation boundary.
+        var arguments = new PagingArguments(2) { NullOrdering = NullOrdering.NativeNullsFirst };
+        var page1 = await context.Items
+            .OrderBy(x => x.Detail!.Name)
+            .ThenBy(x => x.Id)
+            .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
+
+        arguments = arguments with { After = page1.CreateEndCursor() };
+        var page2 = await context.Items
+            .OrderBy(x => x.Detail!.Name)
+            .ThenBy(x => x.Id)
+            .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal([2, 3], page1.Select(x => x.Id));
+        Assert.Equal([4, 1], page2.Select(x => x.Id));
+    }
+
     private static async Task SeedAsync(string connectionString)
     {
         await using var context = new NullableTestsContext(Provider.SqlServer, connectionString);
@@ -309,6 +367,22 @@ public class PagingHelperSqlServerNullableTests(SqlServerResource resource)
                 Time = new TimeOnly(19, 40, 00),
                 String = "19:40:00"
             });
+
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedItemsAsync(string connectionString)
+    {
+        await using var context = new NullableTestsContext(Provider.SqlServer, connectionString);
+        await context.Database.EnsureCreatedAsync();
+
+        // Only the first item has a navigation; the rest are null and sort first,
+        // so paging crosses a null-navigation boundary between page 1 and page 2.
+        context.Items.AddRange(
+            new Item { Id = 1, Detail = new Detail { Number = 10, Name = "a" } },
+            new Item { Id = 2 },
+            new Item { Id = 3 },
+            new Item { Id = 4 });
 
         await context.SaveChangesAsync();
     }

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/PagingHelperSqlServerNullableTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/PagingHelperSqlServerNullableTests.cs
@@ -269,12 +269,12 @@ public class PagingHelperSqlServerNullableTests(SqlServerResource resource)
     [Fact]
     public async Task Paging_NullableNavigation_ValueTypeLeaf_Pages_Across_Null_Boundary()
     {
-        // arrange
+        // Arrange
         var connectionString = CreateConnectionString();
         await SeedItemsAsync(connectionString);
         await using var context = new NullableTestsContext(Provider.SqlServer, connectionString);
 
-        // act
+        // Act
         // Sort by a non-nullable value-type leaf (Detail.Number) behind a nullable
         // navigation; with nulls first the second page is requested after a
         // null-navigation boundary.
@@ -290,7 +290,7 @@ public class PagingHelperSqlServerNullableTests(SqlServerResource resource)
             .ThenBy(x => x.Id)
             .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
 
-        // assert
+        // Assert
         Assert.Equal([2, 3], page1.Select(x => x.Id));
         Assert.Equal([4, 1], page2.Select(x => x.Id));
     }
@@ -298,12 +298,12 @@ public class PagingHelperSqlServerNullableTests(SqlServerResource resource)
     [Fact]
     public async Task Paging_NullableNavigation_ReferenceLeaf_Pages_Across_Null_Boundary()
     {
-        // arrange
+        // Arrange
         var connectionString = CreateConnectionString();
         await SeedItemsAsync(connectionString);
         await using var context = new NullableTestsContext(Provider.SqlServer, connectionString);
 
-        // act
+        // Act
         // Sort by a non-nullable reference leaf (Detail.Name) behind a nullable
         // navigation; with nulls first the second page is requested after a
         // null-navigation boundary.
@@ -319,7 +319,7 @@ public class PagingHelperSqlServerNullableTests(SqlServerResource resource)
             .ThenBy(x => x.Id)
             .ToPageAsync(arguments, Xunit.TestContext.Current.CancellationToken);
 
-        // assert
+        // Assert
         Assert.Equal([2, 3], page1.Select(x => x.Id));
         Assert.Equal([4, 1], page2.Select(x => x.Id));
     }

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/TestContext/NullableTestsContext.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/TestContext/NullableTestsContext.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace GreenDonut.Data.TestContext;
@@ -20,6 +21,8 @@ public class NullableTestsContext(Provider provider, string connectionString) : 
     }
 
     public DbSet<Record> Records { get; set; } = null!;
+
+    public DbSet<Item> Items { get; set; } = null!;
 }
 
 public class Record
@@ -28,6 +31,25 @@ public class Record
     public DateOnly? Date { get; set; }
     public TimeOnly? Time { get; set; }
     public string? String { get; set; }
+}
+
+public class Item
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int Id { get; set; }
+
+    public int? DetailId { get; set; }
+
+    public Detail? Detail { get; set; }
+}
+
+public class Detail
+{
+    public int Id { get; set; }
+
+    public int Number { get; set; }
+
+    public string Name { get; set; } = null!;
 }
 
 public enum Provider


### PR DESCRIPTION
## Summary
- Follow-up to #9953. Once cursor-key *extraction* was made null-safe, sorting a cursor page on a key whose path includes a nullable navigation (e.g. order by `meter.id` where `Meter` is optional) still produced wrong pages: the keyset `WHERE` builder's `IsNullable` check only inspected the **leaf** member, so such keys were treated as non-nullable. Paging across a row with a null navigation coerced the null cursor value to `default` (e.g. `0`) and skipped the null-aware branches, dropping or duplicating rows.
- `IsNullable` now walks the whole access path and treats a key as nullable when the leaf **or any intermediate navigation** is nullable. Non-nullable value-type leaves (e.g. `int` for `meter.id`) are lifted to `Nullable<T>` so the `IS NULL` comparison can be built and translated by EF. Reference leaves and flat keys are unaffected.

Behavior note: paginating a sort whose path includes a nullable navigation now requires `NullOrdering` to be specified, consistent with the existing rule for nullable leaf keys.

## Test plan
- Added PostgreSQL (nulls-last) and SQL Server (nulls-first) tests that page across a null-navigation boundary, for both a value-type leaf (`Detail.Number`) and a reference leaf (`Detail.Name`); they fail before the fix and pass after.
- New navigation tests: 16/16 (2 tests × 2 providers × 4 TFMs).
- Existing GreenDonut nullable round-trip tests: PostgreSQL 11/11, SQL Server 10/10.
- Cross-project `HotChocolate.Data` `PagingHelperIntegrationTests`: 24/24.
