### PR TITLE
Bump .NET 11 SDK pin to 11.0.100-preview.5.26302.115

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -142,7 +142,7 @@ jobs:
             echo "Installing .NET..."
             curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
             chmod +x dotnet-install.sh
-            ./dotnet-install.sh --version 11.0.100-preview.4.26230.115 --install-dir $HOME/.dotnet
+            ./dotnet-install.sh --version 11.0.100-preview.5.26302.115 --install-dir $HOME/.dotnet
             rm dotnet-install.sh
             echo "$HOME/.dotnet" >> $GITHUB_PATH
             export PATH="$HOME/.dotnet:$PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
             8.x
             9.x
             10.x
-            11.0.100-preview.4.26230.115
+            11.0.100-preview.5.26302.115
 
       - name: Run Build
         id: run-build
@@ -333,7 +333,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
-          dotnet-version: 11.0.100-preview.4.26230.115
+          dotnet-version: 11.0.100-preview.5.26302.115
 
       - name: Install dotnet-coverage
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,7 @@ jobs:
             8.x
             9.x
             10.x
-            11.0.100-preview.4.26230.115
+            11.0.100-preview.5.26302.115
 
       - name: Run Build
         id: run-build
@@ -129,7 +129,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
-          dotnet-version: 11.0.100-preview.4.26230.115
+          dotnet-version: 11.0.100-preview.5.26302.115
 
       - name: Install dotnet-coverage
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
             8.x
             9.x
             10.x
-            11.0.100-preview.4.26230.115
+            11.0.100-preview.5.26302.115
 
       - name: 🖍️ Stamp template PackageReference versions
         shell: bash
@@ -246,7 +246,7 @@ jobs:
       - name: 🛠 Install .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
-          dotnet-version: 11.0.100-preview.4.26230.115
+          dotnet-version: 11.0.100-preview.5.26302.115
 
       - name: 📦 Publish binary
         shell: bash

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.4.26230.115",
+    "version": "11.0.100-preview.5.26302.115",
     "rollForward": "latestMinor"
   },
   "test": {


### PR DESCRIPTION
## Summary
- Bumps the pinned .NET 11 SDK from `preview.4.26230.115` to `preview.5.26302.115` in `global.json` and every workflow that installs the SDK (`release`, `ci`, `coverage`, `benchmarks`).
- Picks up the NativeAOT IL-scanner fix from dotnet/runtime#128107: with `runtime-async` enabled, the preview 4 ILC fails the Nitro CLI AOT publish with `VTable … not computed by the IL scanner`. Preview 5 resolves it.
- All NuGet package versions stay on the existing `11.0.0-preview.4` band (no `Directory.Packages.props` changes), since the Npgsql EF provider has no preview 5 release yet.

## Test plan
- Nitro CLI NativeAOT publish (`PublishAot`, `net11.0`): fails on preview 4, succeeds on preview 5 (produces a working binary).
- PostgreSQL integration tests (EF Core + Npgsql held at preview 4) on the preview 5 SDK/runtime: clean restore with no NuGet version conflicts, 40/40 tests pass.
