### PR TITLE
Enable IDE0370 and remove unnecessary suppression operators

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -275,6 +275,8 @@ dotnet_diagnostic.IDE0305.severity = silent # see https://github.com/dotnet/rosl
 # Use collection expression for new.
 dotnet_diagnostic.IDE0306.severity = warning
 dotnet_style_prefer_collection_expression = when_types_exactly_match
+# Remove unnecessary suppression.
+dotnet_diagnostic.IDE0370.severity = warning
 # Place new line after/before binary operator.
 dotnet_diagnostic.RCS0027.severity = warning
 roslynator_binary_operator_new_line = before

--- a/src/GreenDonut/src/GreenDonut/BatchDataLoader.cs
+++ b/src/GreenDonut/src/GreenDonut/BatchDataLoader.cs
@@ -53,7 +53,7 @@ public abstract class BatchDataLoader<TKey, TValue>
         {
             if (resultMap.TryGetValue(keys[i], out var value))
             {
-                results[i] = value!;
+                results[i] = value;
             }
             else
             {

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/Endpoints/HttpEndpointIntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/Endpoints/HttpEndpointIntegrationTestBase.cs
@@ -624,7 +624,7 @@ public abstract class HttpEndpointIntegrationTestBase : OpenApiTestBase
             return response2.StatusCode == HttpStatusCode.OK;
         }, cts.Token);
 
-        response2!.MatchSnapshot();
+        response2.MatchSnapshot();
     }
 
     [Fact]
@@ -669,7 +669,7 @@ public abstract class HttpEndpointIntegrationTestBase : OpenApiTestBase
             return content != content1;
         }, cts.Token);
 
-        response2!.MatchSnapshot();
+        response2.MatchSnapshot();
     }
 
     [Fact]
@@ -718,7 +718,7 @@ public abstract class HttpEndpointIntegrationTestBase : OpenApiTestBase
 
         Assert.Equal(HttpStatusCode.NotFound, oldRouteResponse2.StatusCode);
 
-        newRouteResponse!.MatchSnapshot();
+        newRouteResponse.MatchSnapshot();
     }
 
     [Fact]

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/OpenApiIntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/OpenApiIntegrationTestBase.cs
@@ -567,7 +567,7 @@ public abstract class OpenApiIntegrationTestBase : OpenApiTestBase
             return openApiDocument2 != openApiDocument1;
         }, cts.Token);
 
-        openApiDocument2!.MatchSnapshot(postFix: TestEnvironment.TargetFramework, extension: ".json");
+        openApiDocument2.MatchSnapshot(postFix: TestEnvironment.TargetFramework, extension: ".json");
     }
 
     [Fact]
@@ -610,7 +610,7 @@ public abstract class OpenApiIntegrationTestBase : OpenApiTestBase
             return openApiDocument2 != openApiDocument1;
         }, cts.Token);
 
-        openApiDocument2!.MatchSnapshot(postFix: TestEnvironment.TargetFramework, extension: ".json");
+        openApiDocument2.MatchSnapshot(postFix: TestEnvironment.TargetFramework, extension: ".json");
     }
 
     [Fact]
@@ -653,7 +653,7 @@ public abstract class OpenApiIntegrationTestBase : OpenApiTestBase
             return openApiDocument2 != openApiDocument1;
         }, cts.Token);
 
-        openApiDocument2!.MatchSnapshot(postFix: TestEnvironment.TargetFramework, extension: ".json");
+        openApiDocument2.MatchSnapshot(postFix: TestEnvironment.TargetFramework, extension: ".json");
     }
 
     [Fact(Skip = "Need to determine what best behavior should be")]
@@ -722,7 +722,7 @@ public abstract class OpenApiIntegrationTestBase : OpenApiTestBase
             return openApiDocument2 != openApiDocument1;
         }, cts.Token);
 
-        openApiDocument2!.MatchSnapshot(postFix: TestEnvironment.TargetFramework, extension: ".json");
+        openApiDocument2.MatchSnapshot(postFix: TestEnvironment.TargetFramework, extension: ".json");
     }
 
     [Fact]

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/ExternalDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/ExternalDirectiveTests.cs
@@ -31,11 +31,11 @@ public class ExternalDirectiveTests : FederationTypesTestBase
                         .Resolve(_ => 1);
                     o.Field("idCode")
                         .Type<StringType>()
-                        .Resolve(_ => default!)
+                        .Resolve(_ => default)
                         .External();
                     o.Field("address")
                         .Type("Address")
-                        .Resolve(_ => default!)
+                        .Resolve(_ => default)
                         .External();
                 })
             .AddObjectType(
@@ -45,10 +45,10 @@ public class ExternalDirectiveTests : FederationTypesTestBase
                     o.External();
                     o.Field("street")
                         .Type<StringType>()
-                        .Resolve(_ => default!);
+                        .Resolve(_ => default);
                     o.Field("city")
                         .Type<StringType>()
-                        .Resolve(_ => default!);
+                        .Resolve(_ => default);
                 })
             .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/Legacy/ExternalDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/Legacy/ExternalDirectiveTests.cs
@@ -31,7 +31,7 @@ public class ExternalDirectiveTests : FederationTypesTestBase
                         .Resolve(_ => 1);
                     o.Field("idCode")
                         .Type<StringType>()
-                        .Resolve(_ => default!)
+                        .Resolve(_ => default)
                         .External();
                 })
             .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/Legacy/ProvidesDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/Legacy/ProvidesDirectiveTests.cs
@@ -19,18 +19,18 @@ public class ProvidesDirectiveTests : FederationTypesTestBase
                     o.Name("Product");
                     o.Field("name")
                         .Type<StringType>()
-                        .Resolve(_ => default!);
+                        .Resolve(_ => default);
                 })
             .AddObjectType(o =>
             {
                 o.Name("Review").Key("id");
                 o.Field("id")
                     .Type<IntType>()
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
                 o.Field("product")
                     .Provides("name")
                     .Type("Product")
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
             })
             .AddQueryType(o =>
                 {
@@ -38,7 +38,7 @@ public class ProvidesDirectiveTests : FederationTypesTestBase
                     o.Field("someField")
                         .Argument("a", a => a.Type<IntType>())
                         .Type("Review")
-                        .Resolve(_ => default!);
+                        .Resolve(_ => default);
                 })
             .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/Legacy/RequiresDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/Legacy/RequiresDirectiveTests.cs
@@ -19,18 +19,18 @@ public class RequiresDirectiveTests : FederationTypesTestBase
                 o.Name("Product");
                 o.Field("name")
                     .Type<StringType>()
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
             })
             .AddObjectType(o =>
             {
                 o.Name("Review").Key("id");
                 o.Field("id")
                     .Type<IntType>()
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
                 o.Field("product")
                     .Requires("id")
                     .Type("Product")
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
             })
             .AddQueryType(o =>
             {
@@ -38,7 +38,7 @@ public class RequiresDirectiveTests : FederationTypesTestBase
                 o.Field("someField")
                     .Argument("a", a => a.Type<IntType>())
                     .Type("Review")
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
             })
             .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/PolicyDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/PolicyDirectiveTests.cs
@@ -74,7 +74,7 @@ public class PolicyDirectiveTests : FederationTypesTestBase
         }
 
         Assert.Fail("No policy directive found.");
-        return null!;
+        return null;
     }
 
     private static void CheckQueryType(Schema schema)

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/ProvidesDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/ProvidesDirectiveTests.cs
@@ -19,18 +19,18 @@ public class ProvidesDirectiveTests : FederationTypesTestBase
                     o.Name("Product");
                     o.Field("name")
                         .Type<StringType>()
-                        .Resolve(_ => default!);
+                        .Resolve(_ => default);
                 })
             .AddObjectType(o =>
             {
                 o.Name("Review").Key("id");
                 o.Field("id")
                     .Type<IntType>()
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
                 o.Field("product")
                     .Provides("name")
                     .Type("Product")
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
             })
             .AddQueryType(o =>
                 {
@@ -38,7 +38,7 @@ public class ProvidesDirectiveTests : FederationTypesTestBase
                     o.Field("someField")
                         .Argument("a", a => a.Type<IntType>())
                         .Type("Review")
-                        .Resolve(_ => default!);
+                        .Resolve(_ => default);
                 })
             .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/RequiresDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/RequiresDirectiveTests.cs
@@ -19,18 +19,18 @@ public class RequiresDirectiveTests : FederationTypesTestBase
                 o.Name("Product");
                 o.Field("name")
                     .Type<StringType>()
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
             })
             .AddObjectType(o =>
             {
                 o.Name("Review").Key("id");
                 o.Field("id")
                     .Type<IntType>()
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
                 o.Field("product")
                     .Requires("id")
                     .Type("Product")
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
             })
             .AddQueryType(o =>
             {
@@ -38,7 +38,7 @@ public class RequiresDirectiveTests : FederationTypesTestBase
                 o.Field("someField")
                     .Argument("a", a => a.Type<IntType>())
                     .Type("Review")
-                    .Resolve(_ => default!);
+                    .Resolve(_ => default);
             })
             .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/RequiresScopesDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/RequiresScopesDirectiveTests.cs
@@ -74,7 +74,7 @@ public class RequiresScopesDirectiveTests : FederationTypesTestBase
         }
 
         Assert.Fail("No requires scopes directive found.");
-        return null!;
+        return null;
     }
 
     private static void CheckQueryType(Schema schema)

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Support/ParsingHelper.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Support/ParsingHelper.cs
@@ -9,13 +9,13 @@ internal static class ParsingHelper
         if (node is not ListValueNode list)
         {
             Assert.Fail("Expected ListValueNode result.");
-            return null!;
+            return null;
         }
 
         if (list.Items is not [ListValueNode innerList])
         {
             Assert.Fail("Expected inner ListValueNode result.");
-            return null!;
+            return null;
         }
 
         return innerList.Items
@@ -29,13 +29,13 @@ internal static class ParsingHelper
         if (node is not ListValueNode list)
         {
             Assert.Fail("Expected ListValueNode result.");
-            return null!;
+            return null;
         }
 
         if (list.Items is not [ListValueNode innerList])
         {
             Assert.Fail("Expected inner ListValueNode result.");
-            return null!;
+            return null;
         }
 
         return innerList.Items

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Utilities/MiddlewareHelper.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Utilities/MiddlewareHelper.cs
@@ -19,7 +19,7 @@ internal static class MiddlewareHelper
         // with a 400 Bad Request.
         if (headerResult.HasError)
         {
-            var errors = headerResult.ErrorResult.Errors!;
+            var errors = headerResult.ErrorResult.Errors;
             executorSession.DiagnosticEvents.HttpRequestError(context, errors[0]);
 
             return new ValidateAcceptContentTypeResult(

--- a/src/HotChocolate/AspNetCore/src/Transport.Http/DefaultGraphQLHttpClient.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Http/DefaultGraphQLHttpClient.cs
@@ -440,21 +440,21 @@ public sealed class DefaultGraphQLHttpClient : GraphQLHttpClient
         {
             AppendAmpersand(sb, ref appendAmpersand);
             sb.Append("id=");
-            sb.Append(Uri.EscapeDataString(or.Id!));
+            sb.Append(Uri.EscapeDataString(or.Id));
         }
 
         if (!string.IsNullOrWhiteSpace(or.Query))
         {
             AppendAmpersand(sb, ref appendAmpersand);
             sb.Append("query=");
-            sb.Append(Uri.EscapeDataString(or.Query!));
+            sb.Append(Uri.EscapeDataString(or.Query));
         }
 
         if (!string.IsNullOrWhiteSpace(or.OperationName))
         {
             AppendAmpersand(sb, ref appendAmpersand);
             sb.Append("operationName=");
-            sb.Append(Uri.EscapeDataString(or.OperationName!));
+            sb.Append(Uri.EscapeDataString(or.OperationName));
         }
 
         if (or.OnError is { } errorHandlingMode)

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/UploadQuery.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/UploadQuery.cs
@@ -90,7 +90,7 @@ public class UploadQuery
 public class InputWithOptionalFile
 {
     [GraphQLType(typeof(UploadType))]
-    public Optional<IFile> File { get; set; } = default!;
+    public Optional<IFile> File { get; set; }
 }
 
 public class InputWithFile

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Serialization/VariablePathTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Serialization/VariablePathTests.cs
@@ -59,7 +59,7 @@ public class VariablePathTests
         // assert
         Assert.Equal("foo", path.Key.Value);
         Assert.Equal("bar", Assert.IsType<KeyPathSegment>(path.Key.Next).Value);
-        Assert.Equal(1, Assert.IsType<IndexPathSegment>(path.Key.Next!.Next).Value);
-        Assert.Equal("baz", Assert.IsType<KeyPathSegment>(path.Key.Next!.Next!.Next).Value);
+        Assert.Equal(1, Assert.IsType<IndexPathSegment>(path.Key.Next.Next).Value);
+        Assert.Equal("baz", Assert.IsType<KeyPathSegment>(path.Key.Next.Next.Next).Value);
     }
 }

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/Apollo/WebSocketProtocolTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/Apollo/WebSocketProtocolTests.cs
@@ -53,7 +53,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue);
-            Assert.Equal(WebSocketCloseStatus.ProtocolError, webSocket.CloseStatus!.Value);
+            Assert.Equal(WebSocketCloseStatus.ProtocolError, webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -77,7 +77,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-            Assert.Equal(WebSocketCloseStatus.ProtocolError, webSocket.CloseStatus!.Value);
+            Assert.Equal(WebSocketCloseStatus.ProtocolError, webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -122,7 +122,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             await WaitForMessage(webSocket, "connection_error", ct);
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-            Assert.Equal(WebSocketCloseStatus.NormalClosure, webSocket.CloseStatus!.Value);
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -181,7 +181,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             var buffer = new byte[1024];
             await webSocket.ReceiveAsync(buffer, ct);
             Assert.True(webSocket.CloseStatus.HasValue);
-            Assert.Equal(WebSocketCloseStatus.NormalClosure, webSocket.CloseStatus!.Value);
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -201,7 +201,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
 
             // assert
             Assert.True(socket.CloseStatus.HasValue);
-            Assert.Equal(WebSocketCloseStatus.ProtocolError, socket.CloseStatus!.Value);
+            Assert.Equal(WebSocketCloseStatus.ProtocolError, socket.CloseStatus.Value);
         });
 
     // TODO : FIX Flaky Test
@@ -270,7 +270,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue);
-            Assert.Equal(WebSocketCloseStatus.InternalServerError, webSocket.CloseStatus!.Value);
+            Assert.Equal(WebSocketCloseStatus.InternalServerError, webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -289,7 +289,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue);
-            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus!.Value);
+            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -308,7 +308,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue);
-            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus!.Value);
+            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -374,7 +374,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue);
-                Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -483,7 +483,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-            Assert.Equal(WebSocketCloseStatus.InternalServerError, webSocket.CloseStatus!.Value);
+            Assert.Equal(WebSocketCloseStatus.InternalServerError, webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -501,7 +501,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus!.Value);
+            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -519,7 +519,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus!.Value);
+            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus.Value);
         });
 
     [Fact]
@@ -537,7 +537,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             // assert
             await webSocket.ReceiveServerMessageAsync(ct);
             Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus!.Value);
+            Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus.Value);
         });
 
     // TODO : FIX Flaky Test

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/GraphQLOverWebSocket/WebSocketProtocolTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/GraphQLOverWebSocket/WebSocketProtocolTests.cs
@@ -62,7 +62,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue);
-                Assert.Equal(CloseReasons.TooManyInitAttempts, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.TooManyInitAttempts, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -122,7 +122,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
                 Assert.Equal(
                     CloseReasons.ConnectionInitWaitTimeout,
-                    (int)webSocket.CloseStatus!.Value);
+                    (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -168,7 +168,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-                Assert.Equal(CloseReasons.Unauthorized, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.Unauthorized, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -229,7 +229,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await socket.ReceiveServerMessageAsync(ct);
                 Assert.True(socket.CloseStatus.HasValue);
-                Assert.Equal(ProtocolError, socket.CloseStatus!.Value);
+                Assert.Equal(ProtocolError, socket.CloseStatus.Value);
             });
 
     [Fact]
@@ -375,7 +375,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue);
-                Assert.Equal(CloseReasons.SubscriberNotUnique, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.SubscriberNotUnique, (int)webSocket.CloseStatus.Value);
             });
     }
 
@@ -398,7 +398,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue);
-                Assert.Equal(CloseReasons.Unauthorized, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.Unauthorized, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -418,7 +418,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue);
-                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -438,7 +438,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue);
-                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -821,7 +821,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-                Assert.Equal(InternalServerError, webSocket.CloseStatus!.Value);
+                Assert.Equal(InternalServerError, webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -840,7 +840,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -859,7 +859,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]
@@ -878,7 +878,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 // assert
                 await webSocket.ReceiveServerMessageAsync(ct);
                 Assert.True(webSocket.CloseStatus.HasValue, "Connection is closed.");
-                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus!.Value);
+                Assert.Equal(CloseReasons.ProtocolError, (int)webSocket.CloseStatus.Value);
             });
 
     [Fact]

--- a/src/HotChocolate/AspNetCore/test/Transport.Http.Tests/GraphQLHttpClientTests.cs
+++ b/src/HotChocolate/AspNetCore/test/Transport.Http.Tests/GraphQLHttpClientTests.cs
@@ -1747,7 +1747,7 @@ public class GraphQLHttpClientTests : ServerTestBase
         Assert.DoesNotContain("\\u0027", handler.LastBody, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("\\u2019", handler.LastBody, StringComparison.OrdinalIgnoreCase);
 
-        using var body = JsonDocument.Parse(handler.LastBody!);
+        using var body = JsonDocument.Parse(handler.LastBody);
         var serializedDescription = body.RootElement
             .GetProperty("variables")
             .GetProperty("description")

--- a/src/HotChocolate/Caching/test/Caching.Memory.Tests/CacheTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Memory.Tests/CacheTests.cs
@@ -173,8 +173,8 @@ public class CacheTests
         Assert.NotNull(diag.SizeGauge);
         Assert.NotNull(diag.CapacityGauge);
 
-        Assert.Equal(2, diag.SizeGauge!());
-        Assert.Equal(4, diag.CapacityGauge!());
+        Assert.Equal(2, diag.SizeGauge());
+        Assert.Equal(4, diag.CapacityGauge());
     }
 
     [Fact]

--- a/src/HotChocolate/Caching/test/Caching.Tests/CacheControlDirectiveTypeTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/CacheControlDirectiveTypeTests.cs
@@ -18,7 +18,7 @@ public class CacheControlDirectiveTypeTests
             .Use(_ => _)
             .Create();
         var directive =
-            schema.DirectiveTypes.OfType<CacheControlDirectiveType>().FirstOrDefault()!;
+            schema.DirectiveTypes.OfType<CacheControlDirectiveType>().FirstOrDefault();
 
         Assert.NotNull(directive);
         Assert.IsType<CacheControlDirectiveType>(directive);

--- a/src/HotChocolate/Caching/test/Caching.Tests/CacheControlTypeInterceptorTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/CacheControlTypeInterceptorTests.cs
@@ -336,7 +336,7 @@ public class CacheControlTypeInterceptorTests
 
         public Task<string> TaskField() => null!;
 
-        public ValueTask<string> ValueTaskField() => default!;
+        public ValueTask<string> ValueTaskField() => default;
 
         public IExecutable<string> ExecutableField() => null!;
 
@@ -355,7 +355,7 @@ public class CacheControlTypeInterceptorTests
         public Task<string> TaskFieldWithCacheControl() => null!;
 
         [CacheControl(200)]
-        public ValueTask<string> ValueTaskFieldWithCacheControl() => default!;
+        public ValueTask<string> ValueTaskFieldWithCacheControl() => default;
 
         [CacheControl(200)]
         public IExecutable<string> ExecutableFieldWithCacheControl() => null!;

