### PR TITLE
Support `@requiresOptIn` on directive definitions

### DIFF
--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
@@ -1826,7 +1826,7 @@ namespace HotChocolate.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used..
+        ///   Looks up a localized string similar to Indicates that the given field, argument, input field, enum value, or directive definition requires giving explicit consent before being used..
         /// </summary>
         internal static string RequiresOptInDirectiveType_TypeDescription {
             get {

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
@@ -1042,7 +1042,7 @@ Type: `{0}`</value>
     <value>{0}Type cannot parse the provided value. The value does not match the required regular expression pattern.</value>
   </data>
   <data name="RequiresOptInDirectiveType_TypeDescription" xml:space="preserve">
-    <value>Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used.</value>
+    <value>Indicates that the given field, argument, input field, enum value, or directive definition requires giving explicit consent before being used.</value>
   </data>
   <data name="RequiresOptInDirectiveType_FeatureDescription" xml:space="preserve">
     <value>The name of the feature that requires opt in.</value>

--- a/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInAttribute.cs
@@ -5,11 +5,12 @@ using HotChocolate.Types.Descriptors;
 namespace HotChocolate.Types;
 
 /// <summary>
-/// Indicates that the given field, argument, input field, or enum value requires giving explicit
-/// consent before being used.
+/// Indicates that the given directive definition, field, argument, input field, or enum value
+/// requires giving explicit consent before being used.
 /// </summary>
 [AttributeUsage(
-    AttributeTargets.Field // Required for enum values
+    AttributeTargets.Class // Required for directive definitions
+    | AttributeTargets.Field // Required for enum values
     | AttributeTargets.Method
     | AttributeTargets.Parameter
     | AttributeTargets.Property,
@@ -47,6 +48,10 @@ public sealed class RequiresOptInAttribute : DescriptorAttribute
                 break;
 
             case IArgumentDescriptor desc:
+                desc.RequiresOptIn(Feature);
+                break;
+
+            case IDirectiveTypeDescriptor desc:
                 desc.RequiresOptIn(Feature);
                 break;
 

--- a/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveExtensions.cs
@@ -111,6 +111,30 @@ public static class RequiresOptInDirectiveExtensions
     }
 
     /// <summary>
+    /// Adds an <c>@requiresOptIn</c> directive to a directive definition.
+    /// <code>
+    /// directive @example @requiresOptIn(feature: "your-feature") on FIELD
+    /// </code>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The <paramref name="descriptor"/> on which this directive shall be annotated.
+    /// </param>
+    /// <param name="feature">
+    /// The name of the feature that requires opt in.
+    /// </param>
+    /// <returns>
+    /// Returns the <paramref name="descriptor"/> on which this directive
+    /// was applied for configuration chaining.
+    /// </returns>
+    public static IDirectiveTypeDescriptor RequiresOptIn(
+        this IDirectiveTypeDescriptor descriptor,
+        string feature)
+    {
+        ApplyRequiresOptIn(descriptor, feature);
+        return descriptor;
+    }
+
+    /// <summary>
     /// Adds an <c>@requiresOptIn</c> directive to an <see cref="EnumValue"/>.
     /// <code>
     /// enum Episode {
@@ -157,6 +181,10 @@ public static class RequiresOptInDirectiveExtensions
                 break;
 
             case IDirectiveArgumentDescriptor desc:
+                desc.Directive(new RequiresOptIn(feature));
+                break;
+
+            case IDirectiveTypeDescriptor desc:
                 desc.Directive(new RequiresOptIn(feature));
                 break;
 

--- a/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveType.cs
@@ -3,8 +3,8 @@ using HotChocolate.Properties;
 namespace HotChocolate.Types;
 
 /// <summary>
-/// Indicates that the given field, argument, input field, or enum value requires giving explicit
-/// consent before being used.
+/// Indicates that the given field, argument, input field, enum value, or directive definition
+/// requires giving explicit consent before being used.
 ///
 /// <code>
 /// type Session {
@@ -25,6 +25,7 @@ public sealed class RequiresOptInDirectiveType : DirectiveType<RequiresOptIn>
             .Name(DirectiveNames.RequiresOptIn.Name)
             .Description(TypeResources.RequiresOptInDirectiveType_TypeDescription)
             .Location(DirectiveLocation.ArgumentDefinition)
+            .Location(DirectiveLocation.DirectiveDefinition)
             .Location(DirectiveLocation.EnumValue)
             .Location(DirectiveLocation.FieldDefinition)
             .Location(DirectiveLocation.InputFieldDefinition)

--- a/src/HotChocolate/Core/src/Types/Types/Interceptors/OptInFeaturesTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Interceptors/OptInFeaturesTypeInterceptor.cs
@@ -29,6 +29,7 @@ internal sealed class OptInFeaturesTypeInterceptor : TypeInterceptor
         switch (configuration)
         {
             case DirectiveTypeConfiguration directiveType:
+                _optInFeatures.UnionWith(directiveType.GetOptInFeatures());
                 _optInFeatures.UnionWith(
                     directiveType.Arguments.SelectMany(a => a.GetOptInFeatures()));
 

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
@@ -84,6 +84,10 @@ internal sealed class __Directive : ObjectType<DirectiveType>
             def.Fields.Single(f => f.Name == Names.Args)
                 .Arguments
                 .Add(new(Names.IncludeOptIn, type: nonNullStringListType));
+
+            def.Fields.Add(new(Names.RequiresOptIn,
+                type: nonNullStringListType,
+                pureResolver: Resolvers.RequiresOptIn));
         }
 
         return def;
@@ -141,6 +145,12 @@ internal sealed class __Directive : ObjectType<DirectiveType>
                 : directive.Arguments.Where(t => !t.IsDeprecated);
         }
 
+        public static object RequiresOptIn(IResolverContext context) =>
+            ((IDirectivesProvider)context.Parent<DirectiveType>())
+                .Directives
+                .Where(t => t.Definition is RequiresOptInDirectiveType)
+                .Select(d => d.ToValue<RequiresOptIn>().Feature);
+
         public static object OnOperation(IResolverContext context)
         {
             var locations = context.Parent<DirectiveType>().Locations;
@@ -171,6 +181,7 @@ internal sealed class __Directive : ObjectType<DirectiveType>
         public const string DeprecationReason = "deprecationReason";
         public const string IncludeDeprecated = "includeDeprecated";
         public const string IncludeOptIn = "includeOptIn";
+        public const string RequiresOptIn = "requiresOptIn";
         public const string Locations = "locations";
         public const string Args = "args";
         public const string OnOperation = "onOperation";

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Schema.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Schema.cs
@@ -27,6 +27,8 @@ internal sealed class __Schema : ObjectType
         var nonNullStringListType = Parse($"[{ScalarNames.String}!]");
         var optInFeatureStabilityListType = Parse($"[{nameof(__OptInFeatureStability)}!]!");
 
+        var optInFeaturesEnabled = context.DescriptorContext.Options.EnableOptInFeatures;
+
         var def = new ObjectTypeConfiguration(Names.__Schema, Schema_Description, typeof(ISchemaDefinition))
         {
             Fields =
@@ -48,7 +50,9 @@ internal sealed class __Schema : ObjectType
                     new(Names.Directives,
                         Schema_Directives,
                         directiveListType,
-                        pureResolver: Resolvers.Directives)
+                        pureResolver: optInFeaturesEnabled
+                            ? Resolvers.DirectivesWithOptIn
+                            : Resolvers.Directives)
                     {
                         Arguments =
                         {
@@ -70,8 +74,12 @@ internal sealed class __Schema : ObjectType
                 pureResolver: Resolvers.AppliedDirectives));
         }
 
-        if (context.DescriptorContext.Options.EnableOptInFeatures)
+        if (optInFeaturesEnabled)
         {
+            def.Fields.Single(f => f.Name == Names.Directives)
+                .Arguments
+                .Add(new(Names.IncludeOptIn, type: nonNullStringListType));
+
             def.Fields.Add(new(
                 Names.OptInFeatures,
                 type: nonNullStringListType,
@@ -103,7 +111,7 @@ internal sealed class __Schema : ObjectType
         public static object? SubscriptionType(IResolverContext context)
             => context.Parent<ISchemaDefinition>().SubscriptionType;
 
-        public static object Directives(IResolverContext context)
+        public static IEnumerable<IDirectiveDefinition> Directives(IResolverContext context)
         {
             var directiveDefinitions = context.Parent<ISchemaDefinition>()
                 .DirectiveDefinitions
@@ -112,6 +120,27 @@ internal sealed class __Schema : ObjectType
             return context.ArgumentValue<bool>(Names.IncludeDeprecated)
                 ? directiveDefinitions
                 : directiveDefinitions.Where(t => !t.IsDeprecated);
+        }
+
+        public static object DirectivesWithOptIn(IResolverContext context)
+        {
+            var includeOptIn = context.ArgumentValue<string[]?>(Names.IncludeOptIn) ?? [];
+
+            // If a directive has no @requiresOptIn directives, it is always included.
+            // If a directive requires opting into features "f1" and "f2", then `includeOptIn`
+            // must list at least one of the features in order for the directive to be included.
+            return Directives(context).Where(
+                t =>
+                {
+                    var requiredFeatures = ((IDirectivesProvider)t)
+                        .Directives
+                        .Where(d => d.Definition is RequiresOptInDirectiveType)
+                        .Select(d => d.ToValue<RequiresOptIn>().Feature)
+                        .ToList();
+
+                    return requiredFeatures.Count == 0
+                        || requiredFeatures.Any(feature => includeOptIn.Contains(feature));
+                });
         }
 
         public static object AppliedDirectives(IResolverContext context)
@@ -139,6 +168,7 @@ internal sealed class __Schema : ObjectType
         public const string SubscriptionType = "subscriptionType";
         public const string Directives = "directives";
         public const string IncludeDeprecated = "includeDeprecated";
+        public const string IncludeOptIn = "includeOptIn";
         public const string AppliedDirectives = "appliedDirectives";
         public const string OptInFeatures = "optInFeatures";
         public const string OptInFeatureStability = "optInFeatureStability";

--- a/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
@@ -601,7 +601,7 @@ public sealed class OptInFeaturesIntrospectionTests
             """
             {
                 __schema {
-                    directives {
+                    directives(includeOptIn: ["directiveFeature"]) {
                         name
                         requiresOptIn
                     }
@@ -764,7 +764,56 @@ public sealed class OptInFeaturesIntrospectionTests
             """);
     }
 
+    [Fact]
+    public async Task Execute_IntrospectionOnDirectives_FiltersByOptIn()
+    {
+        // arrange
+        const string included =
+            """
+            { __schema { directives(includeOptIn: ["directiveFeature"]) { name } } }
+            """;
+
+        const string excluded =
+            """
+            { __schema { directives { name } } }
+            """;
+
+        var executor = SchemaBuilder.New()
+            .AddDocumentFromString(
+                """
+                type Query { field: Int }
+
+                directive @example @requiresOptIn(feature: "directiveFeature") on FIELD
+                """)
+            .Use(_ => _ => default)
+            .ModifyOptions(o => o.EnableOptInFeatures = true)
+            .Create()
+            .MakeExecutable();
+
+        // act
+        var withOptIn = await executor.ExecuteAsync(included, TestContext.Current.CancellationToken);
+        var withoutOptIn = await executor.ExecuteAsync(excluded, TestContext.Current.CancellationToken);
+
+        // assert
+        // The opt-in directive is shown only when its feature is opted into.
+        Assert.Contains("example", GetDirectiveNames(withOptIn));
+        Assert.DoesNotContain("example", GetDirectiveNames(withoutOptIn));
+    }
+
     private static readonly JsonSerializerOptions s_indented = new() { WriteIndented = true };
+
+    private static string[] GetDirectiveNames(IExecutionResult result)
+    {
+        using var document = JsonDocument.Parse(result.ToJson());
+
+        return document.RootElement
+            .GetProperty("data")
+            .GetProperty("__schema")
+            .GetProperty("directives")
+            .EnumerateArray()
+            .Select(d => d.GetProperty("name").GetString()!)
+            .ToArray();
+    }
 
     private static string GetDirective(IExecutionResult result, string directiveName)
     {

--- a/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
@@ -594,6 +594,50 @@ public sealed class OptInFeaturesIntrospectionTests
     }
 
     [Fact]
+    public async Task Execute_IntrospectionOnDirective_RequiresOptIn_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __schema {
+                    directives {
+                        name
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = SchemaBuilder.New()
+            .AddDocumentFromString(
+                """
+                type Query { field: Int }
+
+                directive @example @requiresOptIn(feature: "directiveFeature") on FIELD
+                """)
+            .Use(_ => _ => default)
+            .ModifyOptions(o => o.EnableOptInFeatures = true)
+            .Create()
+            .MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
+
+        // assert
+        var directive = GetDirective(result, "example");
+        directive.MatchInlineSnapshot(
+            """
+            {
+              "name": "example",
+              "requiresOptIn": [
+                "directiveFeature"
+              ]
+            }
+            """);
+    }
+
+    [Fact]
     public async Task Execute_IntrospectionOnDirectiveArgs_MatchesSnapshot()
     {
         // arrange

--- a/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
@@ -765,6 +765,45 @@ public sealed class OptInFeaturesIntrospectionTests
     }
 
     [Fact]
+    public async Task Execute_OptInFeaturesIncludeDirectiveDefinitionFeatures_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            { __schema { optInFeatures } }
+            """;
+
+        var executor = SchemaBuilder.New()
+            .AddDocumentFromString(
+                """
+                type Query { field: Int }
+
+                directive @example @requiresOptIn(feature: "directiveFeature") on FIELD
+                """)
+            .Use(_ => _ => default)
+            .ModifyOptions(o => o.EnableOptInFeatures = true)
+            .Create()
+            .MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__schema": {
+                  "optInFeatures": [
+                    "directiveFeature"
+                  ]
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task Execute_IntrospectionOnDirectives_FiltersByOptIn()
     {
         // arrange

--- a/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
@@ -36,6 +36,8 @@ public sealed class OptInFeaturesIntrospectionTests
                   "optInFeatures": [
                     "directiveArgFeature1",
                     "directiveArgFeature2",
+                    "directiveFeature1",
+                    "directiveFeature2",
                     "enumValueFeature1",
                     "enumValueFeature2",
                     "inputFieldFeature1",
@@ -594,14 +596,14 @@ public sealed class OptInFeaturesIntrospectionTests
     }
 
     [Fact]
-    public async Task Execute_IntrospectionOnDirective_RequiresOptIn_MatchesSnapshot()
+    public async Task Execute_IntrospectionOnDirectives_MatchesSnapshot()
     {
         // arrange
         const string query =
             """
             {
                 __schema {
-                    directives(includeOptIn: ["directiveFeature"]) {
+                    directives(includeOptIn: ["directiveFeature1"]) {
                         name
                         requiresOptIn
                     }
@@ -609,31 +611,82 @@ public sealed class OptInFeaturesIntrospectionTests
             }
             """;
 
-        var executor = SchemaBuilder.New()
-            .AddDocumentFromString(
-                """
-                type Query { field: Int }
-
-                directive @example @requiresOptIn(feature: "directiveFeature") on FIELD
-                """)
-            .Use(_ => _ => default)
-            .ModifyOptions(o => o.EnableOptInFeatures = true)
-            .Create()
-            .MakeExecutable();
+        var executor = CreateSchema().MakeExecutable();
 
         // act
         var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
 
         // assert
-        var directive = GetDirective(result, "example");
-        directive.MatchInlineSnapshot(
+        var directives = GetDirectives(result, "exampleDirective");
+        directives.MatchInlineSnapshot(
+            """
+            [
+              {
+                "name": "exampleDirective",
+                "requiresOptIn": [
+                  "directiveFeature1",
+                  "directiveFeature2"
+                ]
+              }
+            ]
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnDirectivesFeatureDoesNotExist_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
             """
             {
-              "name": "example",
-              "requiresOptIn": [
-                "directiveFeature"
-              ]
+                __schema {
+                    directives(includeOptIn: ["directiveFeatureDoesNotExist"]) {
+                        name
+                        requiresOptIn
+                    }
+                }
             }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
+
+        // assert
+        var directives = GetDirectives(result, "exampleDirective");
+        directives.MatchInlineSnapshot(
+            """
+            []
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnDirectivesNoIncludedFeatures_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __schema {
+                    directives {
+                        name
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
+
+        // assert
+        var directives = GetDirectives(result, "exampleDirective");
+        directives.MatchInlineSnapshot(
+            """
+            []
             """);
     }
 
@@ -645,7 +698,7 @@ public sealed class OptInFeaturesIntrospectionTests
             """
             {
                 __schema {
-                    directives {
+                    directives(includeOptIn: ["directiveFeature1"]) {
                         name
                         args(includeOptIn: ["directiveArgFeature1"]) {
                             name
@@ -692,7 +745,7 @@ public sealed class OptInFeaturesIntrospectionTests
             """
             {
                 __schema {
-                    directives {
+                    directives(includeOptIn: ["directiveFeature1"]) {
                         name
                         args(includeOptIn: ["directiveArgFeatureDoesNotExist"]) {
                             name
@@ -732,7 +785,7 @@ public sealed class OptInFeaturesIntrospectionTests
             """
             {
                 __schema {
-                    directives {
+                    directives(includeOptIn: ["directiveFeature1"]) {
                         name
                         args {
                             name
@@ -764,94 +817,21 @@ public sealed class OptInFeaturesIntrospectionTests
             """);
     }
 
-    [Fact]
-    public async Task Execute_OptInFeaturesIncludeDirectiveDefinitionFeatures_MatchesSnapshot()
-    {
-        // arrange
-        const string query =
-            """
-            { __schema { optInFeatures } }
-            """;
-
-        var executor = SchemaBuilder.New()
-            .AddDocumentFromString(
-                """
-                type Query { field: Int }
-
-                directive @example @requiresOptIn(feature: "directiveFeature") on FIELD
-                """)
-            .Use(_ => _ => default)
-            .ModifyOptions(o => o.EnableOptInFeatures = true)
-            .Create()
-            .MakeExecutable();
-
-        // act
-        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
-
-        // assert
-        result.MatchInlineSnapshot(
-            """
-            {
-              "data": {
-                "__schema": {
-                  "optInFeatures": [
-                    "directiveFeature"
-                  ]
-                }
-              }
-            }
-            """);
-    }
-
-    [Fact]
-    public async Task Execute_IntrospectionOnDirectives_FiltersByOptIn()
-    {
-        // arrange
-        const string included =
-            """
-            { __schema { directives(includeOptIn: ["directiveFeature"]) { name } } }
-            """;
-
-        const string excluded =
-            """
-            { __schema { directives { name } } }
-            """;
-
-        var executor = SchemaBuilder.New()
-            .AddDocumentFromString(
-                """
-                type Query { field: Int }
-
-                directive @example @requiresOptIn(feature: "directiveFeature") on FIELD
-                """)
-            .Use(_ => _ => default)
-            .ModifyOptions(o => o.EnableOptInFeatures = true)
-            .Create()
-            .MakeExecutable();
-
-        // act
-        var withOptIn = await executor.ExecuteAsync(included, TestContext.Current.CancellationToken);
-        var withoutOptIn = await executor.ExecuteAsync(excluded, TestContext.Current.CancellationToken);
-
-        // assert
-        // The opt-in directive is shown only when its feature is opted into.
-        Assert.Contains("example", GetDirectiveNames(withOptIn));
-        Assert.DoesNotContain("example", GetDirectiveNames(withoutOptIn));
-    }
-
     private static readonly JsonSerializerOptions s_indented = new() { WriteIndented = true };
 
-    private static string[] GetDirectiveNames(IExecutionResult result)
+    private static string GetDirectives(IExecutionResult result, string directiveName)
     {
         using var document = JsonDocument.Parse(result.ToJson());
 
-        return document.RootElement
+        var directives = document.RootElement
             .GetProperty("data")
             .GetProperty("__schema")
             .GetProperty("directives")
             .EnumerateArray()
-            .Select(d => d.GetProperty("name").GetString()!)
+            .Where(d => d.GetProperty("name").GetString() == directiveName)
             .ToArray();
+
+        return JsonSerializer.Serialize(directives, s_indented);
     }
 
     private static string GetDirective(IExecutionResult result, string directiveName)
@@ -968,6 +948,9 @@ public sealed class OptInFeaturesIntrospectionTests
         {
             descriptor.Name("exampleDirective");
             descriptor.Location(DirectiveLocation.Field);
+            descriptor
+                .RequiresOptIn("directiveFeature1")
+                .RequiresOptIn("directiveFeature2");
 
             descriptor
                 .Argument("argument1")

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
@@ -22,6 +22,26 @@ public sealed class RequiresOptInDirectiveTests
     }
 
     [Fact]
+    public async Task RequiresOptIn_OnDirectiveDefinition_CodeFirst_AppliesDirective()
+    {
+        // arrange & act
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .ModifyOptions(o => o.EnableOptInFeatures = true)
+                .AddDirectiveType(d => d
+                    .Name("example")
+                    .Location(DirectiveLocation.Field)
+                    .RequiresOptIn("directiveFeature"))
+                .AddQueryType(d => d.Field("field").Type<IntType>().Resolve(() => 1))
+                .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.True(
+            schema.DirectiveTypes["example"].Directives.ContainsDirective("requiresOptIn"));
+    }
+
+    [Fact]
     public async Task RequiresOptIn_OnDirectiveDefinition_SchemaFirst_IsAllowed()
     {
         // arrange & act

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
@@ -22,6 +22,28 @@ public sealed class RequiresOptInDirectiveTests
     }
 
     [Fact]
+    public async Task RequiresOptIn_OnDirectiveDefinition_SchemaFirst_IsAllowed()
+    {
+        // arrange & act
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .ModifyOptions(o => o.EnableOptInFeatures = true)
+                .AddDocumentFromString(
+                    """
+                    type Query { field: Int }
+
+                    directive @example @requiresOptIn(feature: "directiveFeature") on FIELD
+                    """)
+                .UseField(_ => _ => default)
+                .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.True(
+            schema.DirectiveTypes["example"].Directives.ContainsDirective("requiresOptIn"));
+    }
+
+    [Fact]
     public async Task BuildSchemaAsync_CodeFirst_MatchesSnapshot()
     {
         // arrange & act

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
@@ -22,48 +22,6 @@ public sealed class RequiresOptInDirectiveTests
     }
 
     [Fact]
-    public async Task RequiresOptIn_OnDirectiveDefinition_CodeFirst_AppliesDirective()
-    {
-        // arrange & act
-        var schema =
-            await new ServiceCollection()
-                .AddGraphQL()
-                .ModifyOptions(o => o.EnableOptInFeatures = true)
-                .AddDirectiveType(d => d
-                    .Name("example")
-                    .Location(DirectiveLocation.Field)
-                    .RequiresOptIn("directiveFeature"))
-                .AddQueryType(d => d.Field("field").Type<IntType>().Resolve(() => 1))
-                .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        // assert
-        Assert.True(
-            schema.DirectiveTypes["example"].Directives.ContainsDirective("requiresOptIn"));
-    }
-
-    [Fact]
-    public async Task RequiresOptIn_OnDirectiveDefinition_SchemaFirst_IsAllowed()
-    {
-        // arrange & act
-        var schema =
-            await new ServiceCollection()
-                .AddGraphQL()
-                .ModifyOptions(o => o.EnableOptInFeatures = true)
-                .AddDocumentFromString(
-                    """
-                    type Query { field: Int }
-
-                    directive @example @requiresOptIn(feature: "directiveFeature") on FIELD
-                    """)
-                .UseField(_ => _ => default)
-                .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        // assert
-        Assert.True(
-            schema.DirectiveTypes["example"].Directives.ContainsDirective("requiresOptIn"));
-    }
-
-    [Fact]
     public async Task BuildSchemaAsync_CodeFirst_MatchesSnapshot()
     {
         // arrange & act
@@ -95,8 +53,10 @@ public sealed class RequiresOptInDirectiveTests
                     .RequiresOptIn("enumValueFeature1")
                     .RequiresOptIn("enumValueFeature2"))
                 .AddDirectiveType(d => d
-                    .Name("exampleDirective")
+                    .Name("directive")
                     .Location(DirectiveLocation.Field)
+                    .RequiresOptIn("directiveFeature1")
+                    .RequiresOptIn("directiveFeature2")
                     .Argument("argument", a => a
                         .Type<IntType>()
                         .RequiresOptIn("directiveArgFeature1")
@@ -118,6 +78,7 @@ public sealed class RequiresOptInDirectiveTests
                 .AddQueryType<Query>()
                 .AddInputObjectType<Input>()
                 .AddType<Enum>()
+                .AddType<Directive>()
                 .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
@@ -154,29 +115,16 @@ public sealed class RequiresOptInDirectiveTests
                             @requiresOptIn(feature: "enumValueFeature1")
                             @requiresOptIn(feature: "enumValueFeature2")
                     }
+
+                    directive @directive
+                        @requiresOptIn(feature: "directiveFeature1")
+                        @requiresOptIn(feature: "directiveFeature2") on FIELD
                     """)
                 .UseField(_ => _ => default)
                 .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         schema.MatchSnapshot();
-    }
-
-    [Fact]
-    public async Task RequiresOptIn_OnDirectiveDefinition_ImplementationFirst_AppliesDirective()
-    {
-        // arrange & act
-        var schema =
-            await new ServiceCollection()
-                .AddGraphQL()
-                .ModifyOptions(o => o.EnableOptInFeatures = true)
-                .AddType<ExampleDirective>()
-                .AddQueryType(d => d.Field("field").Type<IntType>().Resolve(() => 1))
-                .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        // assert
-        Assert.True(
-            schema.DirectiveTypes["example"].Directives.ContainsDirective("requiresOptIn"));
     }
 
     public sealed class Query
@@ -203,7 +151,8 @@ public sealed class RequiresOptInDirectiveTests
         Value
     }
 
-    [DirectiveType("example", DirectiveLocation.Field)]
-    [RequiresOptIn("directiveFeature")]
-    private sealed class ExampleDirective;
+    [DirectiveType("directive", DirectiveLocation.Field)]
+    [RequiresOptIn("directiveFeature1")]
+    [RequiresOptIn("directiveFeature2")]
+    private sealed class Directive;
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
@@ -162,6 +162,23 @@ public sealed class RequiresOptInDirectiveTests
         schema.MatchSnapshot();
     }
 
+    [Fact]
+    public async Task RequiresOptIn_OnDirectiveDefinition_ImplementationFirst_AppliesDirective()
+    {
+        // arrange & act
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .ModifyOptions(o => o.EnableOptInFeatures = true)
+                .AddType<ExampleDirective>()
+                .AddQueryType(d => d.Field("field").Type<IntType>().Resolve(() => 1))
+                .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.True(
+            schema.DirectiveTypes["example"].Directives.ContainsDirective("requiresOptIn"));
+    }
+
     public sealed class Query
     {
         [RequiresOptIn("objectFieldFeature1")]
@@ -185,4 +202,8 @@ public sealed class RequiresOptInDirectiveTests
         [RequiresOptIn("enumValueFeature2")]
         Value
     }
+
+    [DirectiveType("example", DirectiveLocation.Field)]
+    [RequiresOptIn("directiveFeature")]
+    private sealed class ExampleDirective;
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
@@ -24,7 +24,7 @@ directive @exampleDirective(
   argument: Int @requiresOptIn(feature: "directiveArgFeature1") @requiresOptIn(feature: "directiveArgFeature2")
 ) on FIELD
 
-"Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used."
+"Indicates that the given field, argument, input field, enum value, or directive definition requires giving explicit consent before being used."
 directive @requiresOptIn(
   "The name of the feature that requires opt in."
   feature: String!
@@ -33,3 +33,4 @@ directive @requiresOptIn(
   | ARGUMENT_DEFINITION
   | ENUM_VALUE
   | INPUT_FIELD_DEFINITION
+  | DIRECTIVE_DEFINITION

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
@@ -20,9 +20,11 @@ enum Enum {
     @requiresOptIn(feature: "enumValueFeature2")
 }
 
-directive @exampleDirective(
+directive @directive(
   argument: Int @requiresOptIn(feature: "directiveArgFeature1") @requiresOptIn(feature: "directiveArgFeature2")
-) on FIELD
+)
+  @requiresOptIn(feature: "directiveFeature1")
+  @requiresOptIn(feature: "directiveFeature2") on FIELD
 
 "Indicates that the given field, argument, input field, enum value, or directive definition requires giving explicit consent before being used."
 directive @requiresOptIn(

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_ImplementationFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_ImplementationFirst_MatchesSnapshot.graphql
@@ -20,6 +20,10 @@ enum Enum {
     @requiresOptIn(feature: "enumValueFeature2")
 }
 
+directive @directive
+  @requiresOptIn(feature: "directiveFeature1")
+  @requiresOptIn(feature: "directiveFeature2") on FIELD
+
 "Indicates that the given field, argument, input field, enum value, or directive definition requires giving explicit consent before being used."
 directive @requiresOptIn(
   "The name of the feature that requires opt in."

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_ImplementationFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_ImplementationFirst_MatchesSnapshot.graphql
@@ -20,7 +20,7 @@ enum Enum {
     @requiresOptIn(feature: "enumValueFeature2")
 }
 
-"Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used."
+"Indicates that the given field, argument, input field, enum value, or directive definition requires giving explicit consent before being used."
 directive @requiresOptIn(
   "The name of the feature that requires opt in."
   feature: String!
@@ -29,3 +29,4 @@ directive @requiresOptIn(
   | ARGUMENT_DEFINITION
   | ENUM_VALUE
   | INPUT_FIELD_DEFINITION
+  | DIRECTIVE_DEFINITION

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_SchemaFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_SchemaFirst_MatchesSnapshot.graphql
@@ -20,6 +20,10 @@ enum Enum {
     @requiresOptIn(feature: "enumValueFeature2")
 }
 
+directive @directive
+  @requiresOptIn(feature: "directiveFeature1")
+  @requiresOptIn(feature: "directiveFeature2") on FIELD
+
 "Indicates that the given field, argument, input field, enum value, or directive definition requires giving explicit consent before being used."
 directive @requiresOptIn(
   "The name of the feature that requires opt in."

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_SchemaFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_SchemaFirst_MatchesSnapshot.graphql
@@ -20,7 +20,7 @@ enum Enum {
     @requiresOptIn(feature: "enumValueFeature2")
 }
 
-"Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used."
+"Indicates that the given field, argument, input field, enum value, or directive definition requires giving explicit consent before being used."
 directive @requiresOptIn(
   "The name of the feature that requires opt in."
   feature: String!
@@ -29,3 +29,4 @@ directive @requiresOptIn(
   | ARGUMENT_DEFINITION
   | ENUM_VALUE
   | INPUT_FIELD_DEFINITION
+  | DIRECTIVE_DEFINITION

--- a/website/src/docs/hotchocolate/v16/defining-a-schema/versioning.md
+++ b/website/src/docs/hotchocolate/v16/defining-a-schema/versioning.md
@@ -71,9 +71,9 @@ public class BookQueriesType : ObjectType
 
 # Opt-In Features
 
-While `@deprecated` marks fields that are going away, `@requiresOptIn` marks fields that are not yet stable. This is useful for rolling out experimental features, expensive operations, or anything where consumers should make a deliberate choice to use it.
+While `@deprecated` marks schema elements that are going away, `@requiresOptIn` marks schema elements that are not yet stable. This is useful for rolling out experimental features, expensive operations, or anything where consumers should make a deliberate choice to use it.
 
-Fields marked with `@requiresOptIn` are hidden from introspection by default. Consumers opt in by specifying the feature name.
+Schema elements marked with `@requiresOptIn` are hidden from introspection by default. Consumers opt in by specifying the feature name.
 
 ## Enabling Opt-In Features
 
@@ -85,7 +85,7 @@ builder
     .ModifyOptions(o => o.EnableOptInFeatures = true);
 ```
 
-## Marking Fields as Opt-In
+## Marking Schema Elements as Opt-In
 
 Apply `@requiresOptIn` to output fields, input fields, arguments, enum values, and directive definitions. The directive is repeatable, so a single element can require multiple features.
 

--- a/website/src/docs/hotchocolate/v16/defining-a-schema/versioning.md
+++ b/website/src/docs/hotchocolate/v16/defining-a-schema/versioning.md
@@ -87,7 +87,7 @@ builder
 
 ## Marking Fields as Opt-In
 
-Apply `@requiresOptIn` to output fields, input fields, arguments, and enum values. The directive is repeatable, so a single field can require multiple features.
+Apply `@requiresOptIn` to output fields, input fields, arguments, enum values, and directive definitions. The directive is repeatable, so a single element can require multiple features.
 
 <ExampleTabs>
 <Implementation>
@@ -145,7 +145,7 @@ Consumers discover opt-in fields by passing the `includeOptIn` argument:
 }
 ```
 
-The `includeOptIn` argument is available on `fields`, `args`, `inputFields`, and `enumValues` in introspection queries.
+The `includeOptIn` argument is available on `fields`, `args`, `inputFields`, `enumValues`, and `directives` in introspection queries. A directive definition exposes its own required features via `__Directive.requiresOptIn`, mirroring the `requiresOptIn` field on other introspection types.
 
 To discover all opt-in features in the schema:
 


### PR DESCRIPTION
## Summary

- Extends the opt-in-features system so a **directive definition** can itself require opt-in via `@requiresOptIn`, implementing graphql/graphql-wg#2005 (which adds `DIRECTIVE_DEFINITION` as a valid `@requiresOptIn` location). All behavior is gated behind `EnableOptInFeatures`. Follow-up to #9966, which added directive-argument opt-in.
- Authoring is supported across all three styles: code-first (`IDirectiveTypeDescriptor.RequiresOptIn(...)`), implementation-first (`[RequiresOptIn]` on a directive type), and schema-first (`@requiresOptIn` on a directive definition in SDL).
- Introspection adds the `__Directive.requiresOptIn` field and `includeOptIn` filtering on `__Schema.directives`, so an opt-in directive is hidden unless one of its features is opted into. Directive-definition features are aggregated into `__Schema.optInFeatures` alongside the existing element kinds.
- Documentation for opt-in versioning is updated to cover directive definitions.

## Test plan

- `dotnet test` for `Types.Tests` and `Execution.Tests` (net10.0), covering the new `Execute_IntrospectionOnDirectives*` family, the `__Directive.requiresOptIn` and `directives(includeOptIn:)` behavior, and the code-first, implementation-first, and schema-first authoring snapshots.
