### PR TITLE
[Fusion] Fix flaky NATS broker dispose test race

### DIFF
--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/NatsEventStreamBrokerTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/NatsEventStreamBrokerTests.cs
@@ -379,8 +379,11 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
 
             await broker.DisposeAsync();
 
-            // Disposing the broker cancels its active subscriptions.
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+            // Disposing the broker cancels its active subscriptions. The short
+            // timeout attributes the cancellation to the broker disposal rather
+            // than the test-wide token, and fails fast if it does not happen.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => pending.WaitAsync(TimeSpan.FromSeconds(5), cts.Token));
         }
 
         await using (var broker = factory.Create(null))

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/NatsEventStreamBrokerTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/NatsEventStreamBrokerTests.cs
@@ -374,10 +374,13 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
             await using var enumerator = broker
                 .SubscribeAsync(EmptySubscriptionFieldContext.Instance, [subject], cursor: null, cts.Token)
                 .GetAsyncEnumerator(cts.Token);
-            _ = enumerator.MoveNextAsync().AsTask();
+            var pending = enumerator.MoveNextAsync().AsTask();
             await Task.Delay(250, cts.Token);
 
             await broker.DisposeAsync();
+
+            // Disposing the broker cancels its active subscriptions.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
         }
 
         await using (var broker = factory.Create(null))


### PR DESCRIPTION
## Summary
- `DisposeAsync_Should_DisposeBrokerConnection_When_BrokerIsDisposed` started a fire-and-forget `MoveNextAsync()` and then disposed the subscription enumerator while it was still pending. Disposing an `IAsyncEnumerator` mid-`MoveNextAsync` is illegal, so the compiler-generated async iterator threw `NotSupportedException` ("Specified method is not supported.") under CI threadpool contention.
- The test now awaits the in-flight subscription before the enumerator is disposed, and asserts that disposing the broker cancels its active subscription. The iterator is never disposed while a `MoveNextAsync` is running, and block 1 gains a real assertion (it previously had none).
- Test-only change; no product code is affected.

## Test plan
- Reproduced the exact exception deterministically with a standalone async-iterator repro (unawaited `MoveNextAsync` + `DisposeAsync`).
- Ran the fixed test 30x under multicore CPU stress — all green.
