### PR TITLE
Exclude test and benchmark files from patch coverage

### DIFF
--- a/.github/scripts/patch-coverage.cs
+++ b/.github/scripts/patch-coverage.cs
@@ -50,7 +50,7 @@ var changed = ParseDiff(File.ReadAllLines(diffPath));
 var coverage = ParseCobertura(coberturaPath);
 
 // Whole-project line coverage (production files only; test/benchmark sources are excluded).
-var prodFiles = coverage.Where(f => !IsTestPath(f.Key)).ToList();
+var prodFiles = coverage.Where(f => IsProductionPath(f.Key)).ToList();
 var projValid = prodFiles.Sum(f => f.Value.Count);
 var projCovered = prodFiles.Sum(f => f.Value.Values.Count(h => h > 0));
 var projPct = projValid == 0 ? 100.0 : 100.0 * projCovered / projValid;
@@ -59,7 +59,7 @@ var projPct = projValid == 0 ? 100.0 : 100.0 * projCovered / projValid;
 var rows = new List<FileRow>();
 foreach (var (path, lines) in changed.OrderBy(x => x.Key, StringComparer.Ordinal))
 {
-    if (IsTestPath(path))
+    if (!IsProductionPath(path))
     {
         continue; // patch coverage measures production code, not test/benchmark sources
     }
@@ -355,13 +355,14 @@ static string BuildJson(string sha, List<FileRow> withMisses)
     return b.ToString();
 }
 
-static bool IsTestPath(string path)
+static bool IsProductionPath(string path)
 {
+    // Exclude test and benchmark sources; everything else counts as production.
     var p = "/" + path.Replace('\\', '/') + "/";
-    return p.Contains("/test/", StringComparison.OrdinalIgnoreCase)
+    return !(p.Contains("/test/", StringComparison.OrdinalIgnoreCase)
         || p.Contains("/tests/", StringComparison.OrdinalIgnoreCase)
         || p.Contains("/benchmark/", StringComparison.OrdinalIgnoreCase)
-        || p.Contains("/benchmarks/", StringComparison.OrdinalIgnoreCase);
+        || p.Contains("/benchmarks/", StringComparison.OrdinalIgnoreCase));
 }
 
 static string Sha256Hex(string value)

--- a/.github/scripts/patch-coverage.cs
+++ b/.github/scripts/patch-coverage.cs
@@ -58,6 +58,11 @@ var projPct = projValid == 0 ? 100.0 : 100.0 * projCovered / projValid;
 var rows = new List<FileRow>();
 foreach (var (path, lines) in changed.OrderBy(x => x.Key, StringComparer.Ordinal))
 {
+    if (IsTestPath(path))
+    {
+        continue; // patch coverage measures production code, not test/benchmark sources
+    }
+
     var hits = Match(coverage, path);
     if (hits is null)
     {
@@ -347,6 +352,15 @@ static string BuildJson(string sha, List<FileRow> withMisses)
     b.AppendLine("  ]");
     b.Append('}');
     return b.ToString();
+}
+
+static bool IsTestPath(string path)
+{
+    var p = "/" + path.Replace('\\', '/') + "/";
+    return p.Contains("/test/", StringComparison.OrdinalIgnoreCase)
+        || p.Contains("/tests/", StringComparison.OrdinalIgnoreCase)
+        || p.Contains("/benchmark/", StringComparison.OrdinalIgnoreCase)
+        || p.Contains("/benchmarks/", StringComparison.OrdinalIgnoreCase);
 }
 
 static string Sha256Hex(string value)

--- a/.github/scripts/patch-coverage.cs
+++ b/.github/scripts/patch-coverage.cs
@@ -49,9 +49,10 @@ var changed = ParseDiff(File.ReadAllLines(diffPath));
 // 2. Parse cobertura: absolute path -> (line -> hits). Merge partial-class duplicates by max hits.
 var coverage = ParseCobertura(coberturaPath);
 
-// Whole-project line coverage (every instrumented file in the report).
-var projValid = coverage.Sum(f => f.Value.Count);
-var projCovered = coverage.Sum(f => f.Value.Values.Count(h => h > 0));
+// Whole-project line coverage (production files only; test/benchmark sources are excluded).
+var prodFiles = coverage.Where(f => !IsTestPath(f.Key)).ToList();
+var projValid = prodFiles.Sum(f => f.Value.Count);
+var projCovered = prodFiles.Sum(f => f.Value.Values.Count(h => h > 0));
 var projPct = projValid == 0 ? 100.0 : 100.0 * projCovered / projValid;
 
 // 3. Intersect per file. A changed line counts only if it appears in coverage (executable).


### PR DESCRIPTION
## Summary

- Patch coverage now excludes test and benchmark sources (any path with a `/test/`, `/tests/`, `/benchmark/`, or `/benchmarks/` segment), so both the patch percentage and the project coverage total reflect production code only.
- Test projects instrument their own code, so changed test files were being counted (often at 0%), skewing the patch percentage, and test assemblies inflated the project-total denominator. Both are now dropped from the table, the JSON, the headline patch %, and the project coverage line, via a single `IsProductionPath` helper.

## Test plan

- Verified a changed, instrumented test file is excluded from the report output.
- Confirmed on a real PR: production paths remain; the patch headline is unaffected where test files were already non-instrumented; the project total rises once test assemblies leave the denominator (49.3% → 52.3%).