--- a/src/HotChocolate/Core/src/Execution.Abstractions/Error.cs
+++ b/src/HotChocolate/Core/src/Execution.Abstractions/Error.cs
@@ -129,7 +129,7 @@ public record Error : IError
         if (Extensions is not null)
         {
             var builder = ImmutableOrderedDictionary.CreateBuilder<string, object?>();
-            builder.AddRange(Extensions!);
+            builder.AddRange(Extensions);
             builder.Add(key, value);
             return this with { Extensions = builder.ToImmutable() };
         }
@@ -158,7 +158,7 @@ public record Error : IError
         if (Extensions is not null)
         {
             var builder = ImmutableOrderedDictionary.CreateBuilder<string, object?>();
-            builder.AddRange(Extensions!);
+            builder.AddRange(Extensions);
             builder.Remove(key);
             return this with { Extensions = builder.ToImmutable() };
         }

--- a/src/HotChocolate/Core/src/Execution.Abstractions/Execution/OperationDocumentInfo.cs
+++ b/src/HotChocolate/Core/src/Execution.Abstractions/Execution/OperationDocumentInfo.cs
@@ -45,7 +45,7 @@ public sealed class OperationDocumentInfo : RequestFeature
     /// <inheritdoc />
     protected internal override void Reset()
     {
-        Document = null!;
+        Document = null;
         Id = default;
         Hash = default;
         IsCached = false;

--- a/src/HotChocolate/Core/src/Execution.Projections/Extensions/HotChocolateExecutionSelectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution.Projections/Extensions/HotChocolateExecutionSelectionExtensions.cs
@@ -38,7 +38,7 @@ public static class HotChocolateExecutionSelectionExtensions
         if (selection is not Selection casted)
         {
             throw new ArgumentException(
-                $"Expected {typeof(Selection).FullName!}.",
+                $"Expected {typeof(Selection).FullName}.",
                 nameof(selection));
         }
 
@@ -56,7 +56,7 @@ public static class HotChocolateExecutionSelectionExtensions
         if (selection is not Selection casted)
         {
             throw new ArgumentException(
-                $"Expected {typeof(Selection).FullName!}.",
+                $"Expected {typeof(Selection).FullName}.",
                 nameof(selection));
         }
 

--- a/src/HotChocolate/Core/src/Features/FeatureReferences.cs
+++ b/src/HotChocolate/Core/src/Features/FeatureReferences.cs
@@ -98,7 +98,7 @@ public struct FeatureReferences<TCache>
         if (Revision != revision)
         {
             // Clear cached value to force call to UpdateCached
-            cached = null!;
+            cached = null;
             // Collection changed, clear whole feature cache
             flush = true;
         }

--- a/src/HotChocolate/Core/src/Types.Analyzers/Helpers/GeneratorUtils.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Helpers/GeneratorUtils.cs
@@ -86,7 +86,7 @@ internal static class GeneratorUtils
 
         if (type.SpecialType == SpecialType.System_Boolean)
         {
-            return defaultValue.ToString()!.ToLower();
+            return defaultValue.ToString().ToLower();
         }
 
         if (type.SpecialType == SpecialType.System_Double
@@ -123,7 +123,7 @@ internal static class GeneratorUtils
                 }
 
                 // Fallback to integer value if no matching member found
-                return defaultValue.ToString()!;
+                return defaultValue.ToString();
             }
 
             if (type.IsNullableValueType())

--- a/src/HotChocolate/Core/src/Types.Analyzers/Helpers/SymbolExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Helpers/SymbolExtensions.cs
@@ -214,7 +214,7 @@ public static class SymbolExtensions
                     !string.IsNullOrEmpty(x.Value)
                     && !string.IsNullOrEmpty(x.Attribute("code")?.Value))
                 .Select((e, i) => (Element: e, Index: i + 1))
-                .Select(x => $"{x.Index}. {x.Element.Attribute("code")!.Value}: {x.Element.Value}")
+                .Select(x => $"{x.Index}. {x.Element.Attribute("code").Value}: {x.Element.Value}")
                 .ToArray();
 
             return exceptions.Length == 0

--- a/src/HotChocolate/Core/src/Types.NodaTime/DurationType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/DurationType.cs
@@ -60,7 +60,7 @@ public class DurationType : ScalarType<Duration, StringValueNode>
     /// <inheritdoc />
     protected override Duration OnCoerceInputValue(JsonElement inputValue, IFeatureProvider context)
     {
-        if (Iso8601DurationParser.TryParse(inputValue.GetString()!.AsSpan(), out var value))
+        if (Iso8601DurationParser.TryParse(inputValue.GetString().AsSpan(), out var value))
         {
             return value;
         }

--- a/src/HotChocolate/Core/src/Types.Queries/QueryResultMiddleware.cs
+++ b/src/HotChocolate/Core/src/Types.Queries/QueryResultMiddleware.cs
@@ -24,7 +24,7 @@ internal sealed class QueryResultMiddleware(FieldDelegate next, IReadOnlyList<Cr
                 else
                 {
                     // TODO : this is not good ... it should be clear how errors have to be unwrapped
-                    context.Result = ((object[])fieldResult.Value!)[0];
+                    context.Result = ((object[])fieldResult.Value)[0];
                 }
             }
         }

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInferencePathBuilder.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInferencePathBuilder.cs
@@ -43,7 +43,7 @@ internal static class TypeInferencePathBuilder
         var leafType = unresolved is ExtendedTypeReference extendedRef
             ? extendedRef.Type.Type
             : null;
