### PR TITLE
Add directive-argument opt-in and code-first directive APIs

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/RequiresOptInValidationRule.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/RequiresOptInValidationRule.cs
@@ -55,5 +55,20 @@ internal sealed class RequiresOptInValidationRule : ISchemaValidationRule
                     break;
             }
         }
+
+        foreach (var directive in schema.DirectiveDefinitions)
+        {
+            foreach (var argument in directive.Arguments)
+            {
+                if (argument.Type.IsNonNullType()
+                    && argument.DefaultValue is null
+                    && argument.Directives.Any(d => d.Definition is RequiresOptInDirectiveType))
+                {
+                    errors.Add(RequiresOptInOnRequiredDirectiveArgument(
+                        directive,
+                        argument));
+                }
+            }
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Execution/DependencyInjection/SchemaRequestExecutorBuilderExtensions.Types.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/DependencyInjection/SchemaRequestExecutorBuilderExtensions.Types.cs
@@ -1159,6 +1159,31 @@ public static partial class SchemaRequestExecutorBuilderExtensions
         return builder.ConfigureSchema(b => b.AddDirectiveType(directiveType));
     }
 
+    /// <summary>
+    /// This helper adds a new GraphQL directive type and applies the
+    /// <paramref name="configure"/> delegate.
+    /// </summary>
+    /// <param name="builder">
+    /// The GraphQL configuration builder.
+    /// </param>
+    /// <param name="configure">
+    /// A delegate to configure the type.
+    /// </param>
+    /// <returns>
+    /// Returns the GraphQL configuration builder.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> or <paramref name="configure"/> is <c>null</c>
+    /// </exception>
+    public static IRequestExecutorBuilder AddDirectiveType(
+        this IRequestExecutorBuilder builder,
+        Action<IDirectiveTypeDescriptor> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+        return builder.ConfigureSchema(b => b.AddDirectiveType(configure));
+    }
+
     public static IRequestExecutorBuilder SetSchema<TSchema>(
         this IRequestExecutorBuilder builder)
         where TSchema : Schema

--- a/src/HotChocolate/Core/src/Types/Extensions/SchemaBuilderExtensions.Types.cs
+++ b/src/HotChocolate/Core/src/Types/Extensions/SchemaBuilderExtensions.Types.cs
@@ -468,6 +468,16 @@ public static partial class SchemaBuilderExtensions
         return AddDirectiveType(builder, typeof(TDirective));
     }
 
+    public static ISchemaBuilder AddDirectiveType(
+        this ISchemaBuilder builder,
+        Action<IDirectiveTypeDescriptor> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        return builder.AddDirectiveType(new DirectiveType(configure));
+    }
+
     public static ISchemaBuilder SetSchema<TSchema>(
         this ISchemaBuilder builder)
         where TSchema : Schema

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IDirectiveArgumentDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IDirectiveArgumentDescriptor.cs
@@ -16,6 +16,57 @@ public interface IDirectiveArgumentDescriptor
     IDirectiveArgumentDescriptor Deprecated();
 
     /// <summary>
+    /// Sets a directive on the argument
+    /// <example>
+    /// <code lang="csharp">
+    /// descriptor.Directive(new MyDirective());
+    /// </code>
+    /// Results in the following schema
+    /// <code lang="graphql">
+    /// directive @example(arg: Int @myDirective) on FIELD
+    /// </code>
+    /// </example>
+    /// </summary>
+    /// <param name="directiveInstance">
+    /// The instance of the directive
+    /// </param>
+    /// <typeparam name="T">The type of the directive</typeparam>
+    IDirectiveArgumentDescriptor Directive<T>(T directiveInstance)
+        where T : class;
+
+    /// <summary>
+    /// Sets a directive on the argument
+    /// <example>
+    /// <code lang="csharp">
+    /// descriptor.Directive&lt;MyDirective>();
+    /// </code>
+    /// Results in the following schema
+    /// <code lang="graphql">
+    /// directive @example(arg: Int @myDirective) on FIELD
+    /// </code>
+    /// </example>
+    /// </summary>
+    /// <typeparam name="T">The type of the directive</typeparam>
+    IDirectiveArgumentDescriptor Directive<T>()
+        where T : class, new();
+
+    /// <summary>
+    /// Sets a directive on the argument
+    /// <example>
+    /// <code lang="csharp">
+    /// descriptor.Directive("myDirective");
+    /// </code>
+    /// Results in the following schema
+    /// <code lang="graphql">
+    /// directive @example(arg: Int @myDirective) on FIELD
+    /// </code>
+    /// </example>
+    /// </summary>
+    /// <param name="name">The name of the directive</param>
+    /// <param name="arguments">The arguments of the directive</param>
+    IDirectiveArgumentDescriptor Directive(string name, params ArgumentNode[] arguments);
+
+    /// <summary>
     /// Sets the name of the argument
     /// <example>
     /// <code lang="csharp">

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IDirectiveTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/IDirectiveTypeDescriptor.cs
@@ -44,6 +44,20 @@ public interface IDirectiveTypeDescriptor
     IDirectiveArgumentDescriptor Argument(string name);
 
     /// <summary>
