### PR TITLE
Fix Fusion keyed-service cast build break on older TFMs

### DIFF
--- a/src/HotChocolate/Fusion/src/Fusion.Execution/DependencyInjection/HotChocolateFusionServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/DependencyInjection/HotChocolateFusionServiceCollectionExtensions.cs
@@ -120,7 +120,13 @@ public static class HotChocolateFusionServiceCollectionExtensions
             static (sp, schemaName) =>
             {
                 var optionsMonitor = sp.GetRequiredService<IOptionsMonitor<FusionGatewaySetup>>();
+                // The keyed-service key is non-nullable 'object' on net11.0 but nullable
+                // 'object?' on net8.0-net10.0, where the cast still needs the suppression.
+#if NET11_0_OR_GREATER
                 var setup = optionsMonitor.Get((string)schemaName);
+#else
+                var setup = optionsMonitor.Get((string)schemaName!);
+#endif
 
                 var options = FusionRequestExecutorManager.CreateOptions(setup);
 


### PR DESCRIPTION
## Summary
- The keyed-service factory key is non-nullable `object` on net11.0 but `object?` on net8.0-net10.0, so casting it to `string` needs a null-forgiving suppression on the older TFMs.
- The `IDE0370` cleanup in #10012 was computed against net11.0 and stripped that suppression, breaking the net8.0/net9.0/net10.0 builds with `CS8600` (promoted to an error via `WarningsAsErrors;nullable`). CI's per-area test jobs build only net11.0, so the break was silent.
- Guard the cast behind `#if NET11_0_OR_GREATER` so net11.0 stays suppression-free (no `IDE0370`) and the older TFMs keep the required `!`.

## Test plan
- `dotnet build` of `HotChocolate.Fusion.Execution` succeeds on net11.0, net10.0, net9.0, and net8.0.
