### PR TITLE
Use ordinal comparer for opt-in features ordering

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Interceptors/OptInFeaturesTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Interceptors/OptInFeaturesTypeInterceptor.cs
@@ -88,4 +88,4 @@ file static class Extensions
     }
 }
 
-internal sealed class OptInFeatures : SortedSet<string>;
+internal sealed class OptInFeatures() : SortedSet<string>(StringComparer.Ordinal);


### PR DESCRIPTION
## Summary

- `OptInFeatures` (backing `__schema.optInFeatures`) was a `SortedSet<string>` using the default culture-sensitive comparer, so the introspected feature order depended on the server's culture. It now uses `StringComparer.Ordinal` for deterministic ordering, consistent with Fusion's `FusionOptInFeatures`.

## Test plan

- Core opt-in introspection tests pass (`OptInFeaturesIntrospectionTests`, `RequestExecutorBuilderExtensions_OptInFeatures`, 76/0). Ordinal and invariant ordering agree for the ASCII GraphQL-identifier feature names, so existing snapshots are unchanged; the fix removes culture sensitivity.
