### PR TITLE
Stabilize flaky NestedDataLoader test

### DIFF
--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/DataLoader/DataLoaderTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/DataLoader/DataLoaderTests.cs
@@ -376,7 +376,6 @@ public class DataLoaderTests
     public async Task NestedDataLoader()
     {
         var snapshot = new Snapshot();
-        using var cts = new CancellationTokenSource(2000);
 
         snapshot.Add(
             await new ServiceCollection()
@@ -385,9 +384,11 @@ public class DataLoaderTests
                 .AddType<FooQueries>()
                 .AddDataLoader<FooDataLoader>()
                 .AddDataLoader<FooNestedDataLoader>()
-                .ExecuteRequestAsync("query Foo { foo { id field } }", cancellationToken: cts.Token));
+                .ExecuteRequestAsync(
+                    "query Foo { foo { id field } }",
+                    cancellationToken: TestContext.Current.CancellationToken));
 
-        await snapshot.MatchMarkdownAsync(cts.Token);
+        await snapshot.MatchMarkdownAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- `NestedDataLoader` wrapped its work in a hard `CancellationTokenSource(2000)`, so the 2-second budget had to cover the schema build, execution, and snapshot match. Under CI contention that work crossed 2s, the request was canceled, and the test failed intermittently with `TaskCanceledException`.
- Replaced the fixed deadline with `TestContext.Current.CancellationToken`, matching the sibling tests in the same file, so the test cancels only on the real test-host token.

## Test plan
- Reproduced the original `TaskCanceledException` by running the full assembly under CPU contention.
- After the change, ran the test 12× under 2× CPU saturation — all pass.
