### PR TITLE
[Fusion] Support directive-definition deprecation and location

### DIFF
--- a/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/CompositeSchemaBuilder.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/CompositeSchemaBuilder.cs
@@ -288,9 +288,13 @@ internal static class CompositeSchemaBuilder
     private static FusionDirectiveDefinition CreateDirectiveType(
         DirectiveDefinitionNode definition)
     {
+        var isDeprecated = DeprecatedDirectiveParser.TryParse(definition.Directives, out var deprecated);
+
         return new FusionDirectiveDefinition(
             definition.Name.Value,
             definition.Description?.Value,
+            isDeprecated,
+            deprecated?.Reason,
             definition.IsRepeatable,
             CreateInputFields(definition.Arguments),
             DirectiveLocationUtils.Parse(definition.Locations));

--- a/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/CompositeSchemaContext.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/CompositeSchemaContext.cs
@@ -278,6 +278,8 @@ internal sealed class CompositeSchemaBuilderContext : ICompositeSchemaBuilderCon
         var skipDirective = new FusionDirectiveDefinition(
             DirectiveNames.Skip.Name,
             "Directs the executor to skip this field or fragment when the `if` argument is true.",
+            isDeprecated: false,
+            deprecationReason: null,
             isRepeatable: false,
             new FusionInputFieldDefinitionCollection([ifField]),
             DirectiveLocation.Field | DirectiveLocation.FragmentSpread | DirectiveLocation.InlineFragment);
@@ -322,6 +324,8 @@ internal sealed class CompositeSchemaBuilderContext : ICompositeSchemaBuilderCon
         var includeDirective = new FusionDirectiveDefinition(
             DirectiveNames.Include.Name,
             "Directs the executor to include this field or fragment when the `if` argument is true.",
+            isDeprecated: false,
+            deprecationReason: null,
             isRepeatable: false,
             new FusionInputFieldDefinitionCollection([ifField]),
             DirectiveLocation.Field | DirectiveLocation.FragmentSpread | DirectiveLocation.InlineFragment);
@@ -366,6 +370,8 @@ internal sealed class CompositeSchemaBuilderContext : ICompositeSchemaBuilderCon
         var specifiedByDirective = new FusionDirectiveDefinition(
             DirectiveNames.SpecifiedBy.Name,
             "The `@specifiedBy` directive is used within the type system definition language to provide a URL for specifying the behavior of custom scalar definitions.",
+            isDeprecated: false,
+            deprecationReason: null,
             isRepeatable: false,
             new FusionInputFieldDefinitionCollection([urlField]),
             DirectiveLocation.Scalar);
@@ -399,6 +405,8 @@ internal sealed class CompositeSchemaBuilderContext : ICompositeSchemaBuilderCon
         var oneOfDirective = new FusionDirectiveDefinition(
             DirectiveNames.OneOf.Name,
             "The `@oneOf` directive is used within the type system definition language to indicate that an Input Object is a OneOf Input Object.",
+            isDeprecated: false,
+            deprecationReason: null,
             isRepeatable: false,
             new FusionInputFieldDefinitionCollection([]),
             DirectiveLocation.InputObject);

--- a/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/IntrospectionSchema.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution.Types/Completion/IntrospectionSchema.cs
@@ -15,7 +15,7 @@ internal static class IntrospectionSchema
           queryType: __Type!
           mutationType: __Type
           subscriptionType: __Type
-          directives: [__Directive!]!
+          directives(includeDeprecated: Boolean! = false): [__Directive!]!
         }
 
         type __Type {
@@ -82,6 +82,8 @@ internal static class IntrospectionSchema
           isRepeatable: Boolean!
           locations: [__DirectiveLocation!]!
           args(includeDeprecated: Boolean! = false): [__InputValue!]!
+          isDeprecated: Boolean!
+          deprecationReason: String
         }
 
         enum __DirectiveLocation {
@@ -104,6 +106,7 @@ internal static class IntrospectionSchema
           ENUM_VALUE
           INPUT_OBJECT
           INPUT_FIELD_DEFINITION
+          DIRECTIVE_DEFINITION
         }
         """u8;
 
@@ -115,7 +118,7 @@ internal static class IntrospectionSchema
           queryType: __Type!
           mutationType: __Type
           subscriptionType: __Type
-          directives(includeOptIn: [String!]): [__Directive!]!
+          directives(includeDeprecated: Boolean! = false, includeOptIn: [String!]): [__Directive!]!
           optInFeatures: [String!]
           optInFeatureStability: [__OptInFeatureStability!]!
         }
@@ -188,6 +191,8 @@ internal static class IntrospectionSchema
           locations: [__DirectiveLocation!]!
           args(includeDeprecated: Boolean! = false, includeOptIn: [String!]): [__InputValue!]!
           requiresOptIn: [String!]
+          isDeprecated: Boolean!
+          deprecationReason: String
         }
 
         enum __DirectiveLocation {
@@ -210,6 +215,7 @@ internal static class IntrospectionSchema
           ENUM_VALUE
           INPUT_OBJECT
           INPUT_FIELD_DEFINITION
+          DIRECTIVE_DEFINITION
         }
 
         type __OptInFeatureStability {

--- a/src/HotChocolate/Fusion/src/Fusion.Execution.Types/FusionDirectiveDefinition.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution.Types/FusionDirectiveDefinition.cs
@@ -16,9 +16,32 @@ public sealed class FusionDirectiveDefinition : IDirectiveDefinition
     /// <summary>
     /// Represents a GraphQL directive definition.
     /// </summary>
+    [Obsolete("Use the constructor overload that accepts isDeprecated and deprecationReason.")]
     public FusionDirectiveDefinition(
         string name,
         string? description,
+        bool isRepeatable,
+        FusionInputFieldDefinitionCollection arguments,
+        DirectiveLocation locations)
+        : this(
+            name,
+            description,
+            isDeprecated: false,
+            deprecationReason: null,
+            isRepeatable,
+            arguments,
+            locations)
+    {
+    }
+
+    /// <summary>
+    /// Represents a GraphQL directive definition.
+    /// </summary>
+    public FusionDirectiveDefinition(
+        string name,
+        string? description,
+        bool isDeprecated,
+        string? deprecationReason,
         bool isRepeatable,
         FusionInputFieldDefinitionCollection arguments,
         DirectiveLocation locations)
@@ -35,6 +58,8 @@ public sealed class FusionDirectiveDefinition : IDirectiveDefinition
 
         Name = name;
         Description = description;
+        IsDeprecated = isDeprecated;
+        DeprecationReason = deprecationReason;
         IsRepeatable = isRepeatable;
         Arguments = arguments;
         Locations = locations;
@@ -58,6 +83,16 @@ public sealed class FusionDirectiveDefinition : IDirectiveDefinition
 
     /// <inheritdoc />
     public SchemaCoordinate Coordinate => new(Name, ofDirective: true);
+
+    /// <summary>
+    /// Defines if this directive is deprecated.
+    /// </summary>
+    public bool IsDeprecated { get; }
+
+    /// <summary>
+    /// Gets the reason why this directive is deprecated.
+    /// </summary>
+    public string? DeprecationReason { get; }
 
     /// <summary>
     /// Defines if this directive is repeatable and can be applied multiple times.

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Introspection/__Directive.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Introspection/__Directive.cs
@@ -31,6 +31,12 @@ internal sealed class __Directive : ITypeResolverInterceptor
             case "isRepeatable":
                 features.Set(new ResolveFieldValue(IsRepeatable));
                 break;
+            case "isDeprecated":
+                features.Set(new ResolveFieldValue(IsDeprecated));
+                break;
+            case "deprecationReason":
+                features.Set(new ResolveFieldValue(DeprecationReason));
+                break;
             case "locations":
                 features.Set(new ResolveFieldValue(Locations));
                 break;
@@ -66,6 +72,18 @@ internal sealed class __Directive : ITypeResolverInterceptor
     {
         var directiveDef = context.Parent<IDirectiveDefinition>();
         context.WriteValue(directiveDef.IsRepeatable);
+    }
+
+    public static void IsDeprecated(FieldContext context)
+    {
+        var directiveDef = context.Parent<IDirectiveDefinition>();
+        context.WriteValue(directiveDef.IsDeprecated);
+    }
+
+    public static void DeprecationReason(FieldContext context)
+    {
+        var directiveDef = context.Parent<IDirectiveDefinition>();
+        context.WriteValue(directiveDef.DeprecationReason);
     }
 
     public static void Locations(FieldContext context)
@@ -140,6 +158,9 @@ internal sealed class __Directive : ITypeResolverInterceptor
                     break;
                 case DirectiveLocation.InputFieldDefinition:
                     list.Current.SetStringValue(__DirectiveLocation.InputFieldDefinition);
+                    break;
+                case DirectiveLocation.DirectiveDefinition:
+                    list.Current.SetStringValue(__DirectiveLocation.DirectiveDefinition);
                     break;
                 default:
                     throw new NotSupportedException($"Directive location {directiveDef.Locations} is not supported.");

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Introspection/__DirectiveLocation.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Introspection/__DirectiveLocation.cs
@@ -22,4 +22,5 @@ internal static class __DirectiveLocation
     public static ReadOnlySpan<byte> EnumValue => "ENUM_VALUE"u8;
     public static ReadOnlySpan<byte> InputObject => "INPUT_OBJECT"u8;
     public static ReadOnlySpan<byte> InputFieldDefinition => "INPUT_FIELD_DEFINITION"u8;
+    public static ReadOnlySpan<byte> DirectiveDefinition => "DIRECTIVE_DEFINITION"u8;
 }

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Introspection/__Schema.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Introspection/__Schema.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using HotChocolate.Features;
 using HotChocolate.Fusion.Execution.Nodes;
 using HotChocolate.Fusion.Types.Introspection;
@@ -119,6 +120,7 @@ internal sealed class __Schema : ITypeResolverInterceptor
 
             if (!list.MoveNext())
             {
+                Debug.Fail("Expected enumerator of list value to be able to advance");
                 break;
             }
 
@@ -151,6 +153,7 @@ internal sealed class __Schema : ITypeResolverInterceptor
 
             if (!list.MoveNext())
             {
+                Debug.Fail("Expected enumerator of list value to be able to advance");
                 break;
             }
 

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Introspection/__Schema.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Introspection/__Schema.cs
@@ -103,27 +103,47 @@ internal sealed class __Schema : ITypeResolverInterceptor
 
     public static void Directives(FieldContext context)
     {
-        var list = context.FieldResult.CreateListValue(context.Schema.DirectiveDefinitions.Count);
+        var includeDeprecated = context.ArgumentValue<BooleanValueNode>("includeDeprecated").Value;
+        var directiveDefinitions = context.Schema.DirectiveDefinitions;
+        var count = includeDeprecated
+            ? directiveDefinitions.Count
+            : directiveDefinitions.Count(d => !d.IsDeprecated);
+        using var list = context.FieldResult.CreateListValue(count).EnumerateArray().GetEnumerator();
 
-        var i = 0;
-        foreach (var element in list.EnumerateArray())
+        foreach (var directiveDef in directiveDefinitions)
         {
-            var type = context.Schema.DirectiveDefinitions[i++];
-            context.AddRuntimeResult(type);
-            element.CreateObjectValue(context.Selection, context.IncludeFlags);
+            if (!includeDeprecated && directiveDef.IsDeprecated)
+            {
+                continue;
+            }
+
+            if (!list.MoveNext())
+            {
+                break;
+            }
+
+            context.AddRuntimeResult(directiveDef);
+            list.Current.CreateObjectValue(context.Selection, context.IncludeFlags);
         }
     }
 
     public static void DirectivesWithOptIn(FieldContext context)
     {
+        var includeDeprecated = context.ArgumentValue<BooleanValueNode>("includeDeprecated").Value;
         var includeOptIn = ReadIncludeOptIn(context);
         var schema = context.Schema;
         var count = schema.DirectiveDefinitions.Count(
-            d => OptInIntrospectionHelper.IsIncluded(d.Directives, includeOptIn));
+            d => (includeDeprecated || !d.IsDeprecated)
+                && OptInIntrospectionHelper.IsIncluded(d.Directives, includeOptIn));
         using var list = context.FieldResult.CreateListValue(count).EnumerateArray().GetEnumerator();
 
         foreach (var directiveDef in schema.DirectiveDefinitions)
         {
+            if (!includeDeprecated && directiveDef.IsDeprecated)
+            {
+                continue;
+            }
+
             if (!OptInIntrospectionHelper.IsIncluded(directiveDef.Directives, includeOptIn))
             {
                 continue;

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.IntrospectionQueries_DirectiveCapabilitiesQuery.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.IntrospectionQueries_DirectiveCapabilitiesQuery.yaml
@@ -30,6 +30,12 @@ response:
             },
             {
               "name": "args"
+            },
+            {
+              "name": "isDeprecated"
+            },
+            {
+              "name": "deprecationReason"
             }
           ]
         }

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.IntrospectionQueries_IntrospectionQuery.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.IntrospectionQueries_IntrospectionQuery.yaml
@@ -200,7 +200,24 @@ response:
                 {
                   "name": "directives",
                   "description": null,
-                  "args": [],
+                  "args": [
+                    {
+                      "name": "includeDeprecated",
+                      "description": null,
+                      "type": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "Boolean",
+                          "ofType": null
+                        }
+                      },
+                      "defaultValue": "false",
+                      "isDeprecated": false,
+                      "deprecationReason": null
+                    }
+                  ],
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -935,6 +952,34 @@ response:
                   },
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "isDeprecated",
+                  "description": null,
+                  "args": [],
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    }
+                  },
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "deprecationReason",
+                  "description": null,
+                  "args": [],
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "inputFields": null,
@@ -1062,6 +1107,12 @@ response:
                 },
                 {
                   "name": "INPUT_FIELD_DEFINITION",
+                  "description": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "DIRECTIVE_DEFINITION",
                   "description": null,
                   "isDeprecated": false,
                   "deprecationReason": null

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.Typename_On_Introspection_Types.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.Typename_On_Introspection_Types.yaml
@@ -227,6 +227,12 @@ response:
                 },
                 {
                   "__typename": "__Field"
+                },
+                {
+                  "__typename": "__Field"
+                },
+                {
+                  "__typename": "__Field"
                 }
               ],
               "enumValues": null,
@@ -236,6 +242,9 @@ response:
               "__typename": "__Type",
               "fields": null,
               "enumValues": [
+                {
+                  "__typename": "__EnumValue"
+                },
                 {
                   "__typename": "__EnumValue"
                 },

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/v15/__snapshots__/DemoIntegrationTests.Authors_And_Reviews_And_Products_Introspection.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/v15/__snapshots__/DemoIntegrationTests.Authors_And_Reviews_And_Products_Introspection.yaml
@@ -326,6 +326,20 @@ response:
                     "name": null,
                     "kind": "NON_NULL"
                   }
+                },
+                {
+                  "name": "isDeprecated",
+                  "type": {
+                    "name": null,
+                    "kind": "NON_NULL"
+                  }
+                },
+                {
+                  "name": "deprecationReason",
+                  "type": {
+                    "name": "String",
+                    "kind": "SCALAR"
+                  }
                 }
               ]
             },

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Introspection/DirectiveDefinitionIntrospectionTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Introspection/DirectiveDefinitionIntrospectionTests.cs
@@ -1,0 +1,129 @@
+using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Fusion.Execution.Introspection;
+
+public sealed class DirectiveDefinitionIntrospectionTests : FusionTestBase
+{
+    // A directive whose locations include DIRECTIVE_DEFINITION is introspected with that
+    // location; the deprecation metadata fields resolve for every directive.
+    [Fact]
+    public async Task Directives_Locations_IncludeDirectiveDefinition()
+    {
+        // arrange
+        var services = new ServiceCollection();
+        services.AddHttpClient();
+        services
+            .AddGraphQLGateway()
+            .ModifyOptions(o => o.EnableOptInFeatures = true)
+            .AddInMemoryConfiguration(
+                ComposeSchemaDocument(
+                    """
+                    type Query {
+                        field: String
+                        experimentalField: String @requiresOptIn(feature: "experimental")
+                    }
+
+                    directive @requiresOptIn(feature: String!) repeatable on
+                        | FIELD_DEFINITION
+                        | ARGUMENT_DEFINITION
+                        | ENUM_VALUE
+                        | INPUT_FIELD_DEFINITION
+                        | DIRECTIVE_DEFINITION
+                    """))
+            .UseDefaultPipeline();
+
+        var executor = await services
+            .BuildServiceProvider()
+            .GetRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // act
+        var result = await executor.ExecuteAsync(
+            OperationRequestBuilder.New()
+                .SetDocument(
+                    """
+                    {
+                        __schema {
+                            directives {
+                                name
+                                isDeprecated
+                                deprecationReason
+                                locations
+                            }
+                        }
+                    }
+                    """)
+                .Build(),
+            TestContext.Current.CancellationToken);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__schema": {
+                  "directives": [
+                    {
+                      "name": "requiresOptIn",
+                      "isDeprecated": false,
+                      "deprecationReason": null,
+                      "locations": [
+                        "FIELD_DEFINITION",
+                        "ARGUMENT_DEFINITION",
+                        "ENUM_VALUE",
+                        "INPUT_FIELD_DEFINITION",
+                        "DIRECTIVE_DEFINITION"
+                      ]
+                    },
+                    {
+                      "name": "defer",
+                      "isDeprecated": false,
+                      "deprecationReason": null,
+                      "locations": [
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                      ]
+                    },
+                    {
+                      "name": "skip",
+                      "isDeprecated": false,
+                      "deprecationReason": null,
+                      "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                      ]
+                    },
+                    {
+                      "name": "include",
+                      "isDeprecated": false,
+                      "deprecationReason": null,
+                      "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                      ]
+                    },
+                    {
+                      "name": "specifiedBy",
+                      "isDeprecated": false,
+                      "deprecationReason": null,
+                      "locations": [
+                        "SCALAR"
+                      ]
+                    },
+                    {
+                      "name": "oneOf",
+                      "isDeprecated": false,
+                      "deprecationReason": null,
+                      "locations": [
+                        "INPUT_OBJECT"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+    }
+}


### PR DESCRIPTION
## Summary

- Fusion gateway introspection now reports the `DIRECTIVE_DEFINITION` directive location (added to the `__DirectiveLocation` enum, the location constants, and the `__Directive.locations` resolver), so a directive that targets directive definitions (for example `@requiresOptIn`) is introspected correctly instead of failing the resolver.
- Adds directive-definition deprecation to the introspection surface, matching single-server HotChocolate: `FusionDirectiveDefinition` carries `IsDeprecated`/`DeprecationReason` (parsed from `@deprecated`), `__Directive` exposes `isDeprecated`/`deprecationReason`, and `__Schema.directives` honors `includeDeprecated`.
- Deprecation is added via a new constructor overload; the original `FusionDirectiveDefinition` constructor is retained and marked `[Obsolete]` so existing callers keep compiling.

## Test plan

- Gateway introspection test: a directive whose locations include `DIRECTIVE_DEFINITION` is introspected with that location, and the `isDeprecated`/`deprecationReason` fields resolve for every directive.
- Full `Fusion.Execution.Tests` passes (2308/0).
