### PR TITLE
Optimize shared opt-in introspection resolvers

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Introspection/OptInIntrospectionHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/OptInIntrospectionHelper.cs
@@ -1,0 +1,36 @@
+namespace HotChocolate.Types.Introspection;
+
+internal static class OptInIntrospectionHelper
+{
+    /// <summary>
+    /// Determines whether a type system member is included for the given set of opted-in features.
+    /// A member without any <c>@requiresOptIn</c> directives is always included. A member that
+    /// requires one or more features is only included when <paramref name="includeOptIn"/> lists at
+    /// least one of those features.
+    /// </summary>
+    /// <param name="directives">
+    /// The directives of the type system member.
+    /// </param>
+    /// <param name="includeOptIn">
+    /// The features the client opted into.
+    /// </param>
+    public static bool IsIncluded(IReadOnlyDirectiveCollection directives, string[] includeOptIn)
+    {
+        var requiresOptIn = false;
+
+        foreach (var directive in directives)
+        {
+            if (directive.Definition is RequiresOptInDirectiveType)
+            {
+                requiresOptIn = true;
+
+                if (includeOptIn.Contains(directive.ToValue<RequiresOptIn>().Feature))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return !requiresOptIn;
+    }
+}

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
@@ -116,25 +116,12 @@ internal sealed class __Directive : ObjectType<DirectiveType>
             return DirectiveLocationUtils.AsEnumerable(locations);
         }
 
-        public static object ArgumentsWithOptIn(IResolverContext context)
+        public static IEnumerable<IInputValueDefinition> ArgumentsWithOptIn(IResolverContext context)
         {
             var includeOptIn = context.ArgumentValue<string[]?>(Names.IncludeOptIn) ?? [];
 
-            // If an argument has no @requiresOptIn directives, it is always included.
-            // If an argument requires opting into features "f1" and "f2", then `includeOptIn`
-            // must list at least one of the features in order for the argument to be included.
             return Arguments(context).Where(
-                a =>
-                {
-                    var requiredFeatures = a
-                        .Directives
-                        .Where(d => d.Definition is RequiresOptInDirectiveType)
-                        .Select(d => d.ToValue<RequiresOptIn>().Feature)
-                        .ToList();
-
-                    return requiredFeatures.Count == 0
-                        || requiredFeatures.Any(feature => includeOptIn.Contains(feature));
-                });
+                a => OptInIntrospectionHelper.IsIncluded(a.Directives, includeOptIn));
         }
 
         public static IEnumerable<IInputValueDefinition> Arguments(IResolverContext context)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Field.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Field.cs
@@ -89,25 +89,12 @@ internal sealed class __Field : ObjectType<IOutputFieldDefinition>
         public static string? Description(IResolverContext context)
             => context.Parent<IOutputFieldDefinition>().Description;
 
-        public static object ArgumentsWithOptIn(IResolverContext context)
+        public static IEnumerable<IInputValueDefinition> ArgumentsWithOptIn(IResolverContext context)
         {
             var includeOptIn = context.ArgumentValue<string[]?>(Names.IncludeOptIn) ?? [];
 
-            // If an argument has no @requiresOptIn directives, it is always included.
-            // If an argument requires opting into features "f1" and "f2", then `includeOptIn`
-            // must list at least one of the features in order for the argument to be included.
             return Arguments(context).Where(
-                a =>
-                {
-                    var requiredFeatures = a
-                        .Directives
-                        .Where(d => d.Definition is RequiresOptInDirectiveType)
-                        .Select(d => d.ToValue<RequiresOptIn>().Feature)
-                        .ToList();
-
-                    return requiredFeatures.Count == 0
-                        || requiredFeatures.Any(feature => includeOptIn.Contains(feature));
-                });
+                a => OptInIntrospectionHelper.IsIncluded(a.Directives, includeOptIn));
         }
 
         public static IEnumerable<IInputValueDefinition> Arguments(IResolverContext context)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Schema.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Schema.cs
@@ -122,25 +122,12 @@ internal sealed class __Schema : ObjectType
                 : directiveDefinitions.Where(t => !t.IsDeprecated);
         }
 
-        public static object DirectivesWithOptIn(IResolverContext context)
+        public static IEnumerable<IDirectiveDefinition> DirectivesWithOptIn(IResolverContext context)
         {
             var includeOptIn = context.ArgumentValue<string[]?>(Names.IncludeOptIn) ?? [];
 
-            // If a directive has no @requiresOptIn directives, it is always included.
-            // If a directive requires opting into features "f1" and "f2", then `includeOptIn`
-            // must list at least one of the features in order for the directive to be included.
             return Directives(context).Where(
-                t =>
-                {
-                    var requiredFeatures = ((IDirectivesProvider)t)
-                        .Directives
-                        .Where(d => d.Definition is RequiresOptInDirectiveType)
-                        .Select(d => d.ToValue<RequiresOptIn>().Feature)
-                        .ToList();
-
-                    return requiredFeatures.Count == 0
-                        || requiredFeatures.Any(feature => includeOptIn.Contains(feature));
-                });
+                t => OptInIntrospectionHelper.IsIncluded(t.Directives, includeOptIn));
         }
 
         public static object AppliedDirectives(IResolverContext context)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Type.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Type.cs