+    /// Specifies a directive argument and applies the
+    /// <paramref name="configure"/> delegate.
+    /// </summary>
+    /// <param name="name">
+    /// The name of the argument.
+    /// </param>
+    /// <param name="configure">
+    /// The argument descriptor to specify the argument configuration.
+    /// </param>
+    IDirectiveTypeDescriptor Argument(
+        string name,
+        Action<IDirectiveArgumentDescriptor> configure);
+
+    /// <summary>
     /// Specifies in which location the directive belongs in.
     /// </summary>
     /// <param name="value">The directive location.</param>

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/DirectiveArgumentDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/DirectiveArgumentDescriptor.cs
@@ -101,6 +101,31 @@ public class DirectiveArgumentDescriptor
     }
 
     /// <inheritdoc />
+    public new IDirectiveArgumentDescriptor Directive<T>(T directiveInstance)
+        where T : class
+    {
+        base.Directive(directiveInstance);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public new IDirectiveArgumentDescriptor Directive<T>()
+        where T : class, new()
+    {
+        base.Directive<T>();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public new IDirectiveArgumentDescriptor Directive(
+        string name,
+        params ArgumentNode[] arguments)
+    {
+        base.Directive(name, arguments);
+        return this;
+    }
+
+    /// <inheritdoc />
     public new IDirectiveArgumentDescriptor Description(string value)
     {
         base.Description(value);

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/DirectiveTypeDescriptor.cs
@@ -135,6 +135,17 @@ public class DirectiveTypeDescriptor
         return descriptor;
     }
 
+    public IDirectiveTypeDescriptor Argument(
+        string name,
+        Action<IDirectiveArgumentDescriptor> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var descriptor = Argument(name);
+        configure(descriptor);
+        return this;
+    }
+
     public IDirectiveTypeDescriptor Location(DirectiveLocation value)
     {
         Configuration.Locations |= value;

--- a/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveExtensions.cs
@@ -87,6 +87,30 @@ public static class RequiresOptInDirectiveExtensions
     }
 
     /// <summary>
+    /// Adds an <c>@requiresOptIn</c> directive to a <see cref="DirectiveArgument"/>.
+    /// <code>
+    /// directive @example(arg: Int @requiresOptIn(feature: "your-feature")) on FIELD
+    /// </code>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The <paramref name="descriptor"/> on which this directive shall be annotated.
+    /// </param>
+    /// <param name="feature">
+    /// The name of the feature that requires opt in.
+    /// </param>
+    /// <returns>
+    /// Returns the <paramref name="descriptor"/> on which this directive
+    /// was applied for configuration chaining.
+    /// </returns>
+    public static IDirectiveArgumentDescriptor RequiresOptIn(
+        this IDirectiveArgumentDescriptor descriptor,
+        string feature)
+    {
+        ApplyRequiresOptIn(descriptor, feature);
+        return descriptor;
+    }
+
+    /// <summary>
     /// Adds an <c>@requiresOptIn</c> directive to an <see cref="EnumValue"/>.
     /// <code>
     /// enum Episode {
@@ -129,6 +153,10 @@ public static class RequiresOptInDirectiveExtensions
                 break;
 
             case IArgumentDescriptor desc:
+                desc.Directive(new RequiresOptIn(feature));
+                break;
+
+            case IDirectiveArgumentDescriptor desc:
                 desc.Directive(new RequiresOptIn(feature));
                 break;
 

--- a/src/HotChocolate/Core/src/Types/Types/Interceptors/OptInFeaturesTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Interceptors/OptInFeaturesTypeInterceptor.cs
@@ -1,4 +1,5 @@
 using HotChocolate.Configuration;
+using HotChocolate.Language;
 using HotChocolate.Types.Descriptors;
 using HotChocolate.Types.Descriptors.Configurations;
 
@@ -27,6 +28,12 @@ internal sealed class OptInFeaturesTypeInterceptor : TypeInterceptor
     {
         switch (configuration)
         {
+            case DirectiveTypeConfiguration directiveType:
+                _optInFeatures.UnionWith(
+                    directiveType.Arguments.SelectMany(a => a.GetOptInFeatures()));
+
+                break;
+
             case EnumTypeConfiguration enumType:
                 _optInFeatures.UnionWith(enumType.Values.SelectMany(v => v.GetOptInFeatures()));
 
@@ -61,10 +68,22 @@ file static class Extensions
     public static IEnumerable<string> GetOptInFeatures(
         this IDirectiveConfigurationProvider configuration)
     {
-        return configuration.Directives
-            .Select(d => d.Value)
-            .OfType<RequiresOptIn>()
-            .Select(r => r.Feature);
+        foreach (var directive in configuration.Directives)
+        {
+            switch (directive.Value)
+            {
+                case RequiresOptIn requiresOptIn:
+                    yield return requiresOptIn.Feature;
+                    break;
+
+                case DirectiveNode { Name.Value: DirectiveNames.RequiresOptIn.Name } node
+                    when node.Arguments.FirstOrDefault(
+                        a => a.Name.Value == DirectiveNames.RequiresOptIn.Arguments.Feature)
+                        is { Value: StringValueNode feature }:
+                    yield return feature.Value;
+                    break;
+            }
+        }
     }
 }
 

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
@@ -16,11 +16,14 @@ internal sealed class __Directive : ObjectType<DirectiveType>
     {
         var stringType = Create(ScalarNames.String);
         var nonNullStringType = Parse($"{ScalarNames.String}!");
+        var nonNullStringListType = Parse($"[{ScalarNames.String}!]");
         var nonNullBooleanType = Parse($"{ScalarNames.Boolean}!");
         var argumentListType = Parse($"[{nameof(__InputValue)}!]!");
         var locationListType = Parse($"[{nameof(__DirectiveLocation)}!]!");
 
-        return new ObjectTypeConfiguration(
+        var optInFeaturesEnabled = context.DescriptorContext.Options.EnableOptInFeatures;
+
+        var def = new ObjectTypeConfiguration(
             Names.__Directive,
             TypeResources.Directive_Description,
             typeof(DirectiveType))
@@ -30,7 +33,12 @@ internal sealed class __Directive : ObjectType<DirectiveType>
                 new(Names.Name, type: nonNullStringType, pureResolver: Resolvers.Name),
                 new(Names.Description, type: stringType, pureResolver: Resolvers.Description),
                 new(Names.Locations, type: locationListType, pureResolver: Resolvers.Locations),
-                new(Names.Args, type: argumentListType, pureResolver: Resolvers.Arguments)
+                new(
+                    Names.Args,
+                    type: argumentListType,
+                    pureResolver: optInFeaturesEnabled
+                        ? Resolvers.ArgumentsWithOptIn
+                        : Resolvers.Arguments)
                 {
                     Arguments =
                     {
@@ -70,6 +78,15 @@ internal sealed class __Directive : ObjectType<DirectiveType>
                 }
             }
         };
+
+        if (optInFeaturesEnabled)
+        {
+            def.Fields.Single(f => f.Name == Names.Args)
+                .Arguments
+                .Add(new(Names.IncludeOptIn, type: nonNullStringListType));
+        }
+
+        return def;
     }
 
     private static class Resolvers
@@ -95,7 +112,28 @@ internal sealed class __Directive : ObjectType<DirectiveType>
             return DirectiveLocationUtils.AsEnumerable(locations);
         }
 
-        public static object Arguments(IResolverContext context)
+        public static object ArgumentsWithOptIn(IResolverContext context)
+        {
+            var includeOptIn = context.ArgumentValue<string[]?>(Names.IncludeOptIn) ?? [];
+
+            // If an argument has no @requiresOptIn directives, it is always included.
+            // If an argument requires opting into features "f1" and "f2", then `includeOptIn`
+            // must list at least one of the features in order for the argument to be included.
+            return Arguments(context).Where(
+                a =>
+                {
+                    var requiredFeatures = a
+                        .Directives
+                        .Where(d => d.Definition is RequiresOptInDirectiveType)
+                        .Select(d => d.ToValue<RequiresOptIn>().Feature)
+                        .ToList();
+
+                    return requiredFeatures.Count == 0
+                        || requiredFeatures.Any(feature => includeOptIn.Contains(feature));
+                });
+        }
+
+        public static IEnumerable<IInputValueDefinition> Arguments(IResolverContext context)
         {
             var directive = context.Parent<DirectiveType>();
             return context.ArgumentValue<bool>(Names.IncludeDeprecated)
@@ -132,6 +170,7 @@ internal sealed class __Directive : ObjectType<DirectiveType>
         public const string IsDeprecated = "isDeprecated";
         public const string DeprecationReason = "deprecationReason";
         public const string IncludeDeprecated = "includeDeprecated";
+        public const string IncludeOptIn = "includeOptIn";
         public const string Locations = "locations";
         public const string Args = "args";
         public const string OnOperation = "onOperation";

--- a/src/HotChocolate/Core/src/Types/Utilities/ErrorHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ErrorHelper.cs
@@ -578,4 +578,13 @@ internal static class ErrorHelper
             .SetField(field)
             .SetArgument(argument)
             .Build();
+
+    public static ISchemaError RequiresOptInOnRequiredDirectiveArgument(
+        IDirectiveDefinition directive,
+        IInputValueDefinition argument)
+        => SchemaErrorBuilder.New()
+            .SetMessage(ErrorHelper_RequiresOptInOnRequiredArgument)
+            .SetDirective(directive)
+            .SetArgument(argument)
+            .Build();
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/IntrospectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/IntrospectionTests.cs
@@ -336,12 +336,12 @@ public class IntrospectionTests
                     """)
                 .UseField(next => next)
                 .ModifyOptions(o => o.EnableDirectiveIntrospection = true)
-                .AddDirectiveType(new DirectiveType(d =>
+                .AddDirectiveType(d =>
                 {
                     d.Name("foo");
                     d.Location(DirectiveLocation.FieldDefinition);
                     d.Internal();
-                }))
+                })
                 .ExecuteRequestAsync(
                     @"{
                         __schema {
@@ -391,12 +391,12 @@ public class IntrospectionTests
                 .ModifyOptions(o => o.EnableDirectiveIntrospection = true)
                 .ModifyOptions(o => o.DefaultDirectiveVisibility = DirectiveVisibility.Internal)
                 .ModifyOptions(o => o.DisableInternalDirectives = true)
-                .AddDirectiveType(new DirectiveType(d =>
+                .AddDirectiveType(d =>
                 {
                     d.Name("foo");
                     d.Location(DirectiveLocation.FieldDefinition);
                     d.Internal();
-                }))
+                })
                 .ExecuteRequestAsync(
                     @"{
                         __schema {

--- a/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using HotChocolate.Types;
 
 namespace HotChocolate.Execution;
@@ -33,6 +34,8 @@ public sealed class OptInFeaturesIntrospectionTests
               "data": {
                 "__schema": {
                   "optInFeatures": [
+                    "directiveArgFeature1",
+                    "directiveArgFeature2",
                     "enumValueFeature1",
                     "enumValueFeature2",
                     "inputFieldFeature1",
@@ -590,6 +593,149 @@ public sealed class OptInFeaturesIntrospectionTests
             """);
     }
 
+    [Fact]
+    public async Task Execute_IntrospectionOnDirectiveArgs_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __schema {
+                    directives {
+                        name
+                        args(includeOptIn: ["directiveArgFeature1"]) {
+                            name
+                            requiresOptIn
+                        }
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
+
+        // assert
+        var directive = GetDirective(result, "exampleDirective");
+        directive.MatchInlineSnapshot(
+            """
+            {
+              "name": "exampleDirective",
+              "args": [
+                {
+                  "name": "argument1",
+                  "requiresOptIn": [
+                    "directiveArgFeature1",
+                    "directiveArgFeature2"
+                  ]
+                },
+                {
+                  "name": "argument2",
+                  "requiresOptIn": []
+                }
+              ]
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnDirectiveArgsFeatureDoesNotExist_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __schema {
+                    directives {
+                        name
+                        args(includeOptIn: ["directiveArgFeatureDoesNotExist"]) {
+                            name
+                            requiresOptIn
+                        }
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
+
+        // assert
+        var directive = GetDirective(result, "exampleDirective");
+        directive.MatchInlineSnapshot(
+            """
+            {
+              "name": "exampleDirective",
+              "args": [
+                {
+                  "name": "argument2",
+                  "requiresOptIn": []
+                }
+              ]
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnDirectiveArgsNoIncludedFeatures_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __schema {
+                    directives {
+                        name
+                        args {
+                            name
+                            requiresOptIn
+                        }
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
+
+        // assert
+        var directive = GetDirective(result, "exampleDirective");
+        directive.MatchInlineSnapshot(
+            """
+            {
+              "name": "exampleDirective",
+              "args": [
+                {
+                  "name": "argument2",
+                  "requiresOptIn": []
+                }
+              ]
+            }
+            """);
+    }
+
+    private static readonly JsonSerializerOptions s_indented = new() { WriteIndented = true };
+
+    private static string GetDirective(IExecutionResult result, string directiveName)
+    {
+        using var document = JsonDocument.Parse(result.ToJson());
+
+        var directive = document.RootElement
+            .GetProperty("data")
+            .GetProperty("__schema")
+            .GetProperty("directives")
+            .EnumerateArray()
+            .Single(d => d.GetProperty("name").GetString() == directiveName);
+
+        return JsonSerializer.Serialize(directive, s_indented);
+    }
+
     private static Schema CreateSchema()
     {
         return SchemaBuilder.New()
@@ -600,6 +746,7 @@ public sealed class OptInFeaturesIntrospectionTests
             .AddQueryType<QueryType>()
             .AddType<ExampleInputType>()
             .AddType<ExampleEnumType>()
+            .AddDirectiveType<ExampleDirectiveType>()
             .ModifyOptions(o => o.EnableOptInFeatures = true)
             .Use(next => next)
             .Create();
@@ -680,6 +827,25 @@ public sealed class OptInFeaturesIntrospectionTests
             descriptor
                 .Value("VALUE3")
                 .Deprecated();
+        }
+    }
+
+    private sealed class ExampleDirectiveType : DirectiveType
+    {
+        protected override void Configure(IDirectiveTypeDescriptor descriptor)
+        {
+            descriptor.Name("exampleDirective");
+            descriptor.Location(DirectiveLocation.Field);
+
+            descriptor
+                .Argument("argument1")
+                .Type<IntType>()
+                .RequiresOptIn("directiveArgFeature1")
+                .RequiresOptIn("directiveArgFeature2");
+
+            descriptor
+                .Argument("argument2")
+                .Type<IntType>();
         }
     }
 }

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
@@ -226,18 +226,17 @@ public partial class AnnotationBasedMutations
                 .AddMutationType()
                 .AddTypeExtension<SimpleMutationExtension>()
                 .AddDirectiveType(
-                    new DirectiveType(
-                        d =>
-                        {
-                            d.Name("foo");
-                            d.Location(DirectiveLocation.Field);
-                            d.Use(
-                                (next, _) => async context =>
-                                {
-                                    // this is just a dummy middleware
-                                    await next(context);
-                                });
-                        }))
+                    d =>
+                    {
+                        d.Name("foo");
+                        d.Location(DirectiveLocation.Field);
+                        d.Use(
+                            (next, _) => async context =>
+                            {
+                                // this is just a dummy middleware
+                                await next(context);
+                            });
+                    })
                 .AddMutationConventions(
                     new MutationConventionOptions { ApplyToAllMutations = true })
                 .ModifyOptions(o => o.StrictValidation = false)

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeTrimmerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeTrimmerTests.cs
@@ -151,12 +151,12 @@ public class TypeTrimmerTests
                 .Field("field")
                 .Type<StringType>()
                 .Resolve("test"))
-            .AddDirectiveType(new DirectiveType(d => d
+            .AddDirectiveType(d => d
                 .Name("_abc")
-                .Location(DirectiveLocation.Object)))
-            .AddDirectiveType(new DirectiveType(d => d
+                .Location(DirectiveLocation.Object))
+            .AddDirectiveType(d => d
                 .Name("_def")
-                .Location(DirectiveLocation.Object)))
+                .Location(DirectiveLocation.Object))
             .AddType<FloatType>()
             .ModifyOptions(o => o.RemoveUnreachableTypes = true)
             .Create();
@@ -186,9 +186,9 @@ public class TypeTrimmerTests
                 .Field("field")
                 .Type<StringType>()
                 .Resolve("test"))
-            .AddDirectiveType(new DirectiveType(d => d
+            .AddDirectiveType(d => d
                 .Name("_abc")
-                .Location(DirectiveLocation.Query)))
+                .Location(DirectiveLocation.Query))
             .AddType<FloatType>()
             .ModifyOptions(o => o.RemoveUnreachableTypes = true)
             .Create();
@@ -218,9 +218,9 @@ public class TypeTrimmerTests
                 .Field("field")
                 .Type<StringType>()
                 .Resolve("test"))