-        var leafText = leafType is null ? unresolved.ToString()! : null;
+        var leafText = leafType is null ? unresolved.ToString() : null;
 
         // the first hop locates the member whose type is the unresolved reference.
         if (!TryFindOwner(typeRegistry, unresolved, out var owner, out var segment))

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -761,7 +761,7 @@ internal sealed class TypeInitializer
             {
                 // the name might not be set at this point.
                 var name = string.IsNullOrEmpty(type.Type.Name)
-                    ? type.References[0].ToString()!
+                    ? type.References[0].ToString()
                     : type.Type.Name;
 
                 IReadOnlyList<TypeReference> needed =

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.Arguments.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.Arguments.cs
@@ -9,7 +9,9 @@ namespace HotChocolate.Execution.Processing;
 
 internal partial class MiddlewareContext
 {
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     public IReadOnlyDictionary<string, ArgumentValue> Arguments { get; set; } = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     public T ArgumentValue<T>(string name)
     {

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.Global.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.Global.cs
@@ -10,9 +10,11 @@ internal partial class MiddlewareContext : IMiddlewareContext
 {
     private readonly OperationResultBuilderFacade _operationResultBuilder = new();
     private readonly List<Func<ValueTask>> _cleanupTasks = [];
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     private OperationContext _operationContext = null!;
     private IServiceProvider _services = null!;
     private InputParser _parser = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
     private object? _resolverResult;
     private bool _hasResolverResult;
 

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.Selection.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.Selection.cs
@@ -8,7 +8,9 @@ namespace HotChocolate.Execution.Processing;
 internal partial class MiddlewareContext
 {
     private readonly PureResolverContext _childContext;
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     private Selection _selection = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     public ObjectType ObjectType => _selection.DeclaringType;
 

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.State.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.State.cs
@@ -13,9 +13,11 @@ internal partial class MiddlewareContext
 
     public Path Path => _path ??= ResultValue.Path;
 
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     public IImmutableDictionary<string, object?> ScopedContextData { get; set; } = null!;
 
     public IImmutableDictionary<string, object?> LocalContextData { get; set; } = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     public IType? ValueType { get; set; }
 

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/OperationContext.Pooling.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/OperationContext.Pooling.cs
@@ -109,7 +109,7 @@ internal sealed partial class OperationContext
 
         IncludeFlags = operation.CreateIncludeFlags(variables);
         DeferFlags = operation.CreateDeferFlags(variables);
-        Result.Data = new ResultDocument(_memory!, operation, IncludeFlags);
+        Result.Data = new ResultDocument(_memory, operation, IncludeFlags);
         Result.RequestIndex = _requestContext.RequestIndex;
         Result.VariableIndex = variableIndex;
 

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/OperationResolverHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/OperationResolverHelper.cs
@@ -45,7 +45,7 @@ internal static class OperationResolverHelper
             for (var i = 0; i < document.Definitions.Count; i++)
             {
                 if (document.Definitions[i] is OperationDefinitionNode { Name: { } } op
-                    && op.Name!.Value.EqualsOrdinal(operationName))
+                    && op.Name.Value.EqualsOrdinal(operationName))
                 {
                     return op;
                 }

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/SelectionLookup.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/SelectionLookup.cs
@@ -88,7 +88,7 @@ internal sealed class SelectionLookup
 
         if (table.Length == 0)
         {
-            selection = null!;
+            selection = null;
             return false;
         }
 

--- a/src/HotChocolate/Core/src/Types/Resolvers/AggregateServiceScopeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/AggregateServiceScopeInitializer.cs
@@ -47,7 +47,7 @@ internal sealed class AggregateServiceScopeInitializer : IServiceScopeInitialize
 
                 while (Unsafe.IsAddressLessThan(ref start, ref end))
                 {
-                    start!.Initialize(context, requestScope, resolverScope);
+                    start.Initialize(context, requestScope, resolverScope);
                     start = ref Unsafe.Add(ref start, 1);
                 }
                 break;

--- a/src/HotChocolate/Core/src/Types/Resolvers/Expressions/Parameters/ClaimsPrincipalParameterExpressionBuilder.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/Expressions/Parameters/ClaimsPrincipalParameterExpressionBuilder.cs
@@ -60,5 +60,5 @@ internal sealed class ClaimsPrincipalParameterExpressionBuilder
         => this;
 
     public T Execute<T>(IResolverContext context)
-        => context.GetGlobalState<T>(nameof(ClaimsPrincipal))!;
+        => context.GetGlobalState<T>(nameof(ClaimsPrincipal));
 }

--- a/src/HotChocolate/Core/src/Types/Schema.cs
+++ b/src/HotChocolate/Core/src/Types/Schema.cs
@@ -21,7 +21,9 @@ public partial class Schema
     /// <summary>
     /// Gets the GraphQL object type that represents the query root.
     /// </summary>
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     public ObjectType QueryType { get; private set; } = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     IObjectTypeDefinition ISchemaDefinition.QueryType => QueryType;
 
@@ -42,14 +44,18 @@ public partial class Schema
     /// <summary>
     /// Gets all the schema types.
     /// </summary>
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     public TypeDefinitionCollection Types { get; private set; } = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     IReadOnlyTypeDefinitionCollection ISchemaDefinition.Types => Types;
 
     /// <summary>
     /// Gets all the directives that are supported by this schema.
     /// </summary>
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     public DirectiveTypeCollection DirectiveTypes { get; private set; } = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     IReadOnlyDirectiveDefinitionCollection ISchemaDefinition.DirectiveDefinitions
         => DirectiveTypes.AsReadOnlyDirectiveCollection();
@@ -57,7 +63,9 @@ public partial class Schema
     /// <summary>
     /// Gets the schema directives.
     /// </summary>
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     public DirectiveCollection Directives { get; private set; } = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     IReadOnlyDirectiveCollection IDirectivesProvider.Directives
         => Directives.AsReadOnlyDirectiveCollection();
@@ -65,7 +73,9 @@ public partial class Schema
     /// <summary>
     /// Gets the global schema services.
     /// </summary>
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     public IServiceProvider Services { get; internal set; } = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     /// <summary>
     /// Specifies the time the schema was created.

--- a/src/HotChocolate/Core/src/Types/SchemaErrorBuilder.Error.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaErrorBuilder.Error.cs
@@ -78,7 +78,7 @@ public partial class SchemaErrorBuilder
                 writer.WritePropertyName("path");
                 writer.WriteStartArray();
 
-                foreach (var segment in Path.Select(t => t.ToString()!))
+                foreach (var segment in Path.Select(t => t.ToString()))
                 {
                     writer.WriteStringValue(segment);
                 }

--- a/src/HotChocolate/Core/src/Types/Types/Extensions/SubscribeResolverObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Extensions/SubscribeResolverObjectFieldDescriptorExtensions.cs
@@ -161,7 +161,7 @@ public static class SubscribeResolverObjectFieldDescriptorExtensions
         string argumentName)
         => SubscribeToTopic<TMessage>(
             descriptor,
-            ctx => ctx.ArgumentValue<object>(argumentName).ToString()!);
+            ctx => ctx.ArgumentValue<object>(argumentName).ToString());
 
     /// <summary>
     /// Subscribes to a topic that is resolved by executing <paramref name="resolveTopic" />.

--- a/src/HotChocolate/Core/src/Types/Types/InputObjectType.Initialization.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InputObjectType.Initialization.cs
@@ -17,8 +17,10 @@ namespace HotChocolate.Types;
 public partial class InputObjectType
 {
     private Action<IInputObjectTypeDescriptor>? _configure;
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     private Func<object?[], object> _createInstance = null!;
     private Action<object, object?[]> _getFieldValues = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     protected override InputObjectTypeConfiguration CreateConfiguration(ITypeDiscoveryContext context)
     {

--- a/src/HotChocolate/Core/src/Types/Types/InterfaceType.Initialization.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InterfaceType.Initialization.cs
@@ -13,7 +13,9 @@ public partial class InterfaceType
     private InterfaceTypeCollection _implements = InterfaceTypeCollection.Empty;
     private Action<IInterfaceTypeDescriptor>? _configure;
     private ResolveAbstractType? _resolveAbstractType;
+#pragma warning disable IDE0370 // Remove unnecessary suppression
     private Schema _schema = null!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     protected override InterfaceTypeConfiguration CreateConfiguration(
         ITypeDiscoveryContext context)

--- a/src/HotChocolate/Core/src/Types/Types/ObjectField.cs
+++ b/src/HotChocolate/Core/src/Types/Types/ObjectField.cs
@@ -25,7 +25,7 @@ public sealed class ObjectField : OutputField
         Member = configuration.Member;
         ResolverMember = configuration.ResolverMember ?? configuration.Member;
         Middleware = s_empty;
-        Resolver = configuration.Resolver!;
+        Resolver = configuration.Resolver;
         ResolverExpression = configuration.Expression;
         SubscribeResolver = configuration.SubscribeResolver;
     }
@@ -36,7 +36,7 @@ public sealed class ObjectField : OutputField
         Member = original.Member;
         ResolverMember = original.ResolverMember ?? original.Member;
         Middleware = original.Middleware;
-        Resolver = original.Resolver!;
+        Resolver = original.Resolver;
         ResolverExpression = original.ResolverExpression;
         SubscribeResolver = original.SubscribeResolver;
         ResultPostProcessor = original.ResultPostProcessor;
@@ -307,7 +307,7 @@ file static class ResolverHelpers
 
         if (extendedType.IsArrayOrList)
         {
-            var elementType = extendedType.ElementType!.Type;
+            var elementType = extendedType.ElementType.Type;
             return GetFactoryMethod(elementType);
         }
 

--- a/src/HotChocolate/Core/src/Types/Types/Pagination/PagingHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Pagination/PagingHelper.cs
@@ -133,7 +133,7 @@ public static class PagingHelper
             // the element type of the list or array as our entity type.
             if (r.Type is { IsSchemaType: true, IsArrayOrList: true })
             {
-                return r.Type.ElementType!;
+                return r.Type.ElementType;
             }
 
             // if the member type is unknown we will try to infer it by extracting
@@ -166,7 +166,7 @@ public static class PagingHelper
 
                 if (typeInspector.GetType(current) is { IsArrayOrList: true } schemaType)
                 {
-                    return schemaType.ElementType!;
+                    return schemaType.ElementType;
                 }
             }
         }

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
@@ -550,7 +550,7 @@ internal sealed class OptimizedNodeIdSerializer : INodeIdSerializer
             for (; insertAt < bucketSize; insertAt++)
             {
                 var entry = bucket[insertAt];
-                if (entry.Key == null!)
+                if (entry.Key == null)
                 {
                     foundSpot = true;
                     break;
@@ -597,7 +597,7 @@ internal sealed class OptimizedNodeIdSerializer : INodeIdSerializer
 
             while (Unsafe.IsAddressLessThan(ref entry, ref end))
             {
-                if (entry.Key == null!)
+                if (entry.Key == null)
                 {
                     // we have reached end of entries in this bucket
                     break;

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/DurationType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/DurationType.cs
@@ -90,7 +90,7 @@ public class DurationType : ScalarType<TimeSpan, StringValueNode>
     /// <inheritdoc />
     protected override TimeSpan OnCoerceInputValue(JsonElement inputValue, IFeatureProvider context)
     {
-        var str = inputValue.GetString()!;
+        var str = inputValue.GetString();
 
         if (Format == DurationFormat.Iso8601)
         {

--- a/src/HotChocolate/Core/src/Types/Utilities/ObjectToDictionaryConverter.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ObjectToDictionaryConverter.cs
@@ -116,7 +116,7 @@ internal class ObjectToDictionaryConverter
                 {
                     if (item is DictionaryEntry entry)
                     {
-                        void SetField(object v) => current[entry.Key.ToString()!] = v;
+                        void SetField(object v) => current[entry.Key.ToString()] = v;
                         VisitValue(entry.Value, SetField, processed);
                     }
                     else if (item is KeyValuePair<string, object> pair)

--- a/src/HotChocolate/Core/src/Types/Utilities/ReflectionUtils.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ReflectionUtils.cs
@@ -201,7 +201,7 @@ public static class ReflectionUtils
     {
         if (type.IsNested)
         {
-            return $"{GetNamespace(type.DeclaringType)}.{type.DeclaringType!.Name}";
+            return $"{GetNamespace(type.DeclaringType)}.{type.DeclaringType.Name}";
         }
         return type.Namespace;
     }

--- a/src/HotChocolate/Core/src/Types/Utilities/Serialization/InputObjectCompiler.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/Serialization/InputObjectCompiler.cs
@@ -353,7 +353,7 @@ internal static class InputObjectCompiler
         var from =
             typeof(Optional<>)
                 .MakeGenericType(runtimeType)
-                .GetMethod("From", BindingFlags.Public | BindingFlags.Static)!;
+                .GetMethod("From", BindingFlags.Public | BindingFlags.Static);
         Debug.Assert(from is not null, "From helper on Optional<T> is missing.");
         fieldValue = Expression.Convert(fieldValue, typeof(IOptional));
         return Expression.Call(from, fieldValue);

--- a/src/HotChocolate/Core/src/Types/Utilities/ThrowHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ThrowHelper.cs
@@ -55,7 +55,7 @@ internal static class ThrowHelper
             SchemaErrorBuilder.New()
                 .SetMessage(
                     ThrowHelper_SubscribeAttribute_MessageTypeUnspecified,
-                    member.DeclaringType!.FullName,
+                    member.DeclaringType.FullName,
                     member.Name)
                 .SetExtension("member", member)
                 .Build());
@@ -65,7 +65,7 @@ internal static class ThrowHelper
             SchemaErrorBuilder.New()
                 .SetMessage(
                     ThrowHelper_SubscribeAttribute_TopicTypeUnspecified,
-                    member.DeclaringType!.FullName,
+                    member.DeclaringType.FullName,
                     member.Name)
                 .SetExtension("member", member)
                 .Build());
@@ -77,7 +77,7 @@ internal static class ThrowHelper
             SchemaErrorBuilder.New()
                 .SetMessage(
                     ThrowHelper_SubscribeAttribute_SubscribeResolverNotFound,
-                    member.DeclaringType!.FullName,
+                    member.DeclaringType.FullName,
                     member.Name,
                     subscribeResolverName)
                 .SetExtension("member", member)

--- a/src/HotChocolate/Core/test/Abstractions.Tests/FieldResultTests.cs
+++ b/src/HotChocolate/Core/test/Abstractions.Tests/FieldResultTests.cs
@@ -55,7 +55,7 @@ public class FieldResultTests
 
         Assert.False(result.IsSuccess);
         Assert.True(result.IsError);
-        Assert.Collection(result.Errors!, obj => Assert.Equal(error, obj));
+        Assert.Collection(result.Errors, obj => Assert.Equal(error, obj));
         Assert.Equal(result.Errors, ((IFieldResult)result).Value);
     }
 
@@ -178,7 +178,7 @@ public class FieldResultTests
 
         Assert.False(result.IsSuccess);
         Assert.True(result.IsError);
-        Assert.Collection(result.Errors!, err => Assert.Equal(error, err));
+        Assert.Collection(result.Errors, err => Assert.Equal(error, err));
         Assert.Equal(result.Errors, ((IFieldResult)result).Value);
     }
 

--- a/src/HotChocolate/Core/test/Authorization.Tests/AnnotationBasedAuthorizationTests.cs
+++ b/src/HotChocolate/Core/test/Authorization.Tests/AnnotationBasedAuthorizationTests.cs
@@ -150,7 +150,7 @@ public class AnnotationBasedAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -378,7 +378,7 @@ public class AnnotationBasedAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -430,7 +430,7 @@ public class AnnotationBasedAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -482,7 +482,7 @@ public class AnnotationBasedAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -558,7 +558,7 @@ public class AnnotationBasedAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -765,7 +765,7 @@ public class AnnotationBasedAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -887,7 +887,7 @@ public class AnnotationBasedAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 

--- a/src/HotChocolate/Core/test/Authorization.Tests/CodeFirstAuthorizationTests.cs
+++ b/src/HotChocolate/Core/test/Authorization.Tests/CodeFirstAuthorizationTests.cs
@@ -78,7 +78,7 @@ public class CodeFirstAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -253,7 +253,7 @@ public class CodeFirstAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -353,7 +353,7 @@ public class CodeFirstAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -405,7 +405,7 @@ public class CodeFirstAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -457,7 +457,7 @@ public class CodeFirstAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 
@@ -509,7 +509,7 @@ public class CodeFirstAuthorizationTests
                 """);
 
         Assert.NotNull(result.ContextData);
-        Assert.True(result.ContextData!.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
+        Assert.True(result.ContextData.TryGetValue(ExecutionContextData.HttpStatusCode, out var value));
         Assert.Equal(401, value);
     }
 

--- a/src/HotChocolate/Core/test/Execution.Tests/CodeFirstTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/CodeFirstTests.cs
@@ -61,7 +61,7 @@ public class CodeFirstTests
 
         // assert
         Assert.Collection(
-            Assert.IsType<OperationResult>(result).Errors!,
+            Assert.IsType<OperationResult>(result).Errors,
             e => Assert.Equal("Document contains more than 5 tokens. Parsing aborted.", e.Message));
     }
 
@@ -99,7 +99,7 @@ public class CodeFirstTests
 
         // assert
         Assert.Collection(
-            Assert.IsType<OperationResult>(result).Errors!,
+            Assert.IsType<OperationResult>(result).Errors,
             e => Assert.Equal("Document contains more than 6 nodes. Parsing aborted.", e.Message));
     }
 

--- a/src/HotChocolate/Core/test/Execution.Tests/ScalarExecutionErrorTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/ScalarExecutionErrorTests.cs
@@ -145,7 +145,7 @@ public class ScalarExecutionErrorTests
         {
             if (inputValue.ValueKind is JsonValueKind.String)
             {
-                var value = inputValue.GetString()!;
+                var value = inputValue.GetString();
                 if (value is "a")
                 {
                     return value;

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/UseConnectionAttributeTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/UseConnectionAttributeTests.cs
@@ -130,7 +130,7 @@ public class UseConnectionAttributeTests
         string code)
     {
         var operationResult = executionResult.ExpectOperationResult();
-        var error = Assert.Single(operationResult.Errors!);
+        var error = Assert.Single(operationResult.Errors);
 
         Assert.True(
             error.Code == code,

--- a/src/HotChocolate/Core/test/Types.Queries.Tests/CodeFirstSchemaTests.cs
+++ b/src/HotChocolate/Core/test/Types.Queries.Tests/CodeFirstSchemaTests.cs
@@ -591,7 +591,7 @@ public class CodeFirstSchemaTests
 
     public class InvalidQuery
     {
-        public FieldResult<Foo> Foo() => default!;
+        public FieldResult<Foo> Foo() => default;
     }
 
     public class InvalidQueryTask

--- a/src/HotChocolate/Core/test/Types.Scalars.Tests/LatitudeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Scalars.Tests/LatitudeTypeTests.cs
@@ -440,7 +440,7 @@ public class LatitudeTypeTests : ScalarTypeTestBase
         int precision = 8)
     {
         return Math.Round(
-            (double)scalar.CoerceInputLiteral(valueSyntax)!,
+            (double)scalar.CoerceInputLiteral(valueSyntax),
             precision,
             MidpointRounding.AwayFromZero);
     }

--- a/src/HotChocolate/Core/test/Types.Scalars.Tests/LongitudeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Scalars.Tests/LongitudeTypeTests.cs
@@ -444,7 +444,7 @@ public class LongitudeTypeTests : ScalarTypeTestBase
         int precision = 8)
     {
         return Math.Round(
-            (double)scalar.CoerceInputLiteral(valueSyntax)!,
+            (double)scalar.CoerceInputLiteral(valueSyntax),
             precision,
             MidpointRounding.AwayFromZero);
     }

--- a/src/HotChocolate/Core/test/Types.Scalars.Tests/UtcOffsetTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Scalars.Tests/UtcOffsetTypeTests.cs
@@ -80,7 +80,7 @@ public class UtcOffsetTypeTests : ScalarTypeTestBase
         var expectedResult = new TimeSpan(-12, 0, 0);
 
         // act
-        object result = (TimeSpan)scalar.CoerceInputLiteral(valueSyntax)!;
+        object result = (TimeSpan)scalar.CoerceInputLiteral(valueSyntax);
 
         // assert
         Assert.Equal(expectedResult, result);
@@ -148,7 +148,7 @@ public class UtcOffsetTypeTests : ScalarTypeTestBase
         context.Setup(t => t.Features).Returns(FeatureCollection.Empty);
 
         // act
-        var deserializedValue = (TimeSpan)scalar.CoerceInputValue(doc.RootElement, context.Object)!;
+        var deserializedValue = (TimeSpan)scalar.CoerceInputValue(doc.RootElement, context.Object);
 
         // assert
         Assert.Equal(runtimeValue, deserializedValue);

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeDiscovererTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeDiscovererTests.cs
@@ -406,7 +406,7 @@ public class TypeDiscovererTests
 
         // assert
         // both renderings share the same truncation, so the part count is identical.
-        var shortParts = path!.Value.Short.Split(" -> ");
+        var shortParts = path.Value.Short.Split(" -> ");
         var expandedParts = path.Value.Expanded.Split(" -> ");
         Assert.Equal(5, shortParts.Length);
         Assert.Equal("...", shortParts[0]);
@@ -421,27 +421,27 @@ public class TypeDiscovererTests
 
     public class DeepLevel1
     {
-        public DeepLevel2 Level2 { get; } = null!;
+        public DeepLevel2 Level2 { get; }
     }
 
     public class DeepLevel2
     {
-        public DeepLevel3 Level3 { get; } = null!;
+        public DeepLevel3 Level3 { get; }
     }
 
     public class DeepLevel3
     {
-        public DeepLevel4 Level4 { get; } = null!;
+        public DeepLevel4 Level4 { get; }
     }
 
     public class DeepLevel4
     {
-        public DeepLevel5 Level5 { get; } = null!;
+        public DeepLevel5 Level5 { get; }
     }
 
     public class DeepLevel5
     {
-        public DeepLevel6 Level6 { get; } = null!;
+        public DeepLevel6 Level6 { get; }
     }
 
     public class DeepLevel6
@@ -456,7 +456,7 @@ public class TypeDiscovererTests
 
     public class FooWithBar
     {
-        public BarWithBaz Bar { get; } = null!;
+        public BarWithBaz Bar { get; }
     }
 
     public class BarWithBaz

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/ResolverCompilerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/ResolverCompilerTests.cs
@@ -1450,53 +1450,53 @@ public class ResolverCompilerTests
             "cancel";
 
         public bool GetClaimsPrincipal(ClaimsPrincipal claims)
-            => claims != null!;
+            => claims != null;
 
         public bool GetNullableClaimsPrincipal(ClaimsPrincipal? claims)
-            => claims != null!;
+            => claims != null;
 
         public bool GetPath(Path path)
-            => path != null!;
+            => path != null;
 
         public bool ResolverWithResolverContext(
             IResolverContext context) =>
-            context != null!;
+            context != null;
 
         public bool ResolverWithFieldSelection(
             ISelection fieldSelection) =>
-            fieldSelection != null!;
+            fieldSelection != null;
 
         public bool ResolverWithSelection(
             ISelection fieldSelection) =>
-            fieldSelection != null!;
+            fieldSelection != null;
 
         public bool ResolverWithObjectType(
             ObjectType objectType) =>
-            objectType != null!;
+            objectType != null;
 
         public bool ResolverWithOperationDefinition(
             OperationDefinitionNode operationDefinition) =>
-            operationDefinition != null!;
+            operationDefinition != null;
 
         public bool ResolverWithObjectField(
             ObjectField objectField) =>
-            objectField != null!;
+            objectField != null;
 
         public bool ResolverWithOutputField(
             IOutputFieldDefinition outputField) =>
-            outputField != null!;
+            outputField != null;
 
         public bool ResolverWithDocument(
             DocumentNode document) =>
-            document != null!;
+            document != null;
 
         public bool ResolverWithSchema(
             ISchemaDefinition schema) =>
-            schema != null!;
+            schema != null;
 
         public bool ResolverWithService(
             [Service] MyService service) =>
-            service != null!;
+            service != null;
 
         public string GetGlobalStateWithKey(
             [GlobalState("foo")]

--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
@@ -779,7 +779,7 @@ public class ObjectTypeExtensionTests
     {
         public string? Description => "hello";
 
-        public string? GetName(string? a) => null!;
+        public string? GetName(string? a) => null;
     }
 
     public class FooExtension

--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeTests.cs
@@ -1874,7 +1874,7 @@ public class ObjectTypeTests : TypeTestBase
                 d =>
                 {
                     d.Name("Query");
-                    d.Field("Foo").Type("String").Resolve(_ => null!);
+                    d.Field("Foo").Type("String").Resolve(_ => Task.FromResult<object?>(null));
                 })
             .Create()
             .ToString()
@@ -1892,7 +1892,7 @@ public class ObjectTypeTests : TypeTestBase
                     d.Field("Foo")
                         .Argument("a", t => t.Type("Int"))
                         .Type("String")
-                        .Resolve(_ => null!);
+                        .Resolve(_ => Task.FromResult<object?>(null));
                 })
             .Create()
             .ToString()

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/BooleanTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/BooleanTypeTests.cs
@@ -29,7 +29,7 @@ public class BooleanTypeTests
 
         // assert
         Assert.IsType<bool>(result);
-        Assert.True((bool)result!);
+        Assert.True((bool)result);
     }
 
     [Fact]

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/DateTimeTypeTests.cs
@@ -31,7 +31,7 @@ public class DateTimeTypeTests
             new TimeSpan(4, 0, 0));
 
         // act
-        var dateTime = (DateTimeOffset)type.CoerceInputLiteral(literal)!;
+        var dateTime = (DateTimeOffset)type.CoerceInputLiteral(literal);
 
         // assert
         Assert.Equal(expectedDateTime, dateTime);
@@ -88,7 +88,7 @@ public class DateTimeTypeTests
             new TimeSpan(4, 0, 0));
 
         // act
-        var dateTime = (DateTimeOffset)type.CoerceInputLiteral(literal)!;
+        var dateTime = (DateTimeOffset)type.CoerceInputLiteral(literal);
 
         // assert
         Assert.Equal(expectedDateTime, dateTime);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/DateTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/DateTypeTests.cs
@@ -30,7 +30,7 @@ public class DateTypeTests
         var expectedDate = new DateOnly(2018, 6, 29);
 
         // act
-        var date = (DateOnly)type.CoerceInputLiteral(literal)!;
+        var date = (DateOnly)type.CoerceInputLiteral(literal);
 
         // assert
         Assert.Equal(expectedDate, date);
@@ -53,7 +53,7 @@ public class DateTypeTests
         var expectedDate = new DateOnly(2018, 6, 29);
 
         // act
-        var date = (DateOnly)type.CoerceInputLiteral(literal)!;
+        var date = (DateOnly)type.CoerceInputLiteral(literal);
 
         // assert
         Assert.Equal(expectedDate, date);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/UuidTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/UuidTypeTests.cs
@@ -98,8 +98,8 @@ public class UuidTypeTests
         var literalP = new StringValueNode(expected.ToString("P"));
 
         // act
-        var runtimeValueN = (Guid)type.CoerceInputLiteral(literalN)!;
-        var runtimeValueP = (Guid)type.CoerceInputLiteral(literalP)!;
+        var runtimeValueN = (Guid)type.CoerceInputLiteral(literalN);
+        var runtimeValueP = (Guid)type.CoerceInputLiteral(literalP);
 
         // assert
         Assert.Equal(expected, runtimeValueN);
@@ -338,7 +338,7 @@ public class UuidTypeTests
         var type = new UuidType(defaultFormat: 'D', enforceFormat: enforceFormat);
 
         // act
-        var guid = (Guid)type.CoerceInputLiteral(input)!;
+        var guid = (Guid)type.CoerceInputLiteral(input);
 
         // assert
         Assert.Equal(input.Value, guid.ToString("D"));

--- a/src/HotChocolate/Core/test/Validation.Tests/FieldsOnCorrectTypeRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/FieldsOnCorrectTypeRuleTests.cs
@@ -308,9 +308,9 @@ public class FieldsOnCorrectTypeRuleTests()
                   list: [Foo!]
                 }
                 """)
-            .AddResolver("Query", "list", ctx => null!)
-            .AddResolver("Bar", "baz", ctx => null!)
-            .AddResolver("Baz", "baz", ctx => null!)
+            .AddResolver("Query", "list", ctx => null)
+            .AddResolver("Bar", "baz", ctx => null)
+            .AddResolver("Baz", "baz", ctx => null)
             .Create();
 
         ExpectErrors(

--- a/src/HotChocolate/Data/src/Data/Filters/Convention/FilterConvention.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Convention/FilterConvention.cs
@@ -59,7 +59,7 @@ public class FilterConvention
             context.DescriptorContext,
             context.Scope);
 
-        _configure!(descriptor);
+        _configure(descriptor);
         _configure = null;
 
         return descriptor.CreateConfiguration();

--- a/src/HotChocolate/Data/src/Data/Filters/Visitor/FilterOperationHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Visitor/FilterOperationHandler.cs
@@ -50,7 +50,7 @@ public abstract class FilterOperationHandler<TContext, T>
         ObjectFieldNode node,
         [NotNullWhen(true)] out T? result)
     {
-        result = default!;
+        result = default;
         return false;
     }
 }

--- a/src/HotChocolate/Data/src/Data/Sorting/Expressions/QueryableSortExpressionOptimizer.cs
+++ b/src/HotChocolate/Data/src/Data/Sorting/Expressions/QueryableSortExpressionOptimizer.cs
@@ -186,7 +186,7 @@ internal static class QueryableSortExpressionOptimizer
         // against the constructor parameters.
         if (source is NewExpression { Members: not null } newExpression)
         {
-            for (var i = 0; i < newExpression.Members!.Count; i++)
+            for (var i = 0; i < newExpression.Members.Count; i++)
             {
                 if (newExpression.Members[i].Name.Equals(member.Name, StringComparison.Ordinal))
                 {

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Tests/BookContext.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Tests/BookContext.cs
@@ -15,6 +15,6 @@ public class BookContext(DbContextOptions options) : DbContext(options)
     protected override void OnModelCreating(ModelBuilder modelBuilder)
         => modelBuilder.Entity<Author>()
             .HasMany(t => t.Books)
-            .WithOne(t => t.Author!)
+            .WithOne(t => t.Author)
             .HasForeignKey(t => t.AuthorId);
 }

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/Issue7110ReproTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/Issue7110ReproTests.cs
@@ -48,7 +48,7 @@ public class Issue7110ReproTests : IClassFixture<SchemaCache>
                           }
                         }
                         """)
-                    .SetVariableValues(new Dictionary<string, object?> { ["id"] = relayId! })
+                    .SetVariableValues(new Dictionary<string, object?> { ["id"] = relayId })
                     .Build(),
                 TestContext.Current.CancellationToken);
 

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Context/FilterContextTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Context/FilterContextTests.cs
@@ -42,7 +42,7 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(context);
-        var field = Assert.Single(context!.GetFields());
+        var field = Assert.Single(context.GetFields());
         Assert.Empty(context.GetOperations());
         var operation = Assert.Single(Assert.IsType<FilterInfo>(field.Value).GetOperations());
         Assert.Empty(Assert.IsType<FilterInfo>(field.Value).GetFields());
@@ -85,7 +85,7 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(context);
-        Assert.False(context!.IsDefined);
+        Assert.False(context.IsDefined);
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(context);
-        Assert.True(context!.IsDefined);
+        Assert.True(context.IsDefined);
     }
 
     [Fact]
@@ -210,8 +210,8 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(context);
-        var operation = Assert.Single(context!.GetOperations());
-        Assert.Empty(context!.GetFields());
+        var operation = Assert.Single(context.GetOperations());
+        Assert.Empty(context.GetFields());
         var valueCollection = Assert.IsType<FilterValueCollection>(operation.Value);
         var field0 = Assert.Single(Assert.IsType<FilterInfo>(valueCollection[0]).GetFields());
         Assert.Equal("title", field0.Field.Name);
@@ -259,7 +259,7 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(context);
-        var author = Assert.Single(context!.GetFields());
+        var author = Assert.Single(context.GetFields());
         Assert.Empty(context.GetOperations());
         var name = Assert.Single(Assert.IsType<FilterInfo>(author.Value).GetFields());
         Assert.Empty(Assert.IsType<FilterInfo>(author.Value).GetOperations());
@@ -326,7 +326,7 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(context);
-        context!.ToDictionary().MatchSnapshot();
+        context.ToDictionary().MatchSnapshot();
     }
 
     [Fact]
@@ -375,7 +375,7 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(localContextData);
-        Assert.False(localContextData!.ContainsKey(QueryableFilterProvider.SkipFilteringKey));
+        Assert.False(localContextData.ContainsKey(QueryableFilterProvider.SkipFilteringKey));
     }
 
     [Fact]
@@ -425,7 +425,7 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(localContextData);
-        Assert.True(localContextData!.ContainsKey(QueryableFilterProvider.SkipFilteringKey));
+        Assert.True(localContextData.ContainsKey(QueryableFilterProvider.SkipFilteringKey));
     }
 
     [Fact]
@@ -496,7 +496,7 @@ public class FilterContextTests
 
         // assert
         Assert.NotNull(context);
-        context!.ToDictionary().MatchSnapshot();
+        context.ToDictionary().MatchSnapshot();
     }
 
     public class Book

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/FilterConventionExtensionsTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/FilterConventionExtensionsTests.cs
@@ -117,7 +117,7 @@ public class FilterConventionExtensionsTests
         // assert
         Assert.NotNull(convention.ConfigurationAccessor);
         Assert.Collection(
-            convention.ConfigurationAccessor!.Operations,
+            convention.ConfigurationAccessor.Operations,
             x => Assert.Equal(1, x.Id),
             x => Assert.Equal(2, x.Id));
     }
@@ -143,8 +143,8 @@ public class FilterConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.ConfigurationAccessor);
-        Assert.Contains(typeof(int), convention.ConfigurationAccessor!.Bindings);
-        Assert.Contains(typeof(double), convention.ConfigurationAccessor!.Bindings);
+        Assert.Contains(typeof(int), convention.ConfigurationAccessor.Bindings);
+        Assert.Contains(typeof(double), convention.ConfigurationAccessor.Bindings);
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class FilterConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.ConfigurationAccessor);
-        var configuration = Assert.Single(convention.ConfigurationAccessor!.Configurations.Values);
+        var configuration = Assert.Single(convention.ConfigurationAccessor.Configurations.Values);
         Assert.Equal(2, configuration.Count);
     }
 
@@ -193,7 +193,7 @@ public class FilterConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.ConfigurationAccessor);
-        Assert.Equal(2, convention.ConfigurationAccessor!.Configurations.Count);
+        Assert.Equal(2, convention.ConfigurationAccessor.Configurations.Count);
     }
 
     [Fact]
@@ -218,7 +218,7 @@ public class FilterConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.ConfigurationAccessor);
-        Assert.Equal(2, convention.ConfigurationAccessor!.ProviderExtensionsTypes.Count);
+        Assert.Equal(2, convention.ConfigurationAccessor.ProviderExtensionsTypes.Count);
     }
 
     [Fact]
@@ -243,7 +243,7 @@ public class FilterConventionExtensionsTests
         // assert
         Assert.NotNull(convention.ConfigurationAccessor);
         Assert.Collection(
-            convention.ConfigurationAccessor!.ProviderExtensions,
+            convention.ConfigurationAccessor.ProviderExtensions,
             x => Assert.Equal(provider1, x),
             x => Assert.Equal(provider2, x));
     }

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/FilterProviderExtensionsTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/FilterProviderExtensionsTests.cs
@@ -35,7 +35,7 @@ public class FilterProviderExtensionsTests
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
         Assert.Collection(
-            convention.DefinitionAccessor!.FieldHandlerConfigurations,
+            convention.DefinitionAccessor.FieldHandlerConfigurations,
             x => Assert.Equal(extensionFieldHandler, x.Instance),
             x => Assert.Equal(firstFieldHandler, x.Instance));
     }

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Types/ComparableOperationInputTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Types/ComparableOperationInputTests.cs
@@ -97,7 +97,7 @@ public class ComparableOperationInputTests
 
         public decimal? BarDecimalNullable { get; set; }
 
-        public byte? BarByteNullable { get; set; } = null!;
+        public byte? BarByteNullable { get; set; }
 
         public FooBar FooBar { get; set; }
 

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/AsSelectorEncapsulatedProjectionTests.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/AsSelectorEncapsulatedProjectionTests.cs
@@ -166,7 +166,7 @@ public sealed partial class AsSelectorEncapsulatedProjectionTests(PostgreSqlReso
         params string[] expectedMembers)
     {
         Assert.NotNull(selector);
-        var body = UnwrapConvert(selector!.Body);
+        var body = UnwrapConvert(selector.Body);
 
         // a real projection materializes a new instance via member-init. The reuse path
         // (x => x) returns the parameter itself, so this also proves it is not identity reuse.
@@ -184,7 +184,7 @@ public sealed partial class AsSelectorEncapsulatedProjectionTests(PostgreSqlReso
     {
         Assert.NotNull(sql);
 
-        var selectIndex = sql!.IndexOf("SELECT", StringComparison.Ordinal);
+        var selectIndex = sql.IndexOf("SELECT", StringComparison.Ordinal);
         var fromIndex = sql.IndexOf("FROM", selectIndex, StringComparison.Ordinal);
         var selectClause = sql[selectIndex..fromIndex];
 

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/AsSelectorRecordProjectionTests.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/AsSelectorRecordProjectionTests.cs
@@ -156,7 +156,7 @@ public sealed class AsSelectorRecordProjectionTests(PostgreSqlResource resource)
         params string[] projectedMembers)
     {
         Assert.NotNull(selector);
-        var body = UnwrapConvert(selector!.Body);
+        var body = UnwrapConvert(selector.Body);
 
         Assert.IsType<NewExpression>(body);
 

--- a/src/HotChocolate/Data/test/Data.Projections.Tests/ProjectionConventionExtensionsTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.Tests/ProjectionConventionExtensionsTests.cs
@@ -76,7 +76,7 @@ public class ProjectionConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
-        Assert.Equal(2, convention.DefinitionAccessor!.ProviderExtensionsTypes.Count);
+        Assert.Equal(2, convention.DefinitionAccessor.ProviderExtensionsTypes.Count);
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class ProjectionConventionExtensionsTests
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
         Assert.Collection(
-            convention.DefinitionAccessor!.ProviderExtensions,
+            convention.DefinitionAccessor.ProviderExtensions,
             x => Assert.Equal(provider1, x),
             x => Assert.Equal(provider2, x));
     }

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/Context/SortingContextTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/Context/SortingContextTests.cs
@@ -41,7 +41,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(context);
-        var field = Assert.Single(Assert.Single(context!.GetFields()));
+        var field = Assert.Single(Assert.Single(context.GetFields()));
         var operation = Assert.IsType<SortingValue>(field.Value).Value;
         Assert.Equal("title", field.Field.Name);
         Assert.Equal("DESC", operation);
@@ -81,7 +81,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(context);
-        Assert.False(context!.IsDefined);
+        Assert.False(context.IsDefined);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(context);
-        Assert.True(context!.IsDefined);
+        Assert.True(context.IsDefined);
     }
 
     [Fact]
@@ -154,8 +154,8 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(context);
-        Assert.Equal(2, context!.GetFields().Count);
-        var field = Assert.Single(context!.GetFields()[0]);
+        Assert.Equal(2, context.GetFields().Count);
+        var field = Assert.Single(context.GetFields()[0]);
         var operation = Assert.IsType<SortingValue>(field.Value).Value;
         Assert.Equal("title", field.Field.Name);
         Assert.Equal("DESC", operation);
@@ -194,7 +194,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(context);
-        var field = Assert.Single(Assert.Single(context!.GetFields()));
+        var field = Assert.Single(Assert.Single(context.GetFields()));
         var name =
             Assert.Single(Assert.IsType<SortingInfo>(field.Value).GetFields());
         var operation = Assert.IsType<SortingValue>(name.Value).Value;
@@ -238,7 +238,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(localContextData);
-        Assert.False(localContextData!.ContainsKey(QueryableSortProvider.SkipSortingKey));
+        Assert.False(localContextData.ContainsKey(QueryableSortProvider.SkipSortingKey));
     }
 
     [Fact]
@@ -276,7 +276,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(localContextData);
-        Assert.True(localContextData!.ContainsKey(QueryableSortProvider.SkipSortingKey));
+        Assert.True(localContextData.ContainsKey(QueryableSortProvider.SkipSortingKey));
     }
 
     [Fact]
@@ -347,7 +347,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(context);
-        context!.ToList().MatchSnapshot();
+        context.ToList().MatchSnapshot();
     }
 
     [Fact]
@@ -383,7 +383,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(context);
-        context!.ToList().MatchSnapshot();
+        context.ToList().MatchSnapshot();
     }
 
     [Fact]
@@ -419,7 +419,7 @@ public class SortingContextTests
 
         // assert
         Assert.NotNull(context);
-        context!.ToList().MatchSnapshot();
+        context.ToList().MatchSnapshot();
     }
 
     public class TestSortType : SortInputType<Book>

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/SortConventionExtensionsTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/SortConventionExtensionsTests.cs
@@ -142,7 +142,7 @@ public class SortConventionExtensionsTests
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
         Assert.Collection(
-            convention.DefinitionAccessor!.Operations,
+            convention.DefinitionAccessor.Operations,
             x => Assert.Equal(1, x.Id),
             x => Assert.Equal(2, x.Id));
     }
@@ -168,8 +168,8 @@ public class SortConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
-        Assert.Contains(typeof(int), convention.DefinitionAccessor!.Bindings);
-        Assert.Contains(typeof(double), convention.DefinitionAccessor!.Bindings);
+        Assert.Contains(typeof(int), convention.DefinitionAccessor.Bindings);
+        Assert.Contains(typeof(double), convention.DefinitionAccessor.Bindings);
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public class SortConventionExtensionsTests
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
         var configuration =
-            Assert.Single(convention.DefinitionAccessor!.Configurations.Values);
+            Assert.Single(convention.DefinitionAccessor.Configurations.Values);
         Assert.Equal(2, configuration.Count);
     }
 
@@ -219,7 +219,7 @@ public class SortConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
-        Assert.Equal(2, convention.DefinitionAccessor!.Configurations.Count);
+        Assert.Equal(2, convention.DefinitionAccessor.Configurations.Count);
     }
 
     [Fact]
@@ -244,7 +244,7 @@ public class SortConventionExtensionsTests
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
         var configuration =
-            Assert.Single(convention.DefinitionAccessor!.EnumConfigurations.Values);
+            Assert.Single(convention.DefinitionAccessor.EnumConfigurations.Values);
         Assert.Equal(2, configuration.Count);
     }
 
@@ -269,7 +269,7 @@ public class SortConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
-        Assert.Equal(2, convention.DefinitionAccessor!.EnumConfigurations.Count);
+        Assert.Equal(2, convention.DefinitionAccessor.EnumConfigurations.Count);
     }
 
     [Fact]
@@ -294,7 +294,7 @@ public class SortConventionExtensionsTests
 
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
-        Assert.Equal(2, convention.DefinitionAccessor!.ProviderExtensionsTypes.Count);
+        Assert.Equal(2, convention.DefinitionAccessor.ProviderExtensionsTypes.Count);
     }
 
     [Fact]
@@ -319,7 +319,7 @@ public class SortConventionExtensionsTests
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
         Assert.Collection(
-            convention.DefinitionAccessor!.ProviderExtensions,
+            convention.DefinitionAccessor.ProviderExtensions,
             x => Assert.Equal(provider1, x),
             x => Assert.Equal(provider2, x));
     }

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/SortProviderExtensionsTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/SortProviderExtensionsTests.cs
@@ -30,7 +30,7 @@ public class SortProviderExtensionsTests
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
         Assert.Collection(
-            convention.DefinitionAccessor!.OperationHandlerConfigurations,
+            convention.DefinitionAccessor.OperationHandlerConfigurations,
             x => Assert.Equal(extensionFieldHandler, x.Instance),
             x => Assert.Equal(firstFieldHandler, x.Instance));
     }
@@ -58,7 +58,7 @@ public class SortProviderExtensionsTests
         // assert
         Assert.NotNull(convention.DefinitionAccessor);
         Assert.Collection(
-            convention.DefinitionAccessor!.FieldHandlerConfigurations,
+            convention.DefinitionAccessor.FieldHandlerConfigurations,
             x => Assert.Equal(extensionFieldHandler, x.Instance),
             x => Assert.Equal(firstFieldHandler, x.Instance));
     }

--- a/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
@@ -248,7 +248,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
@@ -288,7 +288,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
@@ -328,7 +328,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
@@ -370,7 +370,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
@@ -410,7 +410,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
@@ -453,7 +453,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
@@ -494,7 +494,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
@@ -537,7 +537,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
@@ -584,7 +584,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                 o =>
                     o.ImplementsNode()
                         .IdField(f => f.Id)
-                        .ResolveNode(_ => default!))
+                        .ResolveNode(_ => default))
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act

--- a/src/HotChocolate/Data/test/Data.Tests/PagingHelperIntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/PagingHelperIntegrationTests.cs
@@ -889,7 +889,7 @@ public class PagingHelperIntegrationTests(PostgreSqlResource resource)
         // Assert
         Assert.True(results.TryGetValue(brandId, out var page));
 
-        var connection = await new ValueTask<Page<Product>>(page!).ToConnectionAsync();
+        var connection = await new ValueTask<Page<Product>>(page).ToConnectionAsync();
         Assert.Equal(2, connection.Edges.Count);
         Assert.All(connection.Edges, edge => Assert.False(string.IsNullOrEmpty(edge.Cursor)));
     }
@@ -920,10 +920,10 @@ public class PagingHelperIntegrationTests(PostgreSqlResource resource)
         // Assert
         Assert.True(results.TryGetValue(brandId, out var page));
 
-        var connection = await new ValueTask<Page<Product>>(page!).ToConnectionAsync();
+        var connection = await new ValueTask<Page<Product>>(page).ToConnectionAsync();
         Assert.Equal(2, connection.Edges.Count);
         Assert.All(connection.Edges, edge => Assert.False(string.IsNullOrEmpty(edge.Cursor)));
-        Assert.True(page!.HasPreviousPage);
+        Assert.True(page.HasPreviousPage);
         Assert.False(page.HasNextPage);
         Assert.Equal("Product 0-2", connection.Edges[0].Node.Name);
         Assert.Equal("Product 0-3", connection.Edges[1].Node.Name);

--- a/src/HotChocolate/Data/test/Data.Tests/ProjectableDataLoaderTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/ProjectableDataLoaderTests.cs
@@ -931,7 +931,7 @@ public class ProjectableDataLoaderTests(PostgreSqlResource resource)
             CancellationToken cancellationToken)
         {
             await Task.Run(() => new InvalidOperationException(), cancellationToken);
-            return null!;
+            return null;
         }
     }
 

--- a/src/HotChocolate/Diagnostics/test/Diagnostics.Tests/ActivityTestHelper.cs
+++ b/src/HotChocolate/Diagnostics/test/Diagnostics.Tests/ActivityTestHelper.cs
@@ -33,7 +33,7 @@ public static partial class ActivityTestHelper
             // Registered after the exporter so the exporter's OnEnd appends the span before
             // this processor signals idle.
             .AddProcessor(quiescence)
-            .Build()!;
+            .Build();
 
         var capture = new Capture(tracerProvider, exported, quiescence);
         activities = capture;

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/DocumentRewriterBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/DocumentRewriterBenchmark.cs
@@ -11,11 +11,11 @@ namespace Fusion.Execution.Benchmarks;
 [MarkdownExporter]
 public class DocumentRewriterBenchmark : FusionBenchmarkBase
 {
-    private DocumentRewriter _documentRewriter = null!;
+    private DocumentRewriter _documentRewriter;
 
-    private DocumentNode _simpleQueryWithRequirements = null!;
-    private DocumentNode _complexQuery = null!;
-    private DocumentNode _conditionalRedundancyQuery = null!;
+    private DocumentNode _simpleQueryWithRequirements;
+    private DocumentNode _complexQuery;
+    private DocumentNode _conditionalRedundancyQuery;
 
     [GlobalSetup]
     public void GlobalSetup()

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/GraphQLQueryBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/GraphQLQueryBenchmark.cs
@@ -25,15 +25,15 @@ namespace Fusion.Execution.Benchmarks;
 public class GraphQLQueryBenchmark
 {
     private readonly Uri _requestUri = new Uri("http://localhost:5000/graphql");
-    private TestServer _server = null!;
-    private WebApplication _app = null!;
-    private HttpClient _client = null!;
-    private FusionClient _fusionClient = null!;
-    private FusionGraphQLHttpRequest _fusionItemsRequest = null!;
-    private FusionGraphQLHttpRequest _fusionFewItemsRequest = null!;
-    private TransportClient _transportClient = null!;
-    private TransportGraphQLHttpRequest _transportItemsRequest = null!;
-    private TransportGraphQLHttpRequest _transportFewItemsRequest = null!;
+    private TestServer _server;
+    private WebApplication _app;
+    private HttpClient _client;
+    private FusionClient _fusionClient;
+    private FusionGraphQLHttpRequest _fusionItemsRequest;
+    private FusionGraphQLHttpRequest _fusionFewItemsRequest;
+    private TransportClient _transportClient;
+    private TransportGraphQLHttpRequest _transportItemsRequest;
+    private TransportGraphQLHttpRequest _transportFewItemsRequest;
 
     private sealed class PercentilesConfig : ManualConfig
     {

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/HashCodeBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/HashCodeBenchmark.cs
@@ -10,7 +10,7 @@ namespace Fusion.Execution.Benchmarks;
 [InProcess]
 public class HashCodeBenchmark
 {
-    private byte[] _data = null!;
+    private byte[] _data;
 
     [Params(8, 16, 24, 32, 48, 64, 96, 128, 256, 512)]
     public int Size { get; set; }

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/InlineFragmentOperationRewriterBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/InlineFragmentOperationRewriterBenchmark.cs
@@ -10,11 +10,11 @@ namespace Fusion.Execution.Benchmarks;
 [MarkdownExporter]
 public class InlineFragmentOperationRewriterBenchmark : FusionBenchmarkBase
 {
-    private InlineFragmentOperationRewriter _rewriter = null!;
+    private InlineFragmentOperationRewriter _rewriter;
 
-    private DocumentNode _simpleQueryWithRequirements = null!;
-    private DocumentNode _complexQuery = null!;
-    private DocumentNode _conditionalRedundancyQuery = null!;
+    private DocumentNode _simpleQueryWithRequirements;
+    private DocumentNode _complexQuery;
+    private DocumentNode _conditionalRedundancyQuery;
 
     [GlobalSetup]
     public void GlobalSetup()

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/LockStoreBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/LockStoreBenchmark.cs
@@ -21,10 +21,10 @@ public class LockStoreBenchmark
     private readonly ReaderWriterLockSlim _readerWriterLock = new(LockRecursionPolicy.NoRecursion);
     private SpinLock _spinLock = new(enableThreadOwnerTracking: false);
 
-    private int[] _operationKinds = null!;
-    private int[] _operationIndexes = null!;
-    private int[] _data = null!;
-    private ParallelOptions _parallelOptions = null!;
+    private int[] _operationKinds;
+    private int[] _operationIndexes;
+    private int[] _data;
+    private ParallelOptions _parallelOptions;
     private int _sink;
 
     [Params(8, 32)]

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/OperationCompilerBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/OperationCompilerBenchmark.cs
@@ -18,11 +18,11 @@ public class OperationCompilerBenchmark : FusionBenchmarkBase
 {
     private const string Id = "123456789101112";
 
-    private OperationCompiler _compiler = null!;
+    private OperationCompiler _compiler;
 
-    private OperationDefinitionNode _simpleQueryWithRequirements = null!;
-    private OperationDefinitionNode _complexQuery = null!;
-    private OperationDefinitionNode _conditionalRedundancyQuery = null!;
+    private OperationDefinitionNode _simpleQueryWithRequirements;
+    private OperationDefinitionNode _complexQuery;
+    private OperationDefinitionNode _conditionalRedundancyQuery;
 
     [GlobalSetup]
     public void GlobalSetup()

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/OperationPlannerBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/OperationPlannerBenchmark.cs
@@ -16,11 +16,11 @@ public class OperationPlannerBenchmark : FusionBenchmarkBase
 {
     private const string Id = "123456789101112";
 
-    private OperationPlanner _planner = null!;
+    private OperationPlanner _planner;
 
-    private OperationDefinitionNode _simpleQueryWithRequirements = null!;
-    private OperationDefinitionNode _complexQuery = null!;
-    private OperationDefinitionNode _conditionalRedundancyQuery = null!;
+    private OperationDefinitionNode _simpleQueryWithRequirements;
+    private OperationDefinitionNode _complexQuery;
+    private OperationDefinitionNode _conditionalRedundancyQuery;
 
     [GlobalSetup]
     public void GlobalSetup()

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/VariableMergingBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/VariableMergingBenchmark.cs
@@ -41,8 +41,8 @@ public class VariableMergingBenchmark
     private static readonly HashSet<string> s_twoImportedKeys =
         new(["__fusion_1_id", "__fusion_2_sku"], StringComparer.Ordinal);
 
-    private FetchResultStore _baselineStore = null!;
-    private FetchResultStore _snapshotStore = null!;
+    private FetchResultStore _baselineStore;
+    private FetchResultStore _snapshotStore;
 
     private ImmutableArray<VariableValues> _singleEntrySnapshot;
     private ImmutableArray<VariableValues> _subsetEntrySnapshot;

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/ApolloFederation/TransformRequiresToRequire.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/ApolloFederation/TransformRequiresToRequire.cs
@@ -99,7 +99,7 @@ internal static class TransformRequiresToRequire
                 var nestedPath = new List<string>(parentPath) { fieldName };
 
                 ExtractRequireArguments(
-                    fieldNode.SelectionSet!,
+                    fieldNode.SelectionSet,
                     nestedPath,
                     nestedType,
                     schema,

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/DependencyInjection/HotChocolateFusionServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/DependencyInjection/HotChocolateFusionServiceCollectionExtensions.cs
@@ -120,7 +120,7 @@ public static class HotChocolateFusionServiceCollectionExtensions
             static (sp, schemaName) =>
             {
                 var optionsMonitor = sp.GetRequiredService<IOptionsMonitor<FusionGatewaySetup>>();
-                var setup = optionsMonitor.Get((string)schemaName!);
+                var setup = optionsMonitor.Get((string)schemaName);
 
                 var options = FusionRequestExecutorManager.CreateOptions(setup);
 

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/ReusableFieldContext.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/ReusableFieldContext.cs
@@ -18,7 +18,7 @@ internal sealed class ReusableFieldContext(
     private readonly List<object?> _runtimeResults = [];
     private Selection _selection = null!;
     private object? _parent;
-    private SourceResultElementBuilder _result = default!;
+    private SourceResultElementBuilder _result;
 
     public override PooledArrayWriter Memory => memory;
 

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanParser.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanParser.cs
@@ -238,7 +238,7 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
 
         foreach (var nodeElement in nodesElement.EnumerateArray())
         {
-            var nodeType = nodeElement.GetProperty("type").GetString()!;
+            var nodeType = nodeElement.GetProperty("type").GetString();
             var id = nodeElement.GetProperty("id").GetInt32();
 
             var schema = _operationCompiler.Schema;

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanContext.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanContext.cs
@@ -40,7 +40,7 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     private readonly INodeIdParser _nodeIdParser;
     private readonly IErrorHandler _errorHandler;
     private bool _collectTelemetry;
-    private ISourceSchemaClientScope _clientScope = default!;
+    private ISourceSchemaClientScope _clientScope;
     private string? _traceId;
     private long _start;
     private long _clientScopeCreatedAt;
@@ -48,18 +48,18 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     private int _nodeSlotCapacity;
     private MemoryArena? _memory;
     private readonly FixedMemoryArenaSource _memorySource = new();
-    private IMemoryArenaSource _currentMemorySource = default!;
+    private IMemoryArenaSource _currentMemorySource;
     internal OperationPlanContextPool? _pool;
 
     /// <summary>
     /// Gets the operation plan being executed.
     /// </summary>
-    public IOperationPlan OperationPlan { get; private set; } = default!;
+    public IOperationPlan OperationPlan { get; private set; }
 
     /// <summary>
     /// Gets the coerced variable values for the current request.
     /// </summary>
-    public IVariableValueCollection Variables { get; private set; } = default!;
+    public IVariableValueCollection Variables { get; private set; }
 
     /// <summary>
     /// Gets the schema definition associated with this execution.
@@ -69,7 +69,7 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     /// <summary>
     /// Gets the request context for the current request.
     /// </summary>
-    public RequestContext RequestContext { get; private set; } = default!;
+    public RequestContext RequestContext { get; private set; }
 
     /// <summary>
     /// Gets the source schema client scope used to obtain HTTP clients for downstream subgraphs.

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanContext.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanContext.cs
@@ -40,7 +40,9 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     private readonly INodeIdParser _nodeIdParser;
     private readonly IErrorHandler _errorHandler;
     private bool _collectTelemetry;
-    private ISourceSchemaClientScope _clientScope;
+#pragma warning disable IDE0370 // Remove unnecessary suppression
+    private ISourceSchemaClientScope _clientScope = default!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
     private string? _traceId;
     private long _start;
     private long _clientScopeCreatedAt;
@@ -48,18 +50,24 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     private int _nodeSlotCapacity;
     private MemoryArena? _memory;
     private readonly FixedMemoryArenaSource _memorySource = new();
-    private IMemoryArenaSource _currentMemorySource;
+#pragma warning disable IDE0370 // Remove unnecessary suppression
+    private IMemoryArenaSource _currentMemorySource = default!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
     internal OperationPlanContextPool? _pool;
 
     /// <summary>
     /// Gets the operation plan being executed.
     /// </summary>
-    public IOperationPlan OperationPlan { get; private set; }
+#pragma warning disable IDE0370 // Remove unnecessary suppression
+    public IOperationPlan OperationPlan { get; private set; } = default!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     /// <summary>
     /// Gets the coerced variable values for the current request.
     /// </summary>
-    public IVariableValueCollection Variables { get; private set; }
+#pragma warning disable IDE0370 // Remove unnecessary suppression
+    public IVariableValueCollection Variables { get; private set; } = default!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     /// <summary>
     /// Gets the schema definition associated with this execution.
@@ -69,7 +77,9 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     /// <summary>
     /// Gets the request context for the current request.
     /// </summary>
-    public RequestContext RequestContext { get; private set; }
+#pragma warning disable IDE0370 // Remove unnecessary suppression
+    public RequestContext RequestContext { get; private set; } = default!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
     /// <summary>
     /// Gets the source schema client scope used to obtain HTTP clients for downstream subgraphs.

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Results/FetchResultStore.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Results/FetchResultStore.cs
@@ -466,7 +466,7 @@ AddErrors_Next:
                 }
 
 AddErrors_Next:
-                path = ref Unsafe.Add(ref path, 1)!;
+                path = ref Unsafe.Add(ref path, 1);
             }
         }
 

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Subscriptions/EventMessage.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Subscriptions/EventMessage.cs
@@ -36,7 +36,7 @@ public sealed class EventMessage : IDisposable
         {
             var message = _message;
             ObjectDisposedException.ThrowIf(message is null, this);
-            return message!.Memory.Span.Slice(_bodyStart, _bodyLength);
+            return message.Memory.Span.Slice(_bodyStart, _bodyLength);
         }
     }
 
@@ -53,7 +53,7 @@ public sealed class EventMessage : IDisposable
         {
             var message = _message;
             ObjectDisposedException.ThrowIf(message is null, this);
-            return message!.Memory.Span.Slice(_cursorStart, _cursorLength);
+            return message.Memory.Span.Slice(_cursorStart, _cursorLength);
         }
     }
 

--- a/src/HotChocolate/Fusion/src/Fusion.Subscriptions.AzureEventHubs/AzureEventHubsEventStreamBroker.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Subscriptions.AzureEventHubs/AzureEventHubsEventStreamBroker.cs
@@ -275,9 +275,9 @@ internal sealed class AzureEventHubsEventStreamBroker(AzureEventHubsEventStreamO
 
         return new EventHubConsumerClient(
             options.ConsumerGroup,
-            options.FullyQualifiedNamespace!,
+            options.FullyQualifiedNamespace,
             hub,
-            options.Credential!,
+            options.Credential,
             clientOptions);
     }
 

--- a/src/HotChocolate/Fusion/src/Fusion.Subscriptions.Kafka/KafkaEventStreamBroker.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Subscriptions.Kafka/KafkaEventStreamBroker.cs
@@ -102,7 +102,7 @@ internal sealed class KafkaEventStreamBroker(KafkaEventStreamOptions options)
                     break;
                 }
 
-                yield return message!;
+                yield return message;
             }
         }
         finally

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/FusionTestBase.MatchSnapshot.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/FusionTestBase.MatchSnapshot.cs
@@ -580,7 +580,7 @@ public abstract partial class FusionTestBase
     {
         var streamReader = new StreamReader(body);
         var rawRequestString = streamReader.ReadToEnd();
-        var contentTypeString = contentType.MediaType!;
+        var contentTypeString = contentType.MediaType;
 
         var boundary = contentType.Parameters
             .FirstOrDefault(

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/ProvidesTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/ProvidesTests.cs
@@ -521,12 +521,12 @@ public class ProvidesTests : FusionTestBase
         // 'products' source must be a productById lookup that returns 'name'.
         var reviewsInteractions = gateway.Interactions.GetValueOrDefault("reviews");
         Assert.NotNull(reviewsInteractions);
-        foreach (var interaction in reviewsInteractions!.Values)
+        foreach (var interaction in reviewsInteractions.Values)
         {
             Assert.NotNull(interaction.Request);
-            interaction.Request!.Body.Position = 0;
+            interaction.Request.Body.Position = 0;
             using var body = JsonDocument.Parse(interaction.Request.Body);
-            var query = body.RootElement.GetProperty("query").GetString()!;
+            var query = body.RootElement.GetProperty("query").GetString();
             Assert.DoesNotContain("name", query);
             Assert.Contains("product", query);
             interaction.Request.Body.Position = 0;
@@ -534,12 +534,12 @@ public class ProvidesTests : FusionTestBase
 
         var productsInteractions = gateway.Interactions.GetValueOrDefault("products");
         Assert.NotNull(productsInteractions);
-        foreach (var interaction in productsInteractions!.Values)
+        foreach (var interaction in productsInteractions.Values)
         {
             Assert.NotNull(interaction.Request);
-            interaction.Request!.Body.Position = 0;
+            interaction.Request.Body.Position = 0;
             using var body = JsonDocument.Parse(interaction.Request.Body);
-            var query = body.RootElement.GetProperty("query").GetString()!;
+            var query = body.RootElement.GetProperty("query").GetString();
             Assert.Contains("productById", query);
             Assert.Contains("name", query);
             interaction.Request.Body.Position = 0;

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/RequestGroupingExecutionTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/RequestGroupingExecutionTests.cs
@@ -309,7 +309,7 @@ public sealed class RequestGroupingExecutionTests : FusionTestBase
         foreach (var interaction in interactions.Values)
         {
             Assert.NotNull(interaction.Request);
-            var request = interaction.Request!;
+            var request = interaction.Request;
             request.Body.Position = 0;
 
             using var body = JsonDocument.Parse(request.Body);

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/SemanticIntrospectionTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/SemanticIntrospectionTests.cs
@@ -340,7 +340,7 @@ public class SemanticIntrospectionTests : FusionTestBase
             TestContext.Current.CancellationToken);
 
         using var firstResponse = await firstResult.ReadAsResultAsync(TestContext.Current.CancellationToken);
-        var firstJson = firstResponse.Data.ToString()!;
+        var firstJson = firstResponse.Data.ToString();
         var cursorStart = firstJson.IndexOf("\"cursor\":\"", StringComparison.Ordinal) + 10;
         var cursorEnd = firstJson.IndexOf("\"", cursorStart, StringComparison.Ordinal);
         var cursor = firstJson[cursorStart..cursorEnd];

--- a/src/HotChocolate/Fusion/test/Fusion.Caching.Tests/FusionCachingTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Caching.Tests/FusionCachingTests.cs
@@ -32,7 +32,7 @@ public class FusionCachingTests : FusionTestBase
 
         // assert
         Assert.NotNull(response.Headers.CacheControl);
-        Assert.Equal(TimeSpan.FromSeconds(3600), response.Headers.CacheControl!.MaxAge);
+        Assert.Equal(TimeSpan.FromSeconds(3600), response.Headers.CacheControl.MaxAge);
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class FusionCachingTests : FusionTestBase
 
         // assert
         Assert.NotNull(response.Headers.CacheControl);
-        Assert.Equal(TimeSpan.FromSeconds(1800), response.Headers.CacheControl!.MaxAge);
+        Assert.Equal(TimeSpan.FromSeconds(1800), response.Headers.CacheControl.MaxAge);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class FusionCachingTests : FusionTestBase
 
         // assert
         Assert.NotNull(response.Headers.CacheControl);
-        Assert.True(response.Headers.CacheControl!.Private);
+        Assert.True(response.Headers.CacheControl.Private);
         Assert.Equal(TimeSpan.FromSeconds(3600), response.Headers.CacheControl.MaxAge);
     }
 
@@ -108,7 +108,7 @@ public class FusionCachingTests : FusionTestBase
 
         // assert
         Assert.NotNull(response.Headers.CacheControl);
-        Assert.Equal(TimeSpan.FromSeconds(1800), response.Headers.CacheControl!.SharedMaxAge);
+        Assert.Equal(TimeSpan.FromSeconds(1800), response.Headers.CacheControl.SharedMaxAge);
     }
 
     [Fact]

--- a/src/HotChocolate/Fusion/test/Fusion.Diagnostics.Tests/ActivityTestHelper.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Diagnostics.Tests/ActivityTestHelper.cs
@@ -34,7 +34,7 @@ public static partial class ActivityTestHelper
             // Registered after the exporter so the exporter's OnEnd appends the span before
             // this processor signals idle.
             .AddProcessor(quiescence)
-            .Build()!;
+            .Build();
 
         var capture = new Capture(tracerProvider, exported, quiescence);
         activities = capture;

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Transport/Http/DefaultGraphQLHttpClientTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Transport/Http/DefaultGraphQLHttpClientTests.cs
@@ -1516,7 +1516,7 @@ public class DefaultGraphQLHttpClientTests
         Assert.DoesNotContain("\\u0027", handler.LastBody, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("\\u2019", handler.LastBody, StringComparison.OrdinalIgnoreCase);
 
-        using var body = JsonDocument.Parse(handler.LastBody!);
+        using var body = JsonDocument.Parse(handler.LastBody);
         var serializedDescription = body.RootElement
             .GetProperty("variables")
             .GetProperty("description")

--- a/src/HotChocolate/Marten/test/Data.Marten.Filters.Tests/QueryableFilterVisitorListTests.cs
+++ b/src/HotChocolate/Marten/test/Data.Marten.Filters.Tests/QueryableFilterVisitorListTests.cs
@@ -48,7 +48,7 @@ public class QueryableFilterVisitorListTests
         {
             FooNested =
             [
-                new() { Bar = null! },
+                new() { Bar = null },
                 new() { Bar = "d" },
                 new() { Bar = "b" }
             ]

--- a/src/HotChocolate/MongoDb/src/Data/Sorting/Handlers/MongoDbSortOperationHandlerBase.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Sorting/Handlers/MongoDbSortOperationHandlerBase.cs
@@ -39,7 +39,7 @@ public abstract class MongoDbSortOperationHandlerBase(
             context.ReportError(
                 ErrorHelper.CreateNonNullError(field, node, context));
 
-            action = null!;
+            action = null;
             return false;
         }
 

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/IntegrationTests.cs
@@ -102,7 +102,7 @@ public class IntegrationTests : IClassFixture<RedisResource>
 
         // assert
         Assert.Collection(
-            result.ExpectOperationResult().Errors!,
+            result.ExpectOperationResult().Errors,
             error =>
             {
                 Assert.Equal("The specified persisted operation key is invalid.", error.Message);

--- a/src/HotChocolate/Raven/test/Data.Raven.Filters.Tests/QueryableFilterVisitorListTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Filters.Tests/QueryableFilterVisitorListTests.cs
@@ -39,7 +39,7 @@ public class QueryableFilterVisitorListTests
         {
             FooNested =
             [
-                new() { Bar = null! }, new() { Bar = "d" }, new() { Bar = "b" }
+                new() { Bar = null }, new() { Bar = "d" }, new() { Bar = "b" }
             ]
         }
     ];

--- a/src/Mocha/src/Mocha/Consumers/Consumer.cs
+++ b/src/Mocha/src/Mocha/Consumers/Consumer.cs
@@ -130,7 +130,7 @@ public abstract class Consumer
         Name = Configuration.Name ?? throw ThrowHelper.ConsumerNameRequired();
         Identity ??= GetType();
 
-        foreach (var route in Configuration!.Routes)
+        foreach (var route in Configuration.Routes)
         {
             route.Consumer = this;
 

--- a/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/InboxServiceRegistrationTests.cs
+++ b/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/InboxServiceRegistrationTests.cs
@@ -65,7 +65,7 @@ public sealed class InboxServiceRegistrationTests
 
         // Act
         var optionsMonitor = provider.GetRequiredService<IOptionsMonitor<PostgresMessageInboxOptions>>();
-        var contextName = typeof(TestDbContext).FullName!;
+        var contextName = typeof(TestDbContext).FullName;
         var options = optionsMonitor.Get(contextName);
 
         // Assert

--- a/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/OutboxServiceRegistrationTests.cs
+++ b/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/OutboxServiceRegistrationTests.cs
@@ -77,7 +77,7 @@ public sealed class OutboxServiceRegistrationTests
 
         // Act
         var optionsMonitor = provider.GetRequiredService<IOptionsMonitor<PostgresMessageOutboxOptions>>();
-        var contextName = typeof(TestDbContext).FullName!;
+        var contextName = typeof(TestDbContext).FullName;
         var options = optionsMonitor.Get(contextName);
 
         // Assert

--- a/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/PostgresOutboxIntegrationTests.cs
+++ b/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/PostgresOutboxIntegrationTests.cs
@@ -133,7 +133,7 @@ public sealed class PostgresOutboxIntegrationTests(PostgresFixture fixture) : IC
         using (var scope = provider.CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
-            var messages = await db.Set<OutboxMessage>()!.ToListAsync(TestContext.Current.CancellationToken);
+            var messages = await db.Set<OutboxMessage>().ToListAsync(TestContext.Current.CancellationToken);
             Assert.Equal(count, messages.Count);
         }
 

--- a/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/SagaServiceRegistrationTests.cs
+++ b/src/Mocha/test/Mocha.EntityFrameworkCore.Postgres.Tests/SagaServiceRegistrationTests.cs
@@ -66,7 +66,7 @@ public sealed class SagaServiceRegistrationTests
 
         // Act
         var optionsMonitor = provider.GetRequiredService<IOptionsMonitor<PostgresSagaStoreOptions>>();
-        var contextName = typeof(TestDbContext).FullName!;
+        var contextName = typeof(TestDbContext).FullName;
         var options = optionsMonitor.Get(contextName);
 
         // Assert

--- a/src/Mocha/test/Mocha.Tests/Descriptions/MessageBusDescriptionVisitorTests.cs
+++ b/src/Mocha/test/Mocha.Tests/Descriptions/MessageBusDescriptionVisitorTests.cs
@@ -80,9 +80,9 @@ public class MessageBusDescriptionVisitorTests
 
         // assert
         Assert.NotNull(description.Sagas);
-        Assert.NotEmpty(description.Sagas!);
+        Assert.NotEmpty(description.Sagas);
 
-        var saga = Assert.Single(description.Sagas!);
+        var saga = Assert.Single(description.Sagas);
         Assert.NotEmpty(saga.States);
         Assert.Contains(saga.States, s => s.Name == "__Initial");
 

--- a/src/Mocha/test/Mocha.Tests/Headers/HeadersSerializationTests.cs
+++ b/src/Mocha/test/Mocha.Tests/Headers/HeadersSerializationTests.cs
@@ -18,7 +18,7 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue(key, out var value));
+        Assert.True(result.TryGetValue(key, out var value));
         Assert.Equal(expected, value);
     }
 
@@ -36,7 +36,7 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue(key, out var value));
+        Assert.True(result.TryGetValue(key, out var value));
         Assert.NotNull(value);
     }
 
@@ -54,9 +54,9 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue("dateTime", out var value));
+        Assert.True(result.TryGetValue("dateTime", out var value));
         Assert.IsType<DateTime>(value);
-        var resultDateTime = (DateTime)value!;
+        var resultDateTime = (DateTime)value;
         // DateTime may be deserialized with some precision loss
         Assert.Equal(dateTime.Year, resultDateTime.Year);
         Assert.Equal(dateTime.Month, resultDateTime.Month);
@@ -77,9 +77,9 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue("nested", out var value));
+        Assert.True(result.TryGetValue("nested", out var value));
         Assert.IsType<Dictionary<string, object?>>(value);
-        var dict = (Dictionary<string, object?>)value!;
+        var dict = (Dictionary<string, object?>)value;
         Assert.Equal("innerValue", dict["innerKey"]);
         Assert.Equal(123, dict["innerNumber"]);
     }
@@ -126,9 +126,9 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue(key, out var value));
+        Assert.True(result.TryGetValue(key, out var value));
         Assert.IsType<object[]>(value);
-        var array = (object[])value!;
+        var array = (object[])value;
         Assert.Equal(expected.Length, array.Length);
         for (var i = 0; i < expected.Length; i++)
         {
@@ -154,11 +154,11 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue("items", out var value));
+        Assert.True(result.TryGetValue("items", out var value));
         Assert.IsType<object[]>(value);
-        var array = (object[])value!;
+        var array = (object[])value;
         Assert.Equal(2, array.Length);
-        var first = (Dictionary<string, object?>)array[0]!;
+        var first = (Dictionary<string, object?>)array[0];
         Assert.Equal(1, first["id"]);
         Assert.Equal("first", first["name"]);
     }
@@ -207,7 +207,7 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.Equal(6, result!.Count);
+        Assert.Equal(6, result.Count);
         Assert.True(result.TryGetValue("string", out var strVal));
         Assert.Equal("value", strVal);
         Assert.True(result.TryGetValue("number", out var numVal));
@@ -237,11 +237,11 @@ public class HeadersSerializationTests
         Assert.NotNull(result);
         if (expectedType is null)
         {
-            Assert.Equal(0, result!.Count);
+            Assert.Equal(0, result.Count);
         }
         else
         {
-            Assert.True(result!.TryGetValue(key, out var value));
+            Assert.True(result.TryGetValue(key, out var value));
             Assert.IsType(expectedType, value);
 
             if (value is Dictionary<string, object?> dict)
@@ -266,7 +266,7 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue("key", out var value));
+        Assert.True(result.TryGetValue("key", out var value));
         Assert.Equal("value", value);
     }
 
@@ -281,9 +281,9 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue("nested", out var value));
+        Assert.True(result.TryGetValue("nested", out var value));
         Assert.IsType<Dictionary<string, object?>>(value);
-        var dict = (Dictionary<string, object?>)value!;
+        var dict = (Dictionary<string, object?>)value;
         Assert.Equal("value", dict["inner"]);
         Assert.Equal(42, dict["count"]);
     }
@@ -299,9 +299,9 @@ public class HeadersSerializationTests
 
         // assert
         Assert.NotNull(result);
-        Assert.True(result!.TryGetValue("items", out var value));
+        Assert.True(result.TryGetValue("items", out var value));
         Assert.IsType<object[]>(value);
-        var array = (object[])value!;
+        var array = (object[])value;
         Assert.Equal(3, array.Length);
     }
 

--- a/src/Mocha/test/Mocha.Tests/Headers/HeadersTests.cs
+++ b/src/Mocha/test/Mocha.Tests/Headers/HeadersTests.cs
@@ -227,7 +227,7 @@ public class HeadersTests
         var headers = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(headers);
-        Assert.Equal(0, headers!.Count);
+        Assert.Equal(0, headers.Count);
     }
 
     [Fact]
@@ -238,7 +238,7 @@ public class HeadersTests
         var headers = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(headers);
-        Assert.True(headers!.TryGetValue("key", out var val));
+        Assert.True(headers.TryGetValue("key", out var val));
         Assert.Equal("value", val);
     }
 
@@ -250,7 +250,7 @@ public class HeadersTests
         var headers = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(headers);
-        Assert.True(headers!.TryGetValue("count", out var val));
+        Assert.True(headers.TryGetValue("count", out var val));
         // JSON numbers may deserialize as different numeric types
         Assert.NotNull(val);
     }
@@ -263,7 +263,7 @@ public class HeadersTests
         var headers = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(headers);
-        Assert.True(headers!.TryGetValue("active", out var val));
+        Assert.True(headers.TryGetValue("active", out var val));
         Assert.Equal(true, val);
     }
 
@@ -275,7 +275,7 @@ public class HeadersTests
         var headers = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(headers);
-        Assert.True(headers!.TryGetValue("key", out var val));
+        Assert.True(headers.TryGetValue("key", out var val));
         Assert.Null(val);
     }
 
@@ -287,7 +287,7 @@ public class HeadersTests
         var headers = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(headers);
-        Assert.True(headers!.TryGetValue("nested", out var val));
+        Assert.True(headers.TryGetValue("nested", out var val));
         Assert.NotNull(val);
     }
 
@@ -299,7 +299,7 @@ public class HeadersTests
         var headers = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(headers);
-        Assert.True(headers!.TryGetValue("items", out var val));
+        Assert.True(headers.TryGetValue("items", out var val));
         Assert.NotNull(val);
     }
 
@@ -314,9 +314,9 @@ public class HeadersTests
         var deserialized = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(deserialized);
-        Assert.True(deserialized!.TryGetValue("key1", out var v1));
+        Assert.True(deserialized.TryGetValue("key1", out var v1));
         Assert.Equal("value1", v1);
-        Assert.True(deserialized!.TryGetValue("key2", out var v2));
+        Assert.True(deserialized.TryGetValue("key2", out var v2));
         Assert.Equal("value2", v2);
     }
 
@@ -331,7 +331,7 @@ public class HeadersTests
         var deserialized = JsonSerializer.Deserialize<IHeaders>(json, HeadersJsonConverter.Options);
 
         Assert.NotNull(deserialized);
-        Assert.True(deserialized!.TryGetValue("str", out var s));
+        Assert.True(deserialized.TryGetValue("str", out var s));
         Assert.Equal("hello", s);
     }
 }

--- a/src/Mocha/test/Mocha.Tests/MessageBusChangeTokenSourceTests.cs
+++ b/src/Mocha/test/Mocha.Tests/MessageBusChangeTokenSourceTests.cs
@@ -181,7 +181,7 @@ public sealed class MessageBusChangeTokenSourceTests
         // assert
         Assert.NotNull(nextToken);
         Assert.NotSame(token, nextToken);
-        Assert.False(nextToken!.HasChanged);
+        Assert.False(nextToken.HasChanged);
     }
 
     [Fact]
@@ -224,7 +224,7 @@ public sealed class MessageBusChangeTokenSourceTests
         // assert
         Assert.NotNull(nextToken);
         Assert.NotSame(token, nextToken);
-        Assert.False(nextToken!.HasChanged);
+        Assert.False(nextToken.HasChanged);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Tests/Serialization/SerializationTests.cs
+++ b/src/Mocha/test/Mocha.Tests/Serialization/SerializationTests.cs
@@ -160,7 +160,7 @@ public class SerializationTests
 
         // assert
         Assert.NotNull(parsed);
-        Assert.Equal("application/msgpack", parsed!.Value);
+        Assert.Equal("application/msgpack", parsed.Value);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Tests/Topology/ChangeTokenSourceTests.cs
+++ b/src/Mocha/test/Mocha.Tests/Topology/ChangeTokenSourceTests.cs
@@ -50,7 +50,7 @@ public sealed class ChangeTokenSourceTests
         // assert
         Assert.NotNull(nextToken);
         Assert.NotSame(token, nextToken);
-        Assert.False(nextToken!.HasChanged);
+        Assert.False(nextToken.HasChanged);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Tests/Transport/MessageEnvelopeReaderTests.cs
+++ b/src/Mocha/test/Mocha.Tests/Transport/MessageEnvelopeReaderTests.cs
@@ -51,9 +51,9 @@ public class MessageEnvelopeReaderTests
         Assert.NotNull(envelope.DeliverBy);
         Assert.Equal(1, envelope.DeliveryCount);
         Assert.NotNull(envelope.EnclosedMessageTypes);
-        Assert.Equal(2, envelope.EnclosedMessageTypes!.Value.Length);
-        Assert.Equal("urn:message:TestEvent", envelope.EnclosedMessageTypes!.Value[0]);
-        Assert.Equal("urn:message:IEvent", envelope.EnclosedMessageTypes!.Value[1]);
+        Assert.Equal(2, envelope.EnclosedMessageTypes.Value.Length);
+        Assert.Equal("urn:message:TestEvent", envelope.EnclosedMessageTypes.Value[0]);
+        Assert.Equal("urn:message:IEvent", envelope.EnclosedMessageTypes.Value[1]);
         Assert.NotNull(envelope.Headers);
         Assert.False(envelope.Body.IsEmpty);
     }
@@ -104,7 +104,7 @@ public class MessageEnvelopeReaderTests
         var envelope = MessageEnvelopeReader.Parse(ToBytes(json));
 
         Assert.NotNull(envelope.EnclosedMessageTypes);
-        Assert.Empty(envelope.EnclosedMessageTypes!.Value);
+        Assert.Empty(envelope.EnclosedMessageTypes.Value);
     }
 
     [Fact]
@@ -115,8 +115,8 @@ public class MessageEnvelopeReaderTests
         var envelope = MessageEnvelopeReader.Parse(ToBytes(json));
 
         Assert.NotNull(envelope.EnclosedMessageTypes);
-        Assert.Single(envelope.EnclosedMessageTypes!.Value);
-        Assert.Equal("urn:message:Foo", envelope.EnclosedMessageTypes!.Value[0]);
+        Assert.Single(envelope.EnclosedMessageTypes.Value);
+        Assert.Equal("urn:message:Foo", envelope.EnclosedMessageTypes.Value[0]);
     }
 
     [Fact]
@@ -150,9 +150,9 @@ public class MessageEnvelopeReaderTests
         var envelope = MessageEnvelopeReader.Parse(ToBytes(json));
 
         Assert.NotNull(envelope.SentAt);
-        Assert.Equal(2026, envelope.SentAt!.Value.Year);
-        Assert.Equal(1, envelope.SentAt!.Value.Month);
-        Assert.Equal(15, envelope.SentAt!.Value.Day);
+        Assert.Equal(2026, envelope.SentAt.Value.Year);
+        Assert.Equal(1, envelope.SentAt.Value.Month);
+        Assert.Equal(15, envelope.SentAt.Value.Day);
     }
 
     [Fact]
@@ -163,9 +163,9 @@ public class MessageEnvelopeReaderTests
         var envelope = MessageEnvelopeReader.Parse(ToBytes(json));
 
         Assert.NotNull(envelope.DeliverBy);
-        Assert.Equal(2026, envelope.DeliverBy!.Value.Year);
-        Assert.Equal(6, envelope.DeliverBy!.Value.Month);
-        Assert.Equal(1, envelope.DeliverBy!.Value.Day);
+        Assert.Equal(2026, envelope.DeliverBy.Value.Year);
+        Assert.Equal(6, envelope.DeliverBy.Value.Month);
+        Assert.Equal(1, envelope.DeliverBy.Value.Day);
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class MessageEnvelopeReaderTests
         var envelope = MessageEnvelopeReader.Parse(ToBytes(json));
 
         Assert.NotNull(envelope.Headers);
-        Assert.True(envelope.Headers!.TryGetValue("custom-key", out var value));
+        Assert.True(envelope.Headers.TryGetValue("custom-key", out var value));
         Assert.Equal("custom-value", value);
     }
 
@@ -234,9 +234,9 @@ public class MessageEnvelopeReaderTests
         var envelope = MessageEnvelopeReader.Parse(ToBytes(json));
 
         Assert.NotNull(envelope.ScheduledTime);
-        Assert.Equal(2026, envelope.ScheduledTime!.Value.Year);
-        Assert.Equal(6, envelope.ScheduledTime!.Value.Month);
-        Assert.Equal(1, envelope.ScheduledTime!.Value.Day);
+        Assert.Equal(2026, envelope.ScheduledTime.Value.Year);
+        Assert.Equal(6, envelope.ScheduledTime.Value.Month);
+        Assert.Equal(1, envelope.ScheduledTime.Value.Day);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Tests/Transport/MessageEnvelopeWriterTests.cs
+++ b/src/Mocha/test/Mocha.Tests/Transport/MessageEnvelopeWriterTests.cs
@@ -30,7 +30,7 @@ public class MessageEnvelopeWriterTests
             Headers = new Headers(),
             Body = """{"orderId":"1"}"""u8.ToArray()
         };
-        envelope.Headers!.Set("x-trace", "abc123");
+        envelope.Headers.Set("x-trace", "abc123");
 
         using var stream = new MemoryStream();
         using var writer = new Utf8JsonWriter(stream);
@@ -444,7 +444,7 @@ public class MessageEnvelopeWriterTests
             Headers = new Headers(),
             Body = """{"orderId":"1"}"""u8.ToArray()
         };
-        original.Headers!.Set("x-trace", "abc123");
+        original.Headers.Set("x-trace", "abc123");
 
         // act - write
         using var stream = new MemoryStream();
@@ -471,9 +471,9 @@ public class MessageEnvelopeWriterTests
         Assert.Equal(original.DeliverBy, result.DeliverBy);
         Assert.Equal(original.DeliveryCount, result.DeliveryCount);
         Assert.NotNull(result.EnclosedMessageTypes);
-        Assert.Equal(2, result.EnclosedMessageTypes!.Value.Length);
+        Assert.Equal(2, result.EnclosedMessageTypes.Value.Length);
         Assert.NotNull(result.Headers);
-        Assert.True(result.Headers!.TryGetValue("x-trace", out var traceValue));
+        Assert.True(result.Headers.TryGetValue("x-trace", out var traceValue));
         Assert.Equal("abc123", traceValue);
         Assert.False(result.Body.IsEmpty);
     }
@@ -523,7 +523,7 @@ public class MessageEnvelopeWriterTests
 
         // assert
         Assert.NotNull(result.EnclosedMessageTypes);
-        Assert.Empty(result.EnclosedMessageTypes!.Value);
+        Assert.Empty(result.EnclosedMessageTypes.Value);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.InMemory.Tests/InMemoryTransportTests.cs
+++ b/src/Mocha/test/Mocha.Transport.InMemory.Tests/InMemoryTransportTests.cs
@@ -27,7 +27,7 @@ public class InMemoryTransportTests
         // assert
         Assert.True(found, "TryGetDispatchEndpoint should resolve queue:// URI");
         Assert.NotNull(endpoint);
-        Assert.IsType<InMemoryQueue>(endpoint!.Destination);
+        Assert.IsType<InMemoryQueue>(endpoint.Destination);
         var queue = (InMemoryQueue)endpoint.Destination;
         Assert.Equal("process-payment", queue.Name);
     }
@@ -51,7 +51,7 @@ public class InMemoryTransportTests
         var topicEndpoint = transport.DispatchEndpoints.FirstOrDefault(e => e.Destination is InMemoryTopic);
 
         Assert.NotNull(topicEndpoint);
-        var topicName = ((InMemoryTopic)topicEndpoint!.Destination).Name;
+        var topicName = ((InMemoryTopic)topicEndpoint.Destination).Name;
 
         var topicUri = new Uri($"topic://{topicName}");
 
@@ -61,7 +61,7 @@ public class InMemoryTransportTests
         // assert
         Assert.True(found, "TryGetDispatchEndpoint should resolve topic:// URI");
         Assert.NotNull(endpoint);
-        Assert.IsType<InMemoryTopic>(endpoint!.Destination);
+        Assert.IsType<InMemoryTopic>(endpoint.Destination);
         Assert.Equal(topicName, ((InMemoryTopic)endpoint.Destination).Name);
     }
 
@@ -133,7 +133,7 @@ public class InMemoryTransportTests
 
         Assert.NotNull(dispatchEndpoint);
 
-        var destinationAddress = dispatchEndpoint!.Destination.Address;
+        var destinationAddress = dispatchEndpoint.Destination.Address;
 
         // act
         var found = transport.TryGetDispatchEndpoint(destinationAddress, out var endpoint);
@@ -277,7 +277,7 @@ public class InMemoryTransportTests
 
         // assert - topology should contain topic entities
         Assert.NotNull(description.Topology);
-        Assert.Contains(description.Topology!.Entities, e => e.Kind == "topic");
+        Assert.Contains(description.Topology.Entities, e => e.Kind == "topic");
     }
 
     [Fact]
@@ -298,7 +298,7 @@ public class InMemoryTransportTests
 
         // assert - topology should contain queue entities
         Assert.NotNull(description.Topology);
-        Assert.Contains(description.Topology!.Entities, e => e.Kind == "queue");
+        Assert.Contains(description.Topology.Entities, e => e.Kind == "queue");
     }
 
     [Fact]
@@ -319,7 +319,7 @@ public class InMemoryTransportTests
 
         // assert - topology should contain links for bindings
         Assert.NotNull(description.Topology);
-        Assert.NotEmpty(description.Topology!.Links);
+        Assert.NotEmpty(description.Topology.Links);
         Assert.All(
             description.Topology.Links,
             link =>
@@ -416,7 +416,7 @@ public class InMemoryTransportTests
 
         // assert - there should be a link representing the topic-to-topic binding
         Assert.NotNull(description.Topology);
-        Assert.NotEmpty(description.Topology!.Links);
+        Assert.NotEmpty(description.Topology.Links);
 
         // The topic-to-topic binding link has the address path containing /b/t/source/t/dest
         var topicToTopicLink = Assert.Single(
@@ -539,7 +539,7 @@ public class InMemoryTransportTests
         );
 
         Assert.NotNull(queueEndpoint);
-        Assert.StartsWith("q/", queueEndpoint!.Name);
+        Assert.StartsWith("q/", queueEndpoint.Name);
     }
 
     [Fact]
@@ -559,7 +559,7 @@ public class InMemoryTransportTests
         var topicEndpoint = transport.DispatchEndpoints.FirstOrDefault(e => e.Destination is InMemoryTopic);
 
         Assert.NotNull(topicEndpoint);
-        Assert.StartsWith("t/", topicEndpoint!.Name);
+        Assert.StartsWith("t/", topicEndpoint.Name);
     }
 
     [Fact]
@@ -670,7 +670,7 @@ public class InMemoryTransportTests
 
         // assert - should have queue entity for process-payment
         Assert.NotNull(description.Topology);
-        Assert.Contains(description.Topology!.Entities, e => e.Kind == "queue" && e.Name == "process-payment");
+        Assert.Contains(description.Topology.Entities, e => e.Kind == "queue" && e.Name == "process-payment");
     }
 
     [Fact]
@@ -692,7 +692,7 @@ public class InMemoryTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        var topicCount = description.Topology!.Entities.Count(e => e.Kind == "topic");
+        var topicCount = description.Topology.Entities.Count(e => e.Kind == "topic");
         var queueCount = description.Topology.Entities.Count(e => e.Kind == "queue");
 
         // Both event handler (creates topic + queue) and request handler (creates queue) contribute
@@ -719,7 +719,7 @@ public class InMemoryTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.Equal(topology.Address.ToString(), description.Topology!.Address);
+        Assert.Equal(topology.Address.ToString(), description.Topology.Address);
         Assert.Equal(topology.Address.ToString(), description.Identifier);
     }
 
@@ -745,7 +745,7 @@ public class InMemoryTransportTests
         Assert.StartsWith("t/", topicDispatch.Name);
         Assert.Equal(DispatchEndpointKind.Default, topicDispatch.Kind);
         Assert.NotNull(topicDispatch.Address);
-        Assert.Contains("/t/", topicDispatch.Address!.AbsolutePath);
+        Assert.Contains("/t/", topicDispatch.Address.AbsolutePath);
     }
 
     [Fact]
@@ -772,7 +772,7 @@ public class InMemoryTransportTests
         Assert.StartsWith("q/", queueDispatch.Name);
         Assert.Equal(DispatchEndpointKind.Default, queueDispatch.Kind);
         Assert.NotNull(queueDispatch.Address);
-        Assert.Contains("/q/", queueDispatch.Address!.AbsolutePath);
+        Assert.Contains("/q/", queueDispatch.Address.AbsolutePath);
     }
 
     [Fact]
@@ -849,7 +849,7 @@ public class InMemoryTransportTests
 
         // assert - binding address should contain path segments b/t/source/q/dest
         Assert.NotNull(queueBinding.Address);
-        var path = queueBinding.Address!.AbsolutePath;
+        var path = queueBinding.Address.AbsolutePath;
         Assert.Contains("/b/t/addr-source/q/addr-dest", path);
     }
 
@@ -874,7 +874,7 @@ public class InMemoryTransportTests
 
         // assert - binding address should contain path segments b/t/source/t/dest
         Assert.NotNull(topicBinding.Address);
-        var path = topicBinding.Address!.AbsolutePath;
+        var path = topicBinding.Address.AbsolutePath;
         Assert.Contains("/b/t/addr-source-t/t/addr-dest-t", path);
     }
 

--- a/src/Mocha/test/Mocha.Transport.InMemory.Tests/Topology/InMemoryMessagingTopologyTests.cs
+++ b/src/Mocha/test/Mocha.Transport.InMemory.Tests/Topology/InMemoryMessagingTopologyTests.cs
@@ -16,7 +16,7 @@ public class InMemoryMessagingTopologyTests
         var config = new InMemoryTopicConfiguration { Name = "test-topic" };
 
         // act
-        var topic = topology!.AddTopic(config);
+        var topic = topology.AddTopic(config);
 
         // assert
         Assert.Equal("test-topic", topic.Name);
@@ -34,7 +34,7 @@ public class InMemoryMessagingTopologyTests
         var config1 = new InMemoryTopicConfiguration { Name = "duplicate-topic" };
         var config2 = new InMemoryTopicConfiguration { Name = "duplicate-topic" };
 
-        var first = topology!.AddTopic(config1);
+        var first = topology.AddTopic(config1);
         var countAfterFirst = topology.Topics.Count;
 
         // act
@@ -56,7 +56,7 @@ public class InMemoryMessagingTopologyTests
         var config = new InMemoryQueueConfiguration { Name = "test-queue" };
 
         // act
-        var queue = topology!.AddQueue(config);
+        var queue = topology.AddQueue(config);
 
         // assert
         Assert.Equal("test-queue", queue.Name);
@@ -74,7 +74,7 @@ public class InMemoryMessagingTopologyTests
         var config1 = new InMemoryQueueConfiguration { Name = "duplicate-queue" };
         var config2 = new InMemoryQueueConfiguration { Name = "duplicate-queue" };
 
-        var first = topology!.AddQueue(config1);
+        var first = topology.AddQueue(config1);
         var countAfterFirst = topology.Queues.Count;
 
         // act
@@ -93,7 +93,7 @@ public class InMemoryMessagingTopologyTests
         var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
-        topology!.AddTopic(new InMemoryTopicConfiguration { Name = "source-topic" });
+        topology.AddTopic(new InMemoryTopicConfiguration { Name = "source-topic" });
         topology.AddQueue(new InMemoryQueueConfiguration { Name = "destination-queue" });
 
         var bindingConfig = new InMemoryBindingConfiguration
@@ -124,7 +124,7 @@ public class InMemoryMessagingTopologyTests
         var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
-        topology!.AddTopic(new InMemoryTopicConfiguration { Name = "source-topic" });
+        topology.AddTopic(new InMemoryTopicConfiguration { Name = "source-topic" });
         topology.AddTopic(new InMemoryTopicConfiguration { Name = "destination-topic" });
 
         var bindingConfig = new InMemoryBindingConfiguration
@@ -155,7 +155,7 @@ public class InMemoryMessagingTopologyTests
         var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
-        topology!.AddQueue(new InMemoryQueueConfiguration { Name = "destination-queue" });
+        topology.AddQueue(new InMemoryQueueConfiguration { Name = "destination-queue" });
 
         var bindingConfig = new InMemoryBindingConfiguration
         {
@@ -178,7 +178,7 @@ public class InMemoryMessagingTopologyTests
         var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
-        topology!.AddTopic(new InMemoryTopicConfiguration { Name = "source-topic" });
+        topology.AddTopic(new InMemoryTopicConfiguration { Name = "source-topic" });
 
         var bindingConfig = new InMemoryBindingConfiguration
         {
@@ -202,7 +202,7 @@ public class InMemoryMessagingTopologyTests
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
         // act
-        var topic = topology!.GetTopic("nonexistent-topic");
+        var topic = topology.GetTopic("nonexistent-topic");
 
         // assert
         Assert.Null(topic);
@@ -216,7 +216,7 @@ public class InMemoryMessagingTopologyTests
         var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
-        var addedTopic = topology!.AddTopic(new InMemoryTopicConfiguration { Name = "my-topic" });
+        var addedTopic = topology.AddTopic(new InMemoryTopicConfiguration { Name = "my-topic" });
 
         // act
         var foundTopic = topology.GetTopic("my-topic");
@@ -235,7 +235,7 @@ public class InMemoryMessagingTopologyTests
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
         // act
-        var queue = topology!.GetQueue("nonexistent-queue");
+        var queue = topology.GetQueue("nonexistent-queue");
 
         // assert
         Assert.Null(queue);
@@ -249,7 +249,7 @@ public class InMemoryMessagingTopologyTests
         var transport = runtime.Transports.OfType<InMemoryMessagingTransport>().Single();
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
-        var addedQueue = topology!.AddQueue(new InMemoryQueueConfiguration { Name = "my-queue" });
+        var addedQueue = topology.AddQueue(new InMemoryQueueConfiguration { Name = "my-queue" });
 
         // act
         var foundQueue = topology.GetQueue("my-queue");
@@ -268,7 +268,7 @@ public class InMemoryMessagingTopologyTests
         var topology = (InMemoryMessagingTopology)transport.Topology;
 
         // Record initial state - the runtime may pre-create some resources
-        var initialTopicCount = topology!.Topics.Count;
+        var initialTopicCount = topology.Topics.Count;
         var initialQueueCount = topology.Queues.Count;
 
         const int operationCount = 100;

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/Conventions/PostgresDefaultConventionTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/Conventions/PostgresDefaultConventionTests.cs
@@ -18,7 +18,7 @@ public class PostgresDefaultConventionTests
         // assert
         var feature = receiveEndpoint.Features.Get<ReceiveFaultEndpointFeature>();
         Assert.NotNull(feature?.Endpoint);
-        Assert.Contains("_error", feature.Endpoint!.Name);
+        Assert.Contains("_error", feature.Endpoint.Name);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class PostgresDefaultConventionTests
         // assert
         var feature = receiveEndpoint.Features.Get<ReceiveSkippedEndpointFeature>();
         Assert.NotNull(feature?.Endpoint);
-        Assert.Contains("_skipped", feature.Endpoint!.Name);
+        Assert.Contains("_skipped", feature.Endpoint.Name);
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class PostgresDefaultConventionTests
         // assert
         var errorEndpoint = receiveEndpoint.Features.Get<ReceiveFaultEndpointFeature>()?.Endpoint;
         Assert.NotNull(errorEndpoint);
-        var errorDest = errorEndpoint!.Destination;
+        var errorDest = errorEndpoint.Destination;
         Assert.IsType<PostgresQueue>(errorDest);
         Assert.EndsWith("_error", ((PostgresQueue)errorDest).Name);
     }
@@ -79,7 +79,7 @@ public class PostgresDefaultConventionTests
         // assert
         var skippedEndpoint = receiveEndpoint.Features.Get<ReceiveSkippedEndpointFeature>()?.Endpoint;
         Assert.NotNull(skippedEndpoint);
-        var skippedDest = skippedEndpoint!.Destination;
+        var skippedDest = skippedEndpoint.Destination;
         Assert.IsType<PostgresQueue>(skippedDest);
         Assert.EndsWith("_skipped", ((PostgresQueue)skippedDest).Name);
     }
@@ -108,7 +108,7 @@ public class PostgresDefaultConventionTests
         // assert
         var errorEndpoint = receiveEndpoint.Features.Get<ReceiveFaultEndpointFeature>()?.Endpoint;
         Assert.NotNull(errorEndpoint);
-        Assert.IsType<PostgresQueue>(errorEndpoint!.Destination);
+        Assert.IsType<PostgresQueue>(errorEndpoint.Destination);
         Assert.Equal("custom-error-q", ((PostgresQueue)errorEndpoint.Destination).Name);
     }
 

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/Descriptors/PostgresDescriptorTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/Descriptors/PostgresDescriptorTests.cs
@@ -58,7 +58,7 @@ public class PostgresDescriptorTests
         Assert.IsType<PostgresQueue>(endpoint.Destination);
         Assert.Equal("my-q", ((PostgresQueue)endpoint.Destination).Name);
         Assert.NotNull(endpoint.Queue);
-        Assert.Equal("my-q", endpoint.Queue!.Name);
+        Assert.Equal("my-q", endpoint.Queue.Name);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class PostgresDescriptorTests
         Assert.IsType<PostgresTopic>(endpoint.Destination);
         Assert.Equal("my-t", ((PostgresTopic)endpoint.Destination).Name);
         Assert.NotNull(endpoint.Topic);
-        Assert.Equal("my-t", endpoint.Topic!.Name);
+        Assert.Equal("my-t", endpoint.Topic.Name);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/Descriptors/PostgresTopologyDescriptorTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/Descriptors/PostgresTopologyDescriptorTests.cs
@@ -79,7 +79,7 @@ public class PostgresTopologyDescriptorTests
         // assert
         var subscription = Assert.Single(topology.Subscriptions);
         Assert.NotNull(subscription.Address);
-        Assert.Contains("/b/t/addr-src/q/addr-dst", subscription.Address!.AbsolutePath);
+        Assert.Contains("/b/t/addr-src/q/addr-dst", subscription.Address.AbsolutePath);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/ErrorInfoTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/ErrorInfoTests.cs
@@ -91,7 +91,7 @@ public class ErrorInfoTests
 
         // assert
         Assert.NotNull(errorInfo);
-        Assert.Equal("ArgumentException", errorInfo!.ExceptionType);
+        Assert.Equal("ArgumentException", errorInfo.ExceptionType);
         Assert.Equal("Bad arg", errorInfo.Message);
         Assert.Null(errorInfo.StackTrace);
     }

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresDispatchEndpointTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresDispatchEndpointTests.cs
@@ -22,7 +22,7 @@ public class PostgresDispatchEndpointTests
 
         // assert
         Assert.NotNull(endpoint.Queue);
-        Assert.Equal("my-q", endpoint.Queue!.Name);
+        Assert.Equal("my-q", endpoint.Queue.Name);
         Assert.Null(endpoint.Topic);
         Assert.IsType<PostgresQueue>(endpoint.Destination);
     }
@@ -45,7 +45,7 @@ public class PostgresDispatchEndpointTests
 
         // assert
         Assert.NotNull(endpoint.Topic);
-        Assert.Equal("my-t", endpoint.Topic!.Name);
+        Assert.Equal("my-t", endpoint.Topic.Name);
         Assert.Null(endpoint.Queue);
         Assert.IsType<PostgresTopic>(endpoint.Destination);
     }

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresDispatchHeaderTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresDispatchHeaderTests.cs
@@ -86,7 +86,7 @@ public class PostgresDispatchHeaderTests
 
         // assert
         Assert.NotNull(parsed.EnclosedMessageTypes);
-        Assert.Equal(2, parsed.EnclosedMessageTypes!.Value.Length);
+        Assert.Equal(2, parsed.EnclosedMessageTypes.Value.Length);
         Assert.Equal("urn:message:OrderCreated", parsed.EnclosedMessageTypes.Value[0]);
         Assert.Equal("urn:message:IEvent", parsed.EnclosedMessageTypes.Value[1]);
     }
@@ -116,7 +116,7 @@ public class PostgresDispatchHeaderTests
 
         // assert
         Assert.NotNull(parsed.DeliverBy);
-        Assert.Equal(deliverBy, parsed.DeliverBy!.Value);
+        Assert.Equal(deliverBy, parsed.DeliverBy.Value);
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class PostgresDispatchHeaderTests
 
         // assert
         Assert.NotNull(parsed.Headers);
-        Assert.True(parsed.Headers!.TryGetValue("x-tenant", out var tenantValue));
+        Assert.True(parsed.Headers.TryGetValue("x-tenant", out var tenantValue));
         Assert.Equal("acme", tenantValue);
         Assert.True(parsed.Headers.TryGetValue("x-priority", out var priorityValue));
         Assert.Equal(5.0, priorityValue);

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresHandlerClaimTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresHandlerClaimTests.cs
@@ -20,7 +20,7 @@ public class PostgresHandlerClaimTests
             .SingleOrDefault(e => e.Name == "order-created");
 
         Assert.NotNull(endpoint);
-        Assert.Equal(ReceiveEndpointKind.Default, endpoint!.Kind);
+        Assert.Equal(ReceiveEndpointKind.Default, endpoint.Kind);
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class PostgresHandlerClaimTests
             .SingleOrDefault(e => e.Queue.Name == "custom-handler-queue");
 
         Assert.NotNull(endpoint);
-        Assert.Equal("custom-handler-queue", endpoint!.Queue.Name);
+        Assert.Equal("custom-handler-queue", endpoint.Queue.Name);
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class PostgresHandlerClaimTests
             .SingleOrDefault(e => e.Name == "order-spy");
 
         Assert.NotNull(endpoint);
-        Assert.Equal(ReceiveEndpointKind.Default, endpoint!.Kind);
+        Assert.Equal(ReceiveEndpointKind.Default, endpoint.Kind);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresMessageEnvelopeParserTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresMessageEnvelopeParserTests.cs
@@ -229,7 +229,7 @@ public class PostgresMessageEnvelopeParserTests
 
         // assert
         Assert.NotNull(envelope.EnclosedMessageTypes);
-        Assert.Equal(2, envelope.EnclosedMessageTypes!.Value.Length);
+        Assert.Equal(2, envelope.EnclosedMessageTypes.Value.Length);
         Assert.Equal("OrderCreated", envelope.EnclosedMessageTypes.Value[0]);
         Assert.Equal("IEvent", envelope.EnclosedMessageTypes.Value[1]);
     }
@@ -343,7 +343,7 @@ public class PostgresMessageEnvelopeParserTests
 
         // assert
         Assert.NotNull(envelope.ScheduledTime);
-        Assert.Equal(2026, envelope.ScheduledTime!.Value.Year);
+        Assert.Equal(2026, envelope.ScheduledTime.Value.Year);
         Assert.Equal(6, envelope.ScheduledTime.Value.Month);
         Assert.Equal(1, envelope.ScheduledTime.Value.Day);
         Assert.Equal(12, envelope.ScheduledTime.Value.Hour);

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresTransportTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/PostgresTransportTests.cs
@@ -55,7 +55,7 @@ public class PostgresTransportTests
         // assert
         Assert.True(found, "TryGetDispatchEndpoint should resolve queue:// URI");
         Assert.NotNull(endpoint);
-        Assert.IsType<PostgresQueue>(endpoint!.Destination);
+        Assert.IsType<PostgresQueue>(endpoint.Destination);
         Assert.Equal("payment", ((PostgresQueue)endpoint.Destination).Name);
     }
 
@@ -78,7 +78,7 @@ public class PostgresTransportTests
         // assert
         Assert.True(found, "TryGetDispatchEndpoint should resolve topic:// URI");
         Assert.NotNull(endpoint);
-        Assert.IsType<PostgresTopic>(endpoint!.Destination);
+        Assert.IsType<PostgresTopic>(endpoint.Destination);
         Assert.Equal("events", ((PostgresTopic)endpoint.Destination).Name);
     }
 
@@ -136,7 +136,7 @@ public class PostgresTransportTests
             e.Destination?.Address != null && topology.Address.IsBaseOf(e.Destination.Address));
 
         Assert.NotNull(dispatchEndpoint);
-        var destinationAddress = dispatchEndpoint!.Destination.Address;
+        var destinationAddress = dispatchEndpoint.Destination.Address;
 
         // act
         var found = transport.TryGetDispatchEndpoint(destinationAddress, out var endpoint);
@@ -241,7 +241,7 @@ public class PostgresTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.Contains(description.Topology!.Entities, e => e.Kind == "topic" && e.Name == "my-events");
+        Assert.Contains(description.Topology.Entities, e => e.Kind == "topic" && e.Name == "my-events");
     }
 
     [Fact]
@@ -256,7 +256,7 @@ public class PostgresTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.Contains(description.Topology!.Entities, e => e.Kind == "queue" && e.Name == "my-queue");
+        Assert.Contains(description.Topology.Entities, e => e.Kind == "queue" && e.Name == "my-queue");
     }
 
     [Fact]
@@ -276,7 +276,7 @@ public class PostgresTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.NotEmpty(description.Topology!.Links);
+        Assert.NotEmpty(description.Topology.Links);
         var link = Assert.Single(description.Topology.Links);
         Assert.Equal("subscription", link.Kind);
         Assert.Equal("forward", link.Direction);
@@ -295,7 +295,7 @@ public class PostgresTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.Equal(topology.Address.ToString(), description.Topology!.Address);
+        Assert.Equal(topology.Address.ToString(), description.Topology.Address);
         Assert.Equal(topology.Address.ToString(), description.Identifier);
     }
 
@@ -319,7 +319,7 @@ public class PostgresTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.True(description.Topology!.Entities.Count(e => e.Kind == "topic") >= 2);
+        Assert.True(description.Topology.Entities.Count(e => e.Kind == "topic") >= 2);
         Assert.True(description.Topology.Entities.Count(e => e.Kind == "queue") >= 2);
         Assert.True(description.Topology.Links.Count >= 2);
     }
@@ -340,7 +340,7 @@ public class PostgresTransportTests
             .FirstOrDefault(e => e.Destination is PostgresQueue && e.Kind == DispatchEndpointKind.Default);
 
         Assert.NotNull(queueEndpoint);
-        Assert.IsType<PostgresQueue>(queueEndpoint!.Destination);
+        Assert.IsType<PostgresQueue>(queueEndpoint.Destination);
         Assert.Equal("process-payment", ((PostgresQueue)queueEndpoint.Destination).Name);
     }
 
@@ -360,7 +360,7 @@ public class PostgresTransportTests
             .FirstOrDefault(e => e.Destination is PostgresTopic);
 
         Assert.NotNull(topicEndpoint);
-        Assert.IsType<PostgresTopic>(topicEndpoint!.Destination);
+        Assert.IsType<PostgresTopic>(topicEndpoint.Destination);
         Assert.Equal("order-created", ((PostgresTopic)topicEndpoint.Destination).Name);
     }
 
@@ -384,7 +384,7 @@ public class PostgresTransportTests
         Assert.NotEmpty(queueEndpoints);
         var queueDispatch = queueEndpoints.First();
         Assert.NotNull(queueDispatch.Destination?.Address);
-        Assert.Contains("/q/", queueDispatch.Destination!.Address!.AbsolutePath);
+        Assert.Contains("/q/", queueDispatch.Destination.Address.AbsolutePath);
     }
 
     [Fact]
@@ -407,7 +407,7 @@ public class PostgresTransportTests
         Assert.NotEmpty(topicEndpoints);
         var topicDispatch = topicEndpoints.First();
         Assert.NotNull(topicDispatch.Destination?.Address);
-        Assert.Contains("/t/", topicDispatch.Destination!.Address!.AbsolutePath);
+        Assert.Contains("/t/", topicDispatch.Destination.Address.AbsolutePath);
     }
 
     [Fact]
@@ -587,11 +587,11 @@ public class PostgresTransportTests
         // assert
         var faultFeature = receiveEndpoint.Features.Get<ReceiveFaultEndpointFeature>();
         Assert.NotNull(faultFeature?.Endpoint);
-        Assert.Contains("_error", faultFeature.Endpoint!.Name);
+        Assert.Contains("_error", faultFeature.Endpoint.Name);
 
         var skippedFeature = receiveEndpoint.Features.Get<ReceiveSkippedEndpointFeature>();
         Assert.NotNull(skippedFeature?.Endpoint);
-        Assert.Contains("_skipped", skippedFeature.Endpoint!.Name);
+        Assert.Contains("_skipped", skippedFeature.Endpoint.Name);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/Topology/PostgresMessageTypeExtensionTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/Topology/PostgresMessageTypeExtensionTests.cs
@@ -13,7 +13,7 @@ public class PostgresMessageTypeExtensionTests
 
         // assert
         Assert.NotNull(descriptor.DestinationUri);
-        Assert.Equal("postgres", descriptor.DestinationUri!.Scheme);
+        Assert.Equal("postgres", descriptor.DestinationUri.Scheme);
         Assert.Contains("q/my-queue", descriptor.DestinationUri.OriginalString);
     }
 
@@ -28,7 +28,7 @@ public class PostgresMessageTypeExtensionTests
 
         // assert
         Assert.NotNull(descriptor.DestinationUri);
-        Assert.Equal("custom", descriptor.DestinationUri!.Scheme);
+        Assert.Equal("custom", descriptor.DestinationUri.Scheme);
         Assert.Contains("q/my-queue", descriptor.DestinationUri.OriginalString);
     }
 
@@ -43,7 +43,7 @@ public class PostgresMessageTypeExtensionTests
 
         // assert
         Assert.NotNull(descriptor.DestinationUri);
-        Assert.Equal("postgres", descriptor.DestinationUri!.Scheme);
+        Assert.Equal("postgres", descriptor.DestinationUri.Scheme);
         Assert.Contains("t/my-topic", descriptor.DestinationUri.OriginalString);
     }
 
@@ -58,7 +58,7 @@ public class PostgresMessageTypeExtensionTests
 
         // assert
         Assert.NotNull(descriptor.DestinationUri);
-        Assert.Equal("custom", descriptor.DestinationUri!.Scheme);
+        Assert.Equal("custom", descriptor.DestinationUri.Scheme);
         Assert.Contains("t/my-topic", descriptor.DestinationUri.OriginalString);
     }
 

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/Topology/PostgresQueueTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/Topology/PostgresQueueTests.cs
@@ -30,7 +30,7 @@ public class PostgresQueueTests
         // assert
         var queue = Assert.Single(topology.Queues, q => q.Name == "addr-queue");
         Assert.NotNull(queue.Address);
-        Assert.Contains("/q/addr-queue", queue.Address!.AbsolutePath);
+        Assert.Contains("/q/addr-queue", queue.Address.AbsolutePath);
     }
 
     [Fact]
@@ -86,6 +86,6 @@ public class PostgresQueueTests
 
         // assert
         var queue = Assert.Single(topology.Queues, q => q.Name == "base-addr");
-        Assert.True(topology.Address.IsBaseOf(queue.Address!));
+        Assert.True(topology.Address.IsBaseOf(queue.Address));
     }
 }

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/Topology/PostgresSubscriptionTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/Topology/PostgresSubscriptionTests.cs
@@ -35,7 +35,7 @@ public class PostgresSubscriptionTests
         // assert
         var subscription = Assert.Single(topology.Subscriptions);
         Assert.NotNull(subscription.Address);
-        Assert.Contains("/b/t/addr-src/q/addr-dst", subscription.Address!.AbsolutePath);
+        Assert.Contains("/b/t/addr-src/q/addr-dst", subscription.Address.AbsolutePath);
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class PostgresSubscriptionTests
 
         // assert
         var subscription = Assert.Single(topology.Subscriptions);
-        Assert.True(topology.Address.IsBaseOf(subscription.Address!));
+        Assert.True(topology.Address.IsBaseOf(subscription.Address));
     }
 
     private static (

--- a/src/Mocha/test/Mocha.Transport.Postgres.Tests/Topology/PostgresTopicTests.cs
+++ b/src/Mocha/test/Mocha.Transport.Postgres.Tests/Topology/PostgresTopicTests.cs
@@ -30,7 +30,7 @@ public class PostgresTopicTests
         // assert
         var topic = Assert.Single(topology.Topics, t => t.Name == "addr-topic");
         Assert.NotNull(topic.Address);
-        Assert.Contains("/t/addr-topic", topic.Address!.AbsolutePath);
+        Assert.Contains("/t/addr-topic", topic.Address.AbsolutePath);
     }
 
     [Fact]
@@ -72,6 +72,6 @@ public class PostgresTopicTests
 
         // assert
         var topic = Assert.Single(topology.Topics, t => t.Name == "base-addr");
-        Assert.True(topology.Address.IsBaseOf(topic.Address!));
+        Assert.True(topology.Address.IsBaseOf(topic.Address));
     }
 }

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Descriptors/RabbitMQDescriptorTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Descriptors/RabbitMQDescriptorTests.cs
@@ -56,7 +56,7 @@ public class RabbitMQDescriptorTests
         Assert.IsType<RabbitMQQueue>(endpoint.Destination);
         Assert.Equal("my-q", ((RabbitMQQueue)endpoint.Destination).Name);
         Assert.NotNull(endpoint.Queue);
-        Assert.Equal("my-q", endpoint.Queue!.Name);
+        Assert.Equal("my-q", endpoint.Queue.Name);
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class RabbitMQDescriptorTests
         Assert.IsType<RabbitMQExchange>(endpoint.Destination);
         Assert.Equal("my-ex", ((RabbitMQExchange)endpoint.Destination).Name);
         Assert.NotNull(endpoint.Exchange);
-        Assert.Equal("my-ex", endpoint.Exchange!.Name);
+        Assert.Equal("my-ex", endpoint.Exchange.Name);
     }
 
     [Fact]
@@ -285,9 +285,9 @@ public class RabbitMQDescriptorTests
         var faultFeature = endpoint.Configuration.Features.Get<ReceiveFaultEndpointFeature>();
         var skippedFeature = endpoint.Configuration.Features.Get<ReceiveSkippedEndpointFeature>();
         Assert.NotNull(faultFeature?.Address);
-        Assert.Empty(faultFeature!.Address!.Query);
+        Assert.Empty(faultFeature.Address.Query);
         Assert.NotNull(skippedFeature?.Address);
-        Assert.Empty(skippedFeature!.Address!.Query);
+        Assert.Empty(skippedFeature.Address.Query);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQDispatchEndpointTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQDispatchEndpointTests.cs
@@ -23,7 +23,7 @@ public class RabbitMQDispatchEndpointTests
 
         // assert
         Assert.NotNull(endpoint.Queue);
-        Assert.Equal("my-q", endpoint.Queue!.Name);
+        Assert.Equal("my-q", endpoint.Queue.Name);
         Assert.Null(endpoint.Exchange);
         Assert.IsType<RabbitMQQueue>(endpoint.Destination);
     }
@@ -46,7 +46,7 @@ public class RabbitMQDispatchEndpointTests
 
         // assert
         Assert.NotNull(endpoint.Exchange);
-        Assert.Equal("my-ex", endpoint.Exchange!.Name);
+        Assert.Equal("my-ex", endpoint.Exchange.Name);
         Assert.Null(endpoint.Queue);
         Assert.IsType<RabbitMQExchange>(endpoint.Destination);
     }

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQMessageEnvelopeParserTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQMessageEnvelopeParserTests.cs
@@ -270,7 +270,7 @@ public class RabbitMQMessageEnvelopeParserTests
 
         // assert
         Assert.NotNull(envelope.EnclosedMessageTypes);
-        Assert.Equal(2, envelope.EnclosedMessageTypes!.Value.Length);
+        Assert.Equal(2, envelope.EnclosedMessageTypes.Value.Length);
         Assert.Equal("OrderCreated", envelope.EnclosedMessageTypes.Value[0]);
         Assert.Equal("IEvent", envelope.EnclosedMessageTypes.Value[1]);
     }

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQRoutingKeyTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQRoutingKeyTests.cs
@@ -18,7 +18,7 @@ public class RabbitMQRoutingKeyTests
         // assert
         var messageType = runtime.Messages.GetMessageType(typeof(OrderCreated));
         Assert.NotNull(messageType);
-        Assert.True(messageType!.Features.TryGet<RabbitMQRoutingKeyExtractor>(out var extractor));
+        Assert.True(messageType.Features.TryGet<RabbitMQRoutingKeyExtractor>(out var extractor));
 
         var order = new OrderCreated { OrderId = "ORD-123" };
         Assert.Equal("ORD-123", extractor.Extract(order));
@@ -35,7 +35,7 @@ public class RabbitMQRoutingKeyTests
         // assert
         var messageType = runtime.Messages.GetMessageType(typeof(OrderCreated));
         Assert.NotNull(messageType);
-        Assert.True(messageType!.Features.TryGet<RabbitMQRoutingKeyExtractor>(out var extractor));
+        Assert.True(messageType.Features.TryGet<RabbitMQRoutingKeyExtractor>(out var extractor));
 
         var order = new OrderCreated { OrderId = "ORD-456" };
         Assert.Equal("ORD-456.priority", extractor.Extract(order));
@@ -52,7 +52,7 @@ public class RabbitMQRoutingKeyTests
         // assert
         var messageType = runtime.Messages.GetMessageType(typeof(OrderCreated));
         Assert.NotNull(messageType);
-        Assert.True(messageType!.Features.TryGet<RabbitMQRoutingKeyExtractor>(out var extractor));
+        Assert.True(messageType.Features.TryGet<RabbitMQRoutingKeyExtractor>(out var extractor));
 
         var order = new OrderCreated { OrderId = "ORD-789" };
         Assert.Null(extractor.Extract(order));
@@ -69,7 +69,7 @@ public class RabbitMQRoutingKeyTests
         // assert
         var messageType = runtime.Messages.GetMessageType(typeof(OrderCreated));
         Assert.NotNull(messageType);
-        Assert.False(messageType!.Features.TryGet<RabbitMQRoutingKeyExtractor>(out _));
+        Assert.False(messageType.Features.TryGet<RabbitMQRoutingKeyExtractor>(out _));
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQTransportTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQTransportTests.cs
@@ -154,7 +154,7 @@ public class RabbitMQTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.Contains(description.Topology!.Entities, e => e.Kind == "exchange");
+        Assert.Contains(description.Topology.Entities, e => e.Kind == "exchange");
     }
 
     [Fact]
@@ -169,7 +169,7 @@ public class RabbitMQTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.Contains(description.Topology!.Entities, e => e.Kind == "queue");
+        Assert.Contains(description.Topology.Entities, e => e.Kind == "queue");
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class RabbitMQTransportTests
 
         // assert
         Assert.NotNull(description.Topology);
-        Assert.NotEmpty(description.Topology!.Links);
+        Assert.NotEmpty(description.Topology.Links);
         Assert.All(
             description.Topology.Links,
             link =>
@@ -250,11 +250,11 @@ public class RabbitMQTransportTests
         // assert
         var faultFeature = receiveEndpoint.Features.Get<ReceiveFaultEndpointFeature>();
         Assert.NotNull(faultFeature?.Endpoint);
-        Assert.Contains("_error", faultFeature.Endpoint!.Name);
+        Assert.Contains("_error", faultFeature.Endpoint.Name);
 
         var skippedFeature = receiveEndpoint.Features.Get<ReceiveSkippedEndpointFeature>();
         Assert.NotNull(skippedFeature?.Endpoint);
-        Assert.Contains("_skipped", skippedFeature.Endpoint!.Name);
+        Assert.Contains("_skipped", skippedFeature.Endpoint.Name);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Topology/RabbitMQExplicitTopologyTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Topology/RabbitMQExplicitTopologyTests.cs
@@ -85,8 +85,8 @@ public class RabbitMQExplicitTopologyTests
         // assert
         var bindings = topology.Bindings.Where(b => b.Source.Name == "ex").ToList();
         Assert.Equal(3, bindings.Count);
-        Assert.Equal(3, bindings.Select(b => b.Address!.ToString()).Distinct().Count());
-        Assert.All(bindings, b => Assert.Contains("rk=", b.Address!.ToString()));
+        Assert.Equal(3, bindings.Select(b => b.Address.ToString()).Distinct().Count());
+        Assert.All(bindings, b => Assert.Contains("rk=", b.Address.ToString()));
     }
 
     [Fact]
@@ -234,7 +234,7 @@ public class RabbitMQExplicitTopologyTests
         // assert
         var bindings = topology.Bindings.Where(b => b.Source.Name == "src").ToList();
         Assert.Equal(2, bindings.Count);
-        Assert.Equal(2, bindings.Select(b => b.Address!.ToString()).Distinct().Count());
+        Assert.Equal(2, bindings.Select(b => b.Address.ToString()).Distinct().Count());
         Assert.All(bindings, b => Assert.IsType<RabbitMQExchangeBinding>(b));
     }
 

--- a/src/Nitro/CommandLine/src/CommandLine/Commands/Clients/DownloadClientCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine/Commands/Clients/DownloadClientCommand.cs
@@ -152,7 +152,7 @@ internal sealed class DownloadClientCommand : Command
 
 internal sealed class PersistedQueryStreamResult
 {
-    public Guid ApiId { get; init; } = default!;
+    public Guid ApiId { get; init; }
 
     public string[] DocumentIds { get; init; } = default!;
 

--- a/src/Nitro/CommandLine/src/CommandLine/Helpers/SourceMetadataParser.cs
+++ b/src/Nitro/CommandLine/src/CommandLine/Helpers/SourceMetadataParser.cs
@@ -36,7 +36,7 @@ internal static class SourceMetadataParser
                         $"'{TypePropertyName}' must be a string. Expected '{GitHubType}' or '{AzureDevOpsType}'.");
                 }
 
-                type = typeElement.GetString()!;
+                type = typeElement.GetString();
             }
 
             return type switch

--- a/src/StrawberryShake/Client/src/Transport.Http/ResponseEnumerable.cs
+++ b/src/StrawberryShake/Client/src/Transport.Http/ResponseEnumerable.cs
@@ -35,7 +35,7 @@ internal sealed class ResponseEnumerable : IAsyncEnumerable<Response<JsonDocumen
             transportError = CreateError(result);
         }
 
-        ConfiguredCancelableAsyncEnumerable<HotChocolate.Transport.OperationResult>.Enumerator enumerator = default!;
+        ConfiguredCancelableAsyncEnumerable<HotChocolate.Transport.OperationResult>.Enumerator enumerator = default;
         try
         {
             enumerator = result

--- a/src/StrawberryShake/Client/test/Core.Tests/Extensions/OperationResultExtensionTests.cs
+++ b/src/StrawberryShake/Client/test/Core.Tests/Extensions/OperationResultExtensionTests.cs
@@ -52,7 +52,7 @@ public class OperationResultExtensionTests
         var hasErrors = successResult.IsErrorResult();
 
         // assert
-        Assert.False(hasErrors!);
+        Assert.False(hasErrors);
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class OperationResultExtensionTests
         var hasErrors = successResult.IsSuccessResult();
 
         // assert
-        Assert.True(hasErrors!);
+        Assert.True(hasErrors);
     }
 
     [Fact]
@@ -130,11 +130,11 @@ public class OperationResultExtensionTests
             Errors = new[] { error };
         }
 
-        public object? Data => null!;
+        public object? Data => null;
 
         public Type DataType => null!;
 
-        public IOperationResultDataInfo? DataInfo => null!;
+        public IOperationResultDataInfo? DataInfo => null;
 
         public object DataFactory => null!;
 

--- a/src/StrawberryShake/Client/test/Transport.InMemory.Tests/InMemoryConnectionTests.cs
+++ b/src/StrawberryShake/Client/test/Transport.InMemory.Tests/InMemoryConnectionTests.cs
@@ -6,7 +6,7 @@ public class InMemoryConnectionTests
     public void Constructor_AllArgs_NoException()
     {
         // arrange
-        Func<CancellationToken, ValueTask<IInMemoryClient>> create = _ => default!;
+        Func<CancellationToken, ValueTask<IInMemoryClient>> create = _ => default;
 
         // act
         var ex = Record.Exception(() => new InMemoryConnection(create));

--- a/src/StrawberryShake/Client/test/Transport.WebSocket.Tests/SessionTests.cs
+++ b/src/StrawberryShake/Client/test/Transport.WebSocket.Tests/SessionTests.cs
@@ -41,7 +41,7 @@ public class SessionTests
                 async (snapshot, ct) =>
                 {
                     // arrange
-                    var client = new SocketClientStub { Protocol = null! };
+                    var client = new SocketClientStub { Protocol = null };
                     var manager = new Session(client);
 
                     // act

--- a/src/StrawberryShake/Client/test/Transport.WebSocket.Tests/TestHelper/SocketClientStub.cs
+++ b/src/StrawberryShake/Client/test/Transport.WebSocket.Tests/TestHelper/SocketClientStub.cs
@@ -51,7 +51,7 @@ public sealed class SocketClientStub : ISocketClient
         ReadOnlyMemory<byte> message,
         CancellationToken cancellationToken = default)
     {
-        Increment(x => x.SendAsync(default!, CancellationToken.None));
+        Increment(x => x.SendAsync(default, CancellationToken.None));
 
         SentMessages.Enqueue(Encoding.UTF8.GetString(message.Span));
         LatestCancellationToken = cancellationToken;

--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration.CSharp/Generators/TypeMapperGenerator_EntityOrUnionDataHandler.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration.CSharp/Generators/TypeMapperGenerator_EntityOrUnionDataHandler.cs
@@ -83,7 +83,7 @@ public partial class TypeMapperGenerator
             .AddIfElse(IfBuilder
                 .New()
                 .SetCondition(
-                    $"{parameterName}.Data is {complexTypeDescriptor.ParentRuntimeType!} d")
+                    $"{parameterName}.Data is {complexTypeDescriptor.ParentRuntimeType} d")
                 .AddCode(MethodCallBuilder
                     .New()
                     .SetReturn()

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/CSharpCompiler.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/CSharpCompiler.cs
@@ -12,7 +12,7 @@ namespace StrawberryShake.CodeGeneration.CSharp;
 internal static class CSharpCompiler
 {
     // we pin these types so that they are added to this assembly
-#pragma warning disable CS0414, IDE0051, RCS1249
+#pragma warning disable CS0414, IDE0051, IDE0370, RCS1249
     private static readonly EntityId? s_entityId = null!;
     private static readonly JsonDocument? s_jsonDocument = null!;
     private static readonly HttpConnection? s_httpConnection = null!;
@@ -21,7 +21,7 @@ internal static class CSharpCompiler
     private static readonly IHttpClientFactory? s_httpClientFactory = null!;
     private static readonly HttpClient? s_httpClient = null!;
     private static readonly InMemoryClient s_memoryClient = null!;
-#pragma warning restore CS0414, IDE0051, RCS1249
+#pragma warning restore CS0414, IDE0051, IDE0370, RCS1249
 
     private static readonly CSharpCompilationOptions s_options =
         new(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Debug);

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests/CSharpCompiler.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Razor.Tests/CSharpCompiler.cs
@@ -12,7 +12,7 @@ namespace StrawberryShake.CodeGeneration.CSharp;
 internal static class CSharpCompiler
 {
     // we pin these types so that they are added to this assembly
-#pragma warning disable CS0414, IDE0051, RCS1249
+#pragma warning disable CS0414, IDE0051, IDE0370, RCS1249
     private static readonly EntityId? s_entityId = null!;
     private static readonly JsonDocument? s_jsonDocument = null!;
     private static readonly HttpConnection? s_httpConnection = null!;
@@ -21,7 +21,7 @@ internal static class CSharpCompiler
     private static readonly IHttpClientFactory? s_httpClientFactory = null!;
     private static readonly HttpClient? s_httpClient = null!;
     private static readonly InMemoryClient s_memoryClient = null!;
-#pragma warning restore CS0414, IDE0051, RCS1249
+#pragma warning restore CS0414, IDE0051, IDE0370, RCS1249
 
     private static readonly CSharpCompilationOptions s_options =
         new(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Debug);


### PR DESCRIPTION
## Summary
- Enable the `IDE0370` analyzer ("Remove unnecessary suppression operator") as a warning in `.editorconfig`.
- Remove the now-flagged unnecessary `!` null-forgiving operators across the source and test code.
- Where a `= null!` deferred-initialization field genuinely needs the operator (e.g. `Schema`, `MiddlewareContext`, `InputObjectType`, `InterfaceType`), wrap it in `#pragma warning disable IDE0370` instead.

## Test plan
- `dotnet build src/All.slnx` builds clean with no `IDE0370` warnings.
- Existing test suites pass (the `!` operator is compile-time only, so removals are behavior-neutral).
