### PR TITLE
Fix flaky error-result timeout test

### DIFF
--- a/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorTests.cs
@@ -94,11 +94,9 @@ public class RequestExecutorTests
         Assert.True(tokenWasCorrectlyPassedToResolver);
     }
 
-    [Fact]
+    [Fact(Timeout = 30_000)]
     public async Task Ensure_Errors_Do_Not_Result_In_Timeouts()
     {
-        using var cts = new CancellationTokenSource(1000);
-
         await new ServiceCollection()
             .AddGraphQL()
             .AddQueryType(d => d.Name("abc").Field("a").Resolve("a"))
@@ -116,7 +114,7 @@ public class RequestExecutorTests
                             __typename
                         }
                     }",
-                cancellationToken: cts.Token)
+                cancellationToken: TestContext.Current.CancellationToken)
             .MatchSnapshotAsync();
     }
 


### PR DESCRIPTION
## Summary

- `RequestExecutorTests.Ensure_Errors_Do_Not_Result_In_Timeouts` bounded its execution with `new CancellationTokenSource(1000)`, a wall-clock deadline. On a slow or contended CI runner the 1s timer could fire mid-execution and fold a cancellation error into the result, flipping the snapshot from `"Unexpected Execution Error"` to `"The GraphQL request execution was canceled."` and failing the test even though nothing hung.
- Replaced the racy in-test deadline with a framework-level `[Fact(Timeout = 30_000)]` guard and passed `TestContext.Current.CancellationToken`, so the test still fails fast on a genuine hang without racing normal-load execution time.

## Test plan

- `dotnet test` on `HotChocolate.Execution.Tests`, filtered to `Ensure_Errors_Do_Not_Result_In_Timeouts` — passes.
