### PR TITLE
Stop cancelling in-progress main coverage runs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,8 +9,7 @@ on:
       - "src/**"
 
 concurrency:
-  group: main-coverage
-  cancel-in-progress: true
+  group: main-coverage-${{ github.ref }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- The Main Branch Coverage workflow used `concurrency.cancel-in-progress: true`, which killed an already-running coverage run whenever a newer commit landed on `main`, surfacing the cancelled run as a red status in the commit list.
- Drop `cancel-in-progress` (defaults to `false`), switching to queue mode: a running coverage job now finishes, and only superseded *pending* runs are cancelled. Serialization is preserved, so the latest commit's run still finishes last.
- Key the concurrency group per ref (`main-coverage-${{ github.ref }}`) so `main` and `main-version-*` branches serialize independently rather than cancelling each other.

## Test plan

- Confirmed the workflow YAML parses and the `concurrency` block is well-formed.
- Verified against GitHub concurrency semantics: with `cancel-in-progress` unset, in-progress runs are never auto-cancelled and at most one pending run is retained per group, giving latest-wins ordering without killing active runs.