@@ -134,7 +134,7 @@ internal sealed class __Type : ObjectType
         public static object? Description(IResolverContext context)
             => context.Parent<IType>() is ITypeDefinition n ? n.Description : null;
 
-        public static object? FieldsWithOptIn(IResolverContext context)
+        public static IEnumerable<IOutputFieldDefinition>? FieldsWithOptIn(IResolverContext context)
         {
             var type = context.Parent<IType>();
 
@@ -149,21 +149,8 @@ internal sealed class __Type : ObjectType
 
                 var includeOptIn = context.ArgumentValue<string[]?>(Names.IncludeOptIn) ?? [];
 
-                // If a field has no @requiresOptIn directives, it is always included.
-                // If a field requires opting into features "f1" and "f2", then `includeOptIn`
-                // must list at least one of the features in order for the field to be included.
                 return fields.Where(
-                    f =>
-                    {
-                        var requiredFeatures = f
-                            .Directives
-                            .Where(d => d.Definition is RequiresOptInDirectiveType)
-                            .Select(d => d.ToValue<RequiresOptIn>().Feature)
-                            .ToList();
-
-                        return requiredFeatures.Count == 0
-                            || requiredFeatures.Any(feature => includeOptIn.Contains(feature));
-                    });
+                    f => OptInIntrospectionHelper.IsIncluded(f.Directives, includeOptIn));
             }
 
             return default;
@@ -196,7 +183,7 @@ internal sealed class __Type : ObjectType
                     : null
                 : null;
 
-        public static object? EnumValuesWithOptIn(IResolverContext context)
+        public static IEnumerable<IEnumValue>? EnumValuesWithOptIn(IResolverContext context)
         {
             var type = context.Parent<IType>();
 
@@ -211,21 +198,8 @@ internal sealed class __Type : ObjectType
 
                 var includeOptIn = context.ArgumentValue<string[]?>(Names.IncludeOptIn) ?? [];
 
-                // If an enum value has no @requiresOptIn directives, it is always included.
-                // If an enum value requires opting into features "f1" and "f2", then `includeOptIn`
-                // must list at least one of the features in order for the value to be included.
                 return enumValues.Where(
-                    v =>
-                    {
-                        var requiredFeatures = v
-                            .Directives
-                            .Where(d => d.Definition is RequiresOptInDirectiveType)
-                            .Select(d => d.ToValue<RequiresOptIn>().Feature)
-                            .ToList();
-
-                        return requiredFeatures.Count == 0
-                            || requiredFeatures.Any(feature => includeOptIn.Contains(feature));
-                    });
+                    v => OptInIntrospectionHelper.IsIncluded(v.Directives, includeOptIn));
             }
 
             return default;
@@ -238,7 +212,7 @@ internal sealed class __Type : ObjectType
                     : et.Values.Where(t => !t.IsDeprecated)
                 : null;
 
-        public static object? InputFieldsWithOptIn(IResolverContext context)
+        public static IEnumerable<IInputValueDefinition>? InputFieldsWithOptIn(IResolverContext context)
         {
             var type = context.Parent<IType>();
 
@@ -253,22 +227,8 @@ internal sealed class __Type : ObjectType
 
                 var includeOptIn = context.ArgumentValue<string[]?>(Names.IncludeOptIn) ?? [];
 
-                // If an input field has no @requiresOptIn directives, it is always included.
-                // If an input field requires opting into features "f1" and "f2", then
-                // `includeOptIn` must list at least one of the features in order for the field to
-                // be included.
                 return inputFields.Where(
-                    f =>
-                    {
-                        var requiredFeatures = f
-                            .Directives
-                            .Where(d => d.Definition is RequiresOptInDirectiveType)
-                            .Select(d => d.ToValue<RequiresOptIn>().Feature)
-                            .ToList();
-
-                        return requiredFeatures.Count == 0
-                            || requiredFeatures.Any(feature => includeOptIn.Contains(feature));
-                    });
+                    f => OptInIntrospectionHelper.IsIncluded(f.Directives, includeOptIn));
             }
 
             return default;


### PR DESCRIPTION
## Summary

- The six `*WithOptIn` introspection resolvers (`__Type` fields/enumValues/inputFields, `__Field` args, `__Directive` args, and `__Schema` directives) each duplicated a per-element predicate that allocated a `List<string>` for every element just to test "no required features, or at least one is opted into". Extracted that predicate into a single `OptInIntrospectionHelper.IsIncluded`, which scans a member's directives once with an early return and no per-element allocation.
- Tightened each resolver's return type from `object`/`object?` to the `IEnumerable<...>` its non-opt-in sibling already returns.

## Test plan

- Existing `OptInFeaturesIntrospectionTests` snapshots, which cover all six resolvers across the feature-included, feature-absent, and no-included-features cases, pass: 76/76 across net8.0–net11.0.