-            .AddDirectiveType(new DirectiveType(d => d
+            .AddDirectiveType(d => d
                 .Name("_abc")
-                .Location(DirectiveLocation.Object | DirectiveLocation.Query)))
+                .Location(DirectiveLocation.Object | DirectiveLocation.Query))
             .AddType<FloatType>()
             .ModifyOptions(o => o.RemoveUnreachableTypes = true)
             .Create();
@@ -251,11 +251,11 @@ public class TypeTrimmerTests
                 .Type<StringType>()
                 .Resolve("test"))
             .AddType(new UuidType('D'))
-            .AddDirectiveType(new DirectiveType(d => d
+            .AddDirectiveType(d => d
                 .Name("_abc")
                 .Location(DirectiveLocation.Object | DirectiveLocation.Query)
                 .Argument("arg")
-                .Type<UuidType>()))
+                .Type<UuidType>())
             .AddType<FloatType>()
             .ModifyOptions(o => o.RemoveUnreachableTypes = true)
             .Create();

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/RequiresOptInValidation.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/RequiresOptInValidation.cs
@@ -80,4 +80,42 @@ public class RequiresOptInValidation : TypeValidationTestBase
             }
             """);
     }
+
+    [Fact]
+    public void Must_Not_Appear_On_Required_Directive_Argument()
+    {
+        ExpectError(
+            """
+            type Query { field: Int }
+
+            directive @example(
+                argument: Int!
+                    @requiresOptIn(feature: "feature1")
+                    @requiresOptIn(feature: "feature2")) on FIELD
+            """);
+    }
+
+    [Fact]
+    public void May_Appear_On_Required_With_Default_Directive_Argument()
+    {
+        ExpectValid(
+            """
+            type Query { field: Int }
+
+            directive @example(
+                argument: Int! = 1 @requiresOptIn(feature: "feature")) on FIELD
+            """);
+    }
+
+    [Fact]
+    public void May_Appear_On_Nullable_Directive_Argument()
+    {
+        ExpectValid(
+            """
+            type Query { field: Int }
+
+            directive @example(
+                argument: Int @requiresOptIn(feature: "feature")) on FIELD
+            """);
+    }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/__snapshots__/RequiresOptInValidation.Must_Not_Appear_On_Required_Directive_Argument.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/__snapshots__/RequiresOptInValidation.Must_Not_Appear_On_Required_Directive_Argument.snap
@@ -1,0 +1,7 @@
+{
+  "message": "The @requiresOptIn directive must not appear on required (non-null without a default) arguments.",
+  "extensions": {
+    "argument": "argument"
+  }
+}
+

--- a/src/HotChocolate/Core/test/Types.Tests/Extensions/SchemaBuilderExtensions.Types.Tests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Extensions/SchemaBuilderExtensions.Types.Tests.cs
@@ -606,7 +606,7 @@ public class SchemaBuilderExtensionsTypeTests
 
         // act
         Action action = () =>
-            SchemaBuilderExtensions.AddDirectiveType(builder, null!);
+            SchemaBuilderExtensions.AddDirectiveType(builder, (Type)null!);
 
         // assert
         Assert.Throws<ArgumentNullException>(action);
@@ -655,6 +655,28 @@ public class SchemaBuilderExtensionsTypeTests
 
         // assert
         builder.Create().ToString().MatchSnapshot();
+    }
+
+    [Fact]
+    public void AddDirectiveType_ConfigureDelegate_AddsDirectiveWithArgument()
+    {
+        // arrange
+        var builder = SchemaBuilder.New()
+            .AddQueryType(d => d
+                .Name("Query")
+                .Field("field")
+                .Type<IntType>()
+                .Resolve(() => 1));
+
+        // act
+        builder.AddDirectiveType(d => d
+            .Name("exampleDirective")
+            .Location(Types.DirectiveLocation.Field)
+            .Argument("arg", a => a.Type<IntType>()));
+
+        // assert
+        var directive = builder.Create().DirectiveTypes["exampleDirective"];
+        Assert.True(directive.Arguments.ContainsField("arg"));
     }
 
     [Fact]

--- a/src/HotChocolate/Core/test/Types.Tests/Types/DirectiveTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/DirectiveTypeTests.cs
@@ -434,11 +434,10 @@ public class DirectiveTypeTests : TypeTestBase
                     .Type<StringType>()
                     .Resolve("bar"))
             .AddDirectiveType(
-                new DirectiveType(
-                    d => d
-                        .Name("foo")
-                        .Location(DirectiveLocation.Object)
-                        .Use((_, _) => _ => default)))
+                d => d
+                    .Name("foo")
+                    .Location(DirectiveLocation.Object)
+                    .Use((_, _) => _ => default))
             .Create();
 
         // assert
@@ -460,11 +459,10 @@ public class DirectiveTypeTests : TypeTestBase
                     .Type<StringType>()
                     .Resolve("bar"))
             .AddDirectiveType(
-                new DirectiveType(
-                    d => d
-                        .Name("foo")
-                        .Location(DirectiveLocation.Object)
-                        .Use<DirectiveMiddleware>()))
+                d => d
+                    .Name("foo")
+                    .Location(DirectiveLocation.Object)
+                    .Use<DirectiveMiddleware>())
             .Create();
 
         // assert
@@ -486,11 +484,10 @@ public class DirectiveTypeTests : TypeTestBase
                     .Type<StringType>()
                     .Resolve("bar"))
             .AddDirectiveType(
-                new DirectiveType(
-                    d => d
-                        .Name("foo")
-                        .Location(DirectiveLocation.Object)
-                        .Use((_, next) => new DirectiveMiddleware(next))))
+                d => d
+                    .Name("foo")
+                    .Location(DirectiveLocation.Object)
+                    .Use((_, next) => new DirectiveMiddleware(next)))
             .Create();
 
         // assert
@@ -512,10 +509,9 @@ public class DirectiveTypeTests : TypeTestBase
                         .Type<StringType>()
                         .Resolve("bar"))
                 .AddDirectiveType(
-                    new DirectiveType(
-                        d => d.Name("foo")
-                            .Location(DirectiveLocation.Object)
-                            .Use(null!)))
+                    d => d.Name("foo")
+                        .Location(DirectiveLocation.Object)
+                        .Use(null!))
                 .Create();
 
         // assert
@@ -618,13 +614,12 @@ public class DirectiveTypeTests : TypeTestBase
                     .Resolve("asd")
                     .Directive("Qux"))
             .AddDirectiveType(
-                new DirectiveType(
-                    x => x
-                        .Name("Qux")
-                        .Location(DirectiveLocation.FieldDefinition)
-                        .Argument("bar")
-                        .Type<IntType>()
-                        .Deprecated("a")))
+                x => x
+                    .Name("Qux")
+                    .Location(DirectiveLocation.FieldDefinition)
+                    .Argument("bar")
+                    .Type<IntType>()
+                    .Deprecated("a"))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
@@ -646,13 +641,12 @@ public class DirectiveTypeTests : TypeTestBase
                         .Resolve("asd")
                         .Directive("Qux", new ArgumentNode("bar", 1)))
                 .AddDirectiveType(
-                    new DirectiveType(
-                        x => x
-                            .Name("Qux")
-                            .Location(DirectiveLocation.FieldDefinition)
-                            .Argument("bar")
-                            .Type<NonNullType<IntType>>()
-                            .Deprecated("a")))
+                    x => x
+                        .Name("Qux")
+                        .Location(DirectiveLocation.FieldDefinition)
+                        .Argument("bar")
+                        .Type<NonNullType<IntType>>()
+                        .Deprecated("a"))
                 .BuildRequestExecutorAsync();
 
         // assert
@@ -1185,6 +1179,30 @@ public class DirectiveTypeTests : TypeTestBase
         var legacy = schema.DirectiveTypes["legacy"];
         Assert.True(legacy.IsDeprecated);
         Assert.Equal("Use the replacement directive.", legacy.DeprecationReason);
+    }
+
+    [Fact]
+    public void DirectiveArgument_AppliesDirective()
+    {
+        // arrange
+        // act
+        var schema = SchemaBuilder.New()
+            .AddQueryType(c => c
+                .Name("Query")
+                .Field("foo")
+                .Type<StringType>()
+                .Resolve("bar"))
+            .AddDirectiveType(d => d
+                .Name("foo")
+                .Location(DirectiveLocation.Field)
+                .Argument("arg", a => a
+                    .Type<IntType>()
+                    .Directive("deprecated")))
+            .Create();
+
+        // assert
+        var argument = schema.DirectiveTypes["foo"].Arguments["arg"];
+        Assert.True(argument.Directives.ContainsDirective("deprecated"));
     }
 
     public class DirectiveWithSyntaxTypeArg : DirectiveType

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
@@ -52,6 +52,13 @@ public sealed class RequiresOptInDirectiveTests
                     .Value("VALUE")
                     .RequiresOptIn("enumValueFeature1")
                     .RequiresOptIn("enumValueFeature2"))
+                .AddDirectiveType(d => d
+                    .Name("exampleDirective")
+                    .Location(DirectiveLocation.Field)
+                    .Argument("argument", a => a
+                        .Type<IntType>()
+                        .RequiresOptIn("directiveArgFeature1")
+                        .RequiresOptIn("directiveArgFeature2")))
                 .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // assert

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
@@ -20,6 +20,10 @@ enum Enum {
     @requiresOptIn(feature: "enumValueFeature2")
 }
 
+directive @exampleDirective(
+  argument: Int @requiresOptIn(feature: "directiveArgFeature1") @requiresOptIn(feature: "directiveArgFeature2")
+) on FIELD
+
 "Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used."
 directive @requiresOptIn(
   "The name of the feature that requires opt in."

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeTests.cs
@@ -95,9 +95,9 @@ public class EnumTypeTests : TypeTestBase
     {
         // act
         var schema = SchemaBuilder.New()
-            .AddDirectiveType(new DirectiveType(d => d
+            .AddDirectiveType(d => d
                 .Name("bar")
-                .Location(DirectiveLocation.Enum)))
+                .Location(DirectiveLocation.Enum))
             .AddEnumType(d => d.Name("Foo").Directive(new DirectiveNode("bar")).Value("ABC"))
             .ModifyOptions(o => o.StrictValidation = false)
             .Create();
@@ -357,9 +357,9 @@ public class EnumTypeTests : TypeTestBase
         // act
         var schema = SchemaBuilder
             .New()
-            .AddDirectiveType(new DirectiveType(d => d
+            .AddDirectiveType(d => d
                 .Name("bar")
-                .Location(DirectiveLocation.EnumValue)))
+                .Location(DirectiveLocation.EnumValue))
             .AddEnumType(d => d
                 .Name("Foo")
                 .Value("baz")
@@ -380,9 +380,9 @@ public class EnumTypeTests : TypeTestBase
         // act
         var schema = SchemaBuilder
             .New()
-            .AddDirectiveType(new DirectiveType(d => d
+            .AddDirectiveType(d => d
                 .Name("bar")
-                .Location(DirectiveLocation.EnumValue)))
+                .Location(DirectiveLocation.EnumValue))
             .AddEnumType(d => d
                 .Name("Foo")
                 .Value("baz")
@@ -403,9 +403,9 @@ public class EnumTypeTests : TypeTestBase
         // act
         var schema = SchemaBuilder
             .New()
-            .AddDirectiveType(new DirectiveType(d => d
+            .AddDirectiveType(d => d
                 .Name("bar")
-                .Location(DirectiveLocation.EnumValue)))
+                .Location(DirectiveLocation.EnumValue))
             .AddEnumType(d => d
                 .Name("Foo")
                 .Value("baz")

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Interceptors/FlagEnumInterceptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Interceptors/FlagEnumInterceptorTests.cs
@@ -57,12 +57,11 @@ public class FlagEnumInterceptorTests
                 x
                     => x.Name("Query").Field("asd").Resolve("baz"))
             .AddDirectiveType(
-                new DirectiveType(
-                    x
-                        => x.Name("Test")
-                            .Location(DirectiveLocation.FragmentSpread)
-                            .Argument("a")
-                            .Type(typeof(FlagsEnum))))
+                x
+                    => x.Name("Test")
+                        .Location(DirectiveLocation.FragmentSpread)
+                        .Argument("a")
+                        .Type(typeof(FlagsEnum)))
             .ModifyOptions(x => x.EnableFlagEnums = true)
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
         executor.Schema.ToString().MatchSnapshot();

--- a/src/HotChocolate/Core/test/Validation.Tests/ValidationUtils.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/ValidationUtils.cs
@@ -34,8 +34,8 @@ public static class ValidationUtils
         string name,
         DirectiveLocation location,
         Func<IDirectiveTypeDescriptor, IDirectiveTypeDescriptor> configure) =>
-        builder.AddDirectiveType(new DirectiveType(x =>
-            configure(x.Name(name).Location(location))));
+        builder.AddDirectiveType(x =>
+            configure(x.Name(name).Location(location)));
 
     public static ISchemaDefinition CreateSchema()
         => SchemaBuilder.New()


### PR DESCRIPTION
## Summary
- Directive arguments now participate in opt-in features: `@requiresOptIn` on a directive argument is validated (rejected on required, non-null arguments without a default), filtered via `includeOptIn` on `__Directive.args`, and aggregated into `__schema.optInFeatures`.
- New code-first directive APIs: apply directives to directive arguments (`IDirectiveArgumentDescriptor.Directive<T>()`), mark a directive argument opt-in (`.RequiresOptIn(feature)`), register directive types via a configure delegate (`AddDirectiveType(Action<IDirectiveTypeDescriptor>)` on both `ISchemaBuilder` and `IRequestExecutorBuilder`), and configure directive arguments inline (`IDirectiveTypeDescriptor.Argument(name, Action<IDirectiveArgumentDescriptor>)`).
- Simplified existing `AddDirectiveType(new DirectiveType(d => …))` call sites to the new lambda overload.

## Test plan
- Directive-argument opt-in: validation rejects `@requiresOptIn` on required directive arguments; `__Directive.args(includeOptIn:)` filtering; `optInFeatures` aggregation includes directive-argument features.
- Code-first: `.Directive()` and `.RequiresOptIn()` on directive arguments; `AddDirectiveType(Action<…>)` registration with an argument configurator.
- Verified the affected suites on net10.0 (Types.Tests, Execution.Tests, Validation.Tests, Types.Mutations.Tests).
