### PR TITLE
Fix patch coverage diff base for branches behind main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,9 +368,11 @@ jobs:
           "./output/download/**/*.cobertura.xml"
 
       - name: Compute changed lines
+        # HEAD is the PR merge commit; diff its base parent (^1) against its head parent (^2)
+        # so the result matches GitHub's "Files changed" even when the branch is behind main.
         run: >
           git diff --unified=0 --diff-filter=d
-          "${{ github.event.pull_request.base.sha }}...HEAD"
+          "HEAD^1...HEAD^2"
           -- '*.cs' > ./output/pr.diff
 
       - name: Generate patch coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,8 +368,8 @@ jobs:
           "./output/download/**/*.cobertura.xml"
 
       - name: Compute changed lines
-        # HEAD is the PR merge commit; diff its base parent (^1) against its head parent (^2)
-        # so the result matches GitHub's "Files changed" even when the branch is behind main.
+        # HEAD is the PR merge commit. The three-dot "^1...^2" diffs merge-base(base, head)..head,
+        # i.e. only the PR's own changes, matching GitHub's "Files changed" even when behind main.
         run: >
           git diff --unified=0 --diff-filter=d
           "HEAD^1...HEAD^2"


### PR DESCRIPTION
## Summary

- The patch-coverage job computed changed lines as `git diff <pull_request.base.sha>...HEAD`. That base SHA is captured when the webhook fires and goes stale once `main` advances, so for a PR that's behind `main` the diff swept in every commit merged to `main` in between, massively inflating the reported file list.
- It now diffs the merge commit's own parents (`HEAD^1...HEAD^2`), which yields the PR's true changes against the real fork point and matches GitHub's "Files changed" regardless of `main` drift.

## Test plan

- On a real PR that was behind `main`, the old base produced 202 changed `.cs` files; `HEAD^1...HEAD^2` produces 13, matching GitHub's Files-changed count.
