### PR TITLE
[Fusion] Fix abstract type conditions in selection paths never matching result elements

### DIFF
--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/BatchOperationDefinition.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/BatchOperationDefinition.cs
@@ -1,17 +1,15 @@
-using HotChocolate.Execution;
-
 namespace HotChocolate.Fusion.Execution.Nodes;
 
 internal sealed class BatchOperationDefinition : OperationDefinition
 {
-    private readonly SelectionPath[] _targets;
+    private readonly ResolvedSelectionPath[] _targets;
 
     internal BatchOperationDefinition(
         int id,
         OperationSourceText operation,
         string? schemaName,
-        SelectionPath[] targets,
-        SelectionPath source,
+        ResolvedSelectionPath[] targets,
+        ResolvedSelectionPath source,
         OperationRequirement[] requirements,
         string[] forwardedVariables,
         ResultSelectionSet resultSelectionSet,
@@ -35,5 +33,5 @@ internal sealed class BatchOperationDefinition : OperationDefinition
     /// Gets the paths to the selection sets for which this batch operation
     /// fetches data. Each target corresponds to one of the merged operations.
     /// </summary>
-    public ReadOnlySpan<SelectionPath> Targets => _targets;
+    public ReadOnlySpan<ResolvedSelectionPath> Targets => _targets;
 }

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/EventStreamExecutionNode.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/EventStreamExecutionNode.cs
@@ -30,14 +30,14 @@ public sealed class EventStreamExecutionNode : ExecutionNode
     private readonly string _message;
     private readonly ResultSelectionSet _resultSelectionSet;
     private readonly ExecutionNodeCondition[] _conditions;
-    private readonly SelectionPath _source;
-    private readonly SelectionPath _target;
+    private readonly ResolvedSelectionPath _source;
+    private readonly ResolvedSelectionPath _target;
 
     internal EventStreamExecutionNode(
         int id,
         string fieldName,
-        SelectionPath target,
-        SelectionPath source,
+        ResolvedSelectionPath target,
+        ResolvedSelectionPath source,
         ResultSelectionSet resultSelectionSet,
         EventStreamSource eventStreamSource,
         string message,
@@ -71,9 +71,9 @@ public sealed class EventStreamExecutionNode : ExecutionNode
 
     public string FieldName { get; }
 
-    public SelectionPath Target => _target;
+    public SelectionPath Target => _target.Path;
 
-    public SelectionPath Source => _source;
+    public SelectionPath Source => _source.Path;
 
     internal ResultSelectionSet ResultSelectionSet => _resultSelectionSet;
 
@@ -452,9 +452,10 @@ public sealed class EventStreamExecutionNode : ExecutionNode
             var builder = new StringBuilder();
             var lastField = default(string);
 
-            for (var i = 0; i < node._target.Length; i++)
+            var targetPath = node._target.Path;
+            for (var i = 0; i < targetPath.Length; i++)
             {
-                var segment = node._target[i];
+                var segment = targetPath[i];
                 if (segment.Kind is not SelectionPathSegmentKind.Field)
                 {
                     continue;

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/IncrementalPlan.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/IncrementalPlan.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using HotChocolate.Execution;
+using HotChocolate.Fusion.Types;
 
 namespace HotChocolate.Fusion.Execution.Nodes;
 
@@ -8,6 +10,7 @@ namespace HotChocolate.Fusion.Execution.Nodes;
 public sealed class IncrementalPlan : IOperationPlan
 {
     private readonly ExecutionNode?[] _nodesById;
+    private ResolvedSelectionPath? _requirementAnchor;
 
     /// <summary>
     /// Initializes a new instance of <see cref="IncrementalPlan"/>.
@@ -141,6 +144,14 @@ public sealed class IncrementalPlan : IOperationPlan
 
         throw ThrowHelper.NodeNotFound(planNode.Id);
     }
+
+    /// <summary>
+    /// Gets the anchor selection set shared by this plan's parent-scope requirements, resolved
+    /// against the schema. The anchor is plan-invariant, so it is resolved once and reused across
+    /// every delivery this plan handles.
+    /// </summary>
+    internal ResolvedSelectionPath GetRequirementAnchor(SelectionPath anchor, FusionSchemaDefinition schema)
+        => _requirementAnchor ??= ResolvedSelectionPath.Create(anchor, schema);
 
     private static ExecutionNode?[] CreateNodeLookup(ImmutableArray<ExecutionNode> allNodes)
     {

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/OperationDefinition.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/OperationDefinition.cs
@@ -1,5 +1,3 @@
-using HotChocolate.Execution;
-
 namespace HotChocolate.Fusion.Execution.Nodes;
 
 internal abstract class OperationDefinition : IOperationPlanNode
@@ -19,7 +17,7 @@ internal abstract class OperationDefinition : IOperationPlanNode
         int id,
         OperationSourceText operation,
         string? schemaName,
-        SelectionPath source,
+        ResolvedSelectionPath source,
         OperationRequirement[] requirements,
         string[] forwardedVariables,
         ResultSelectionSet resultSelectionSet,
@@ -64,7 +62,7 @@ internal abstract class OperationDefinition : IOperationPlanNode
     /// Gets the path to the local selection set (the selection set within the
     /// source schema request) to extract the data from.
     /// </summary>
-    public SelectionPath Source { get; }
+    public ResolvedSelectionPath Source { get; }
 
     /// <summary>
     /// Gets the data requirements that must be satisfied before this operation

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/OperationExecutionNode.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/OperationExecutionNode.cs
@@ -19,15 +19,15 @@ public sealed class OperationExecutionNode : ExecutionNode
     private readonly OperationSourceText _operation;
     private readonly ulong _operationHash;
     private readonly string? _schemaName;
-    private readonly SelectionPath _target;
-    private readonly SelectionPath _source;
+    private readonly ResolvedSelectionPath _target;
+    private readonly ResolvedSelectionPath _source;
 
     internal OperationExecutionNode(
         int id,
         OperationSourceText operation,
         string? schemaName,
-        SelectionPath target,
-        SelectionPath source,
+        ResolvedSelectionPath target,
+        ResolvedSelectionPath source,
         OperationRequirement[] requirements,
         string[] forwardedVariables,
         ResultSelectionSet resultSelectionSet,
@@ -72,13 +72,17 @@ public sealed class OperationExecutionNode : ExecutionNode
     /// <summary>
     /// Gets the path to the selection set for which this operation fetches data.
     /// </summary>
-    public SelectionPath Target => _target;
+    public SelectionPath Target => _target.Path;
 
     /// <summary>
     /// Gets the path to the local selection set (the selection set within the source schema request)
     /// to extract the data from.
     /// </summary>
-    public SelectionPath Source => _source;
+    public SelectionPath Source => _source.Path;
+
+    internal ResolvedSelectionPath ResolvedTarget => _target;
+
+    internal ResolvedSelectionPath ResolvedSource => _source;
 
     /// <summary>
     /// Gets the data requirements that are needed to execute this operation.

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/ResolvedSelectionPath.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/ResolvedSelectionPath.cs
@@ -6,10 +6,9 @@ using HotChocolate.Types;
 namespace HotChocolate.Fusion.Execution.Nodes;
 
 /// <summary>
-/// Pairs a <see cref="SelectionPath"/> with the type-system information needed to match its
-/// inline-fragment segments against runtime data. Resolving the type conditions once when the
-/// plan is built lets the result store match segments without consulting the schema during
-/// execution.
+/// Pairs a <see cref="SelectionPath"/> with the type conditions of its inline-fragment segments
+/// resolved against the schema, so that segments can be matched against runtime data by type
+/// identity.
 /// </summary>
 internal sealed class ResolvedSelectionPath
 {
@@ -27,14 +26,16 @@ internal sealed class ResolvedSelectionPath
     public SelectionPath Path { get; }
 
     /// <summary>
-    /// Gets the resolved type condition of the inline-fragment segment at the specified index.
+    /// Gets the resolved type condition of the inline-fragment segment at the specified index,
+    /// or <c>null</c> when the type condition could not be resolved against the schema and is
+    /// matched by name instead.
     /// </summary>
-    public ITypeDefinition GetTypeCondition(int index)
+    public ITypeDefinition? GetTypeCondition(int index)
         => _fragmentSegments![index].TypeCondition;
 
     /// <summary>
     /// Gets the object types that satisfy the inline-fragment type condition at the specified index.
-    /// The result is empty when the condition is a concrete object type.
+    /// The result is empty when the condition is a concrete object type or could not be resolved.
     /// </summary>
     public ImmutableArray<FusionObjectTypeDefinition> GetPossibleTypes(int index)
         => _fragmentSegments![index].PossibleTypes;
@@ -46,10 +47,7 @@ internal sealed class ResolvedSelectionPath
     /// <param name="path">The selection path to resolve.</param>
     /// <param name="schema">The schema that provides the type conditions.</param>
     /// <returns>A <see cref="ResolvedSelectionPath"/> for <paramref name="path"/>.</returns>
-    /// <exception cref="InvalidOperationException">
-    /// An inline-fragment type condition does not exist in the schema.
-    /// </exception>
-    public static ResolvedSelectionPath Create(SelectionPath path, ISchemaDefinition schema)
+    public static ResolvedSelectionPath Create(SelectionPath path, FusionSchemaDefinition schema)
     {
         ArgumentNullException.ThrowIfNull(path);
         ArgumentNullException.ThrowIfNull(schema);
@@ -65,26 +63,31 @@ internal sealed class ResolvedSelectionPath
                 continue;
             }
 
-            if (!schema.Types.TryGetType(segment.Name, out var type))
-            {
-                throw new InvalidOperationException(
-                    $"The inline-fragment type condition '{segment.Name}' in the selection path "
-                    + $"'{path}' does not exist in the schema.");
-            }
-
             fragmentSegments ??= new FragmentSegment[path.Length];
 
-            var possibleTypes = type.Kind is TypeKind.Interface or TypeKind.Union
-                ? ((FusionSchemaDefinition)schema).GetPossibleTypes(type)
-                : ImmutableArray<FusionObjectTypeDefinition>.Empty;
+            // A type condition the schema cannot resolve (for example a type removed from the
+            // schema after a plan was cached) is kept as a name-only segment. Such segments match
+            // by type-name equality, preserving the behavior of the original string-based matching.
+            if (schema.Types.TryGetType(segment.Name, allowInaccessibleFields: true, out var type))
+            {
+                var possibleTypes = type.Kind is TypeKind.Interface or TypeKind.Union
+                    ? schema.GetPossibleTypes(type)
+                    : ImmutableArray<FusionObjectTypeDefinition>.Empty;
 
-            fragmentSegments[i] = new FragmentSegment(type, possibleTypes);
+                fragmentSegments[i] = new FragmentSegment(type, possibleTypes);
+            }
+            else
+            {
+                fragmentSegments[i] = new FragmentSegment(
+                    TypeCondition: null,
+                    ImmutableArray<FusionObjectTypeDefinition>.Empty);
+            }
         }
 
         return new ResolvedSelectionPath(path, fragmentSegments);
     }
 
     private readonly record struct FragmentSegment(
-        ITypeDefinition TypeCondition,
+        ITypeDefinition? TypeCondition,
         ImmutableArray<FusionObjectTypeDefinition> PossibleTypes);
 }

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/ResolvedSelectionPath.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/ResolvedSelectionPath.cs
@@ -1,0 +1,90 @@
+using System.Collections.Immutable;
+using HotChocolate.Execution;
+using HotChocolate.Fusion.Types;
+using HotChocolate.Types;
+
+namespace HotChocolate.Fusion.Execution.Nodes;
+
+/// <summary>
+/// Pairs a <see cref="SelectionPath"/> with the type-system information needed to match its
+/// inline-fragment segments against runtime data. Resolving the type conditions once when the
+/// plan is built lets the result store match segments without consulting the schema during
+/// execution.
+/// </summary>
+internal sealed class ResolvedSelectionPath
+{
+    private readonly FragmentSegment[]? _fragmentSegments;
+
+    private ResolvedSelectionPath(SelectionPath path, FragmentSegment[]? fragmentSegments)
+    {
+        Path = path;
+        _fragmentSegments = fragmentSegments;
+    }
+
+    /// <summary>
+    /// Gets the underlying selection path.
+    /// </summary>
+    public SelectionPath Path { get; }
+
+    /// <summary>
+    /// Gets the resolved type condition of the inline-fragment segment at the specified index.
+    /// </summary>
+    public ITypeDefinition GetTypeCondition(int index)
+        => _fragmentSegments![index].TypeCondition;
+
+    /// <summary>
+    /// Gets the object types that satisfy the inline-fragment type condition at the specified index.
+    /// The result is empty when the condition is a concrete object type.
+    /// </summary>
+    public ImmutableArray<FusionObjectTypeDefinition> GetPossibleTypes(int index)
+        => _fragmentSegments![index].PossibleTypes;
+
+    /// <summary>
+    /// Resolves the inline-fragment type conditions of <paramref name="path"/> against
+    /// <paramref name="schema"/>.
+    /// </summary>
+    /// <param name="path">The selection path to resolve.</param>
+    /// <param name="schema">The schema that provides the type conditions.</param>
+    /// <returns>A <see cref="ResolvedSelectionPath"/> for <paramref name="path"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// An inline-fragment type condition does not exist in the schema.
+    /// </exception>
+    public static ResolvedSelectionPath Create(SelectionPath path, ISchemaDefinition schema)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(schema);
+
+        FragmentSegment[]? fragmentSegments = null;
+
+        for (var i = 0; i < path.Length; i++)
+        {
+            var segment = path[i];
+
+            if (segment.Kind is not SelectionPathSegmentKind.InlineFragment)
+            {
+                continue;
+            }
+
+            if (!schema.Types.TryGetType(segment.Name, out var type))
+            {
+                throw new InvalidOperationException(
+                    $"The inline-fragment type condition '{segment.Name}' in the selection path "
+                    + $"'{path}' does not exist in the schema.");
+            }
+
+            fragmentSegments ??= new FragmentSegment[path.Length];
+
+            var possibleTypes = type.Kind is TypeKind.Interface or TypeKind.Union
+                ? ((FusionSchemaDefinition)schema).GetPossibleTypes(type)
+                : ImmutableArray<FusionObjectTypeDefinition>.Empty;
+
+            fragmentSegments[i] = new FragmentSegment(type, possibleTypes);
+        }
+
+        return new ResolvedSelectionPath(path, fragmentSegments);
+    }
+
+    private readonly record struct FragmentSegment(
+        ITypeDefinition TypeCondition,
+        ImmutableArray<FusionObjectTypeDefinition> PossibleTypes);
+}

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanFormatter.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanFormatter.cs
@@ -598,16 +598,16 @@ public sealed class JsonOperationPlanFormatter(JsonWriterOptions? options = null
         jsonWriter.WritePropertyName("resultSelectionSet");
         jsonWriter.WriteStringValue(operationDef.ResultSelectionSet.ToString(indented: false));
 
-        if (!operationDef.Source.IsRoot)
+        if (!operationDef.Source.Path.IsRoot)
         {
             jsonWriter.WritePropertyName("source");
-            jsonWriter.WriteStringValue(operationDef.Source.ToString());
+            jsonWriter.WriteStringValue(operationDef.Source.Path.ToString());
         }
 
-        if (!operationDef.Target.IsRoot)
+        if (!operationDef.Target.Path.IsRoot)
         {
             jsonWriter.WritePropertyName("target");
-            jsonWriter.WriteStringValue(operationDef.Target.ToString());
+            jsonWriter.WriteStringValue(operationDef.Target.Path.ToString());
         }
 
         jsonWriter.WritePropertyName("batchingGroupId");
@@ -728,10 +728,10 @@ public sealed class JsonOperationPlanFormatter(JsonWriterOptions? options = null
         jsonWriter.WritePropertyName("resultSelectionSet");
         jsonWriter.WriteStringValue(operationDef.ResultSelectionSet.ToString(indented: false));
 
-        if (!operationDef.Source.IsRoot)
+        if (!operationDef.Source.Path.IsRoot)
         {
             jsonWriter.WritePropertyName("source");
-            jsonWriter.WriteStringValue(operationDef.Source.ToString());
+            jsonWriter.WriteStringValue(operationDef.Source.Path.ToString());
         }
 
         jsonWriter.WritePropertyName("targets");
@@ -739,7 +739,7 @@ public sealed class JsonOperationPlanFormatter(JsonWriterOptions? options = null
 
         foreach (var target in operationDef.Targets)
         {
-            jsonWriter.WriteStringValue(target.ToString());
+            jsonWriter.WriteStringValue(target.Path.ToString());
         }
 
         jsonWriter.WriteEndArray();

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanParser.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanParser.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Text.Json;
 using HotChocolate.Execution;
 using HotChocolate.Fusion.Language;
+using HotChocolate.Fusion.Types;
 using HotChocolate.Fusion.Types.Directives;
 using HotChocolate.Language;
 using HotChocolate.Types;
@@ -258,11 +259,11 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
                     break;
 
                 case "Introspection":
-                    parsedNodes.Add(ParseIntrospectionNodeInfo(nodeElement, id, operation));
+                    parsedNodes.Add(ParseIntrospectionNodeInfo(nodeElement, id, operation, schema));
                     break;
 
                 case "Node":
-                    parsedNodes.Add(ParseNodeFieldNodeInfo(nodeElement, id, operation));
+                    parsedNodes.Add(ParseNodeFieldNodeInfo(nodeElement, id, operation, schema));
                     break;
 
                 default:
@@ -492,7 +493,7 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
     }
 
     private static ParsedOperationNodeInfo ParseOperationNodeInfo(
-        JsonElement nodeElement, int id, ISchemaDefinition schema)
+        JsonElement nodeElement, int id, FusionSchemaDefinition schema)
     {
         var (schemaName, opSource, source, requirements, forwardedVariables,
             resultSelectionSet, dependencies, parentDependencies, batchingGroupId, conditions,
@@ -525,7 +526,7 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
     }
 
     private static ParsedEventStreamNodeInfo ParseEventStreamNodeInfo(
-        JsonElement nodeElement, int id, ISchemaDefinition schema)
+        JsonElement nodeElement, int id, FusionSchemaDefinition schema)
     {
         var resultSelectionSet = Utf8GraphQLParser.Syntax.ParseSelectionSet(
             nodeElement.GetProperty("resultSelectionSet").GetString()!);
@@ -609,7 +610,7 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
     }
 
     private static ParsedOperationNodeInfo ParseOperationBatchNodeInfo(
-        JsonElement nodeElement, int id, ISchemaDefinition schema)
+        JsonElement nodeElement, int id, FusionSchemaDefinition schema)
     {
         var (schemaName, opSource, source, requirements, forwardedVariables,
             resultSelectionSet, dependencies, parentDependencies, batchingGroupId, conditions,
@@ -766,7 +767,8 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
     private static ParsedNodeInfo ParseIntrospectionNodeInfo(
         JsonElement nodeElement,
         int id,
-        Operation operation)
+        Operation operation,
+        FusionSchemaDefinition schema)
     {
         var selectionsElement = nodeElement.GetProperty("selections");
         var selections = new List<Selection>();
@@ -784,7 +786,8 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
         {
             Id = id,
             Selections = selections.ToArray(),
-            Conditions = conditions
+            Conditions = conditions,
+            Schema = schema
         };
 
         Selection GetRootSelection(string responseName)
@@ -803,7 +806,7 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
     }
 
     private static ParsedNodeInfo ParseNodeFieldNodeInfo(
-        JsonElement nodeElement, int id, Operation operation)
+        JsonElement nodeElement, int id, Operation operation, FusionSchemaDefinition schema)
     {
         var responseName = nodeElement.GetProperty("responseName").GetString()!;
 
@@ -846,7 +849,8 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
             IdValue = idValue,
             Conditions = conditions,
             Branches = branches,
-            FallbackNodeId = fallbackNodeId
+            FallbackNodeId = fallbackNodeId,
+            Schema = schema
         };
     }
 
@@ -880,6 +884,7 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
     {
         public int Id { get; init; }
         public int[]? Dependencies { get; init; }
+        public required FusionSchemaDefinition Schema { get; init; }
 
         public abstract (ExecutionNode Node, int[]? Dependencies, Dictionary<string, int>? Branches, int? Fallback)
             ToExecutionNodeTuple();
@@ -897,7 +902,6 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
         public int[]? ParentDependencies { get; init; }
         public ExecutionNodeCondition[] Conditions { get; init; } = [];
         public bool RequiresFileUpload { get; init; }
-        public required ISchemaDefinition Schema { get; init; }
 
         public abstract OperationDefinition ToOperationDefinition();
     }
@@ -974,8 +978,6 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
         public int[]? ParentDependencies { get; init; }
 
         public ExecutionNodeCondition[] Conditions { get; init; } = [];
-
-        public required ISchemaDefinition Schema { get; init; }
 
         public override (ExecutionNode, int[]?, Dictionary<string, int>?, int?) ToExecutionNodeTuple()
         {

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanParser.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanParser.cs
@@ -552,7 +552,8 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
             Message = message,
             Dependencies = dependencies,
             ParentDependencies = parentDependencies,
-            Conditions = conditions
+            Conditions = conditions,
+            Schema = schema
         };
     }
 
@@ -911,8 +912,8 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
                 Id,
                 OperationSource,
                 SchemaName,
-                Target,
-                Source,
+                ResolvedSelectionPath.Create(Target, Schema),
+                ResolvedSelectionPath.Create(Source, Schema),
                 Requirements,
                 ForwardedVariables,
                 ResultSelectionSet,
@@ -936,8 +937,8 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
                 Id,
                 OperationSource,
                 SchemaName,
-                Target,
-                Source,
+                ResolvedSelectionPath.Create(Target, Schema),
+                ResolvedSelectionPath.Create(Source, Schema),
                 Requirements,
                 ForwardedVariables,
                 ResultSelectionSet,
@@ -974,13 +975,15 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
 
         public ExecutionNodeCondition[] Conditions { get; init; } = [];
 
+        public required ISchemaDefinition Schema { get; init; }
+
         public override (ExecutionNode, int[]?, Dictionary<string, int>?, int?) ToExecutionNodeTuple()
         {
             var node = new EventStreamExecutionNode(
                 Id,
                 FieldName,
-                Target,
-                Source,
+                ResolvedSelectionPath.Create(Target, Schema),
+                ResolvedSelectionPath.Create(Source, Schema),
                 ResultSelectionSet,
                 EventStreamSource,
                 Message,
@@ -1004,12 +1007,18 @@ public sealed class JsonOperationPlanParser : OperationPlanParser
 
         public override OperationDefinition ToOperationDefinition()
         {
+            var resolvedTargets = new ResolvedSelectionPath[Targets.Length];
+            for (var i = 0; i < Targets.Length; i++)
+            {
+                resolvedTargets[i] = ResolvedSelectionPath.Create(Targets[i], Schema);
+            }
+
             var definition = new BatchOperationDefinition(
                 Id,
                 OperationSource,
                 SchemaName,
-                Targets,
-                Source,
+                resolvedTargets,
+                ResolvedSelectionPath.Create(Source, Schema),
                 Requirements,
                 ForwardedVariables,
                 ResultSelectionSet,

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/YamlOperationPlanFormatter.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/Serialization/YamlOperationPlanFormatter.cs
@@ -410,14 +410,14 @@ public sealed class YamlOperationPlanFormatter : OperationPlanFormatter
         }
         writer.Unindent();
 
-        if (!opDef.Source.IsRoot)
+        if (!opDef.Source.Path.IsRoot)
         {
-            writer.WriteLine("source: {0}", opDef.Source.ToString());
+            writer.WriteLine("source: {0}", opDef.Source.Path.ToString());
         }
 
-        if (!opDef.Target.IsRoot)
+        if (!opDef.Target.Path.IsRoot)
         {
-            writer.WriteLine("target: {0}", opDef.Target.ToString());
+            writer.WriteLine("target: {0}", opDef.Target.Path.ToString());
         }
 
         writer.WriteLine("batchingGroupId: {0}", batchNode.Id);
@@ -464,9 +464,9 @@ public sealed class YamlOperationPlanFormatter : OperationPlanFormatter
         }
         writer.Unindent();
 
-        if (!opDef.Source.IsRoot)
+        if (!opDef.Source.Path.IsRoot)
         {
-            writer.WriteLine("source: {0}", opDef.Source.ToString());
+            writer.WriteLine("source: {0}", opDef.Source.Path.ToString());
         }
 
         if (opDef.Targets.Length > 0)
@@ -475,7 +475,7 @@ public sealed class YamlOperationPlanFormatter : OperationPlanFormatter
             writer.Indent();
             foreach (var target in opDef.Targets)
             {
-                writer.WriteLine("- {0}", target.ToString());
+                writer.WriteLine("- {0}", target.Path.ToString());
             }
             writer.Unindent();
         }

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/SingleOperationDefinition.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Nodes/SingleOperationDefinition.cs
@@ -1,5 +1,3 @@
-using HotChocolate.Execution;
-
 namespace HotChocolate.Fusion.Execution.Nodes;
 
 internal sealed class SingleOperationDefinition : OperationDefinition
@@ -8,8 +6,8 @@ internal sealed class SingleOperationDefinition : OperationDefinition
         int id,
         OperationSourceText operation,
         string? schemaName,
-        SelectionPath target,
-        SelectionPath source,
+        ResolvedSelectionPath target,
+        ResolvedSelectionPath source,
         OperationRequirement[] requirements,
         string[] forwardedVariables,
         ResultSelectionSet resultSelectionSet,
@@ -32,5 +30,5 @@ internal sealed class SingleOperationDefinition : OperationDefinition
     /// <summary>
     /// Gets the path to the selection set for which this operation fetches data.
     /// </summary>
-    public SelectionPath Target { get; }
+    public ResolvedSelectionPath Target { get; }
 }

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanContext.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanContext.cs
@@ -308,7 +308,7 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
         => _executionState.EnqueueMerge(merge);
 
     internal ImmutableArray<VariableValues> CreateVariableValueSets(
-        SelectionPath selectionSet,
+        ResolvedSelectionPath selectionSet,
         ReadOnlySpan<string> forwardedVariables,
         ReadOnlySpan<OperationRequirement> requirements)
     {
@@ -318,12 +318,12 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
         {
             if (forwardedVariables.Length == 0)
             {
-                if (selectionSet.IsRoot)
+                if (selectionSet.Path.IsRoot)
                 {
                     return [];
                 }
 
-                return [_resultStore.CreateVariableValueSets(ToResultPath(selectionSet), [])];
+                return [_resultStore.CreateVariableValueSets(ToResultPath(selectionSet.Path), [])];
             }
 
             var variableValues = GetPathThroughVariables(forwardedVariables);
@@ -363,7 +363,7 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     }
 
     internal ImmutableArray<VariableValues> CreateVariableValueSets(
-        ReadOnlySpan<SelectionPath> selectionSets,
+        ReadOnlySpan<ResolvedSelectionPath> selectionSets,
         ReadOnlySpan<string> forwardedVariables,
         ReadOnlySpan<OperationRequirement> requiredData)
     {
@@ -554,7 +554,7 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     }
 
     internal void AddPartialResult(
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         SourceSchemaResult result,
         ResultSelectionSet resultSelectionSet,
         bool containsErrors)
@@ -569,7 +569,7 @@ public sealed partial class OperationPlanContext : IFeatureProvider, IAsyncDispo
     }
 
     internal void AddPartialResults(
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         ReadOnlySpan<SourceSchemaResult> results,
         ResultSelectionSet resultSelectionSet,
         bool containsErrors)

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanExecutor.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanExecutor.cs
@@ -7,6 +7,7 @@ using HotChocolate.Execution;
 using HotChocolate.Fusion.Execution.Nodes;
 using HotChocolate.Fusion.Execution.Results;
 using HotChocolate.Fusion.Text.Json;
+using HotChocolate.Fusion.Types;
 using HotChocolate.Language;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -567,7 +568,7 @@ internal static class OperationPlanExecutor
         }
 
         var parentValues = parentResultStore.CreateVariableValueSets(
-            ResolvedSelectionPath.Create(anchor, childContext.Schema),
+            incrementalPlan.GetRequirementAnchor(anchor, (FusionSchemaDefinition)childContext.Schema),
             requestVariables: [],
             requirementSpan);
 

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanExecutor.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/OperationPlanExecutor.cs
@@ -567,7 +567,7 @@ internal static class OperationPlanExecutor
         }
 
         var parentValues = parentResultStore.CreateVariableValueSets(
-            anchor,
+            ResolvedSelectionPath.Create(anchor, childContext.Schema),
             requestVariables: [],
             requirementSpan);
 

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/PendingMerge.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/PendingMerge.cs
@@ -16,7 +16,7 @@ internal readonly struct PendingMerge
     private PendingMerge(
         ExecutionNode node,
         string schemaName,
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         ResultSelectionSet resultSelectionSet,
         ImmutableArray<VariableValues> variableValueSets,
         bool containsErrors,
@@ -41,7 +41,7 @@ internal readonly struct PendingMerge
 
     public string SchemaName { get; }
 
-    public SelectionPath SourcePath { get; }
+    public ResolvedSelectionPath SourcePath { get; }
 
     public ResultSelectionSet ResultSelectionSet { get; }
 
@@ -52,7 +52,7 @@ internal readonly struct PendingMerge
     public static PendingMerge Single(
         ExecutionNode node,
         string schemaName,
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         ResultSelectionSet resultSelectionSet,
         ImmutableArray<VariableValues> variableValueSets,
         SourceSchemaResult result,
@@ -72,7 +72,7 @@ internal readonly struct PendingMerge
     public static PendingMerge Multiple(
         ExecutionNode node,
         string schemaName,
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         ResultSelectionSet resultSelectionSet,
         ImmutableArray<VariableValues> variableValueSets,
         SourceSchemaResult[] buffer,

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Results/FetchResultStore.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Results/FetchResultStore.cs
@@ -11,6 +11,7 @@ using HotChocolate.Fusion.Execution.Clients;
 using HotChocolate.Fusion.Execution.Nodes;
 using HotChocolate.Fusion.Language;
 using HotChocolate.Fusion.Text.Json;
+using HotChocolate.Fusion.Types;
 using HotChocolate.Language;
 using HotChocolate.Types;
 using HotChocolate.Text.Json;
@@ -72,7 +73,7 @@ internal sealed partial class FetchResultStore : IDisposable
     public List<IDisposable> MemoryOwners => _memory;
 
     public bool AddPartialResult(
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         SourceSchemaResult result,
         ResultSelectionSet resultSelectionSet,
         bool containsErrors)
@@ -86,7 +87,7 @@ internal sealed partial class FetchResultStore : IDisposable
     }
 
     public bool AddPartialResults(
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         ReadOnlySpan<SourceSchemaResult> results,
         ResultSelectionSet resultSelectionSet,
         bool containsErrors)
@@ -133,7 +134,7 @@ internal sealed partial class FetchResultStore : IDisposable
                 }
 
                 dataElementsSpan[i] = GetDataElement(sourcePath, result.Data);
-                errorTriesSpan[i] = GetErrorTrie(sourcePath, errors?.Trie);
+                errorTriesSpan[i] = GetErrorTrie(sourcePath.Path, errors?.Trie);
             }
 
             lock (_lock)
@@ -206,7 +207,7 @@ internal sealed partial class FetchResultStore : IDisposable
     }
 
     private bool AddPartialResultsNoErrors(
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         ReadOnlySpan<SourceSchemaResult> results,
         ResultSelectionSet resultSelectionSet)
     {
@@ -283,13 +284,13 @@ internal sealed partial class FetchResultStore : IDisposable
     }
 
     private bool AddSinglePartialResult(
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         SourceSchemaResult result,
         ResultSelectionSet resultSelectionSet)
     {
         var errors = result.Errors;
         var dataElement = GetDataElement(sourcePath, result.Data);
-        var errorTrie = GetErrorTrie(sourcePath, errors?.Trie);
+        var errorTrie = GetErrorTrie(sourcePath.Path, errors?.Trie);
 
         lock (_lock)
         {
@@ -319,7 +320,7 @@ internal sealed partial class FetchResultStore : IDisposable
     }
 
     private bool AddSinglePartialResultNoErrors(
-        SelectionPath sourcePath,
+        ResolvedSelectionPath sourcePath,
         SourceSchemaResult result,
         ResultSelectionSet resultSelectionSet)
     {
@@ -669,7 +670,7 @@ AddErrors_Next:
     }
 
     public ImmutableArray<VariableValues> CreateVariableValueSets(
-        SelectionPath selectionSet,
+        ResolvedSelectionPath selectionSet,
         IReadOnlyList<ObjectFieldNode> requestVariables,
         ReadOnlySpan<OperationRequirement> requiredData)
     {
@@ -704,7 +705,7 @@ AddErrors_Next:
     /// into a single <see cref="VariableValues"/> entry via <see cref="VariableValues.AdditionalPaths"/>.
     /// </summary>
     public ImmutableArray<VariableValues> CreateVariableValueSets(
-        ReadOnlySpan<SelectionPath> selectionSets,
+        ReadOnlySpan<ResolvedSelectionPath> selectionSets,
         IReadOnlyList<ObjectFieldNode> requestVariables,
         ReadOnlySpan<OperationRequirement> requiredData)
     {
@@ -787,8 +788,9 @@ AddErrors_Next:
     }
 
     // Caller must hold _lock for reading.
-    private ReadOnlySpan<CompositeResultElement> CollectTargetElements(SelectionPath selectionSet)
+    private ReadOnlySpan<CompositeResultElement> CollectTargetElements(ResolvedSelectionPath selectionSet)
     {
+        var path = selectionSet.Path;
         var current = _collectTargetA;
         var currentCount = 0;
         var next = _collectTargetB;
@@ -796,18 +798,18 @@ AddErrors_Next:
 
         current[currentCount++] = _result.Data;
 
-        for (var i = 0; i < selectionSet.Length; i++)
+        for (var i = 0; i < path.Length; i++)
         {
-            var segment = selectionSet[i];
+            var segment = path[i];
 
             if (segment.Kind is SelectionPathSegmentKind.InlineFragment)
             {
+                var typeCondition = selectionSet.GetTypeCondition(i);
+
                 for (var j = 0; j < currentCount; j++)
                 {
                     var element = current[j];
-                    if (element.TryGetProperty(IntrospectionFieldNames.TypeNameSpan, out var value)
-                        && value.ValueKind is JsonValueKind.String
-                        && value.TextEqualsHelper(segment.Name, isPropertyName: false))
+                    if (typeCondition.IsAssignableFrom(element.AssertSelectionSet().Type))
                     {
                         AddToBuffer(ref next, ref nextCount, element);
                     }
@@ -863,6 +865,27 @@ AddErrors_Next:
         _collectTargetA = current;
         _collectTargetB = next;
         return current.AsSpan(0, currentCount);
+    }
+
+    private static bool MatchesFragmentTypeCondition(
+        SourceResultElement typeName,
+        string typeCondition,
+        ImmutableArray<FusionObjectTypeDefinition> possibleTypes)
+    {
+        if (typeName.TextEqualsHelper(typeCondition, isPropertyName: false))
+        {
+            return true;
+        }
+
+        foreach (var possibleType in possibleTypes)
+        {
+            if (typeName.TextEqualsHelper(possibleType.Name, isPropertyName: false))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private ImmutableArray<VariableValues> BuildVariableValueSetsFromSnapshot(
@@ -1806,16 +1829,20 @@ AddErrors_Next:
         return buffer;
     }
 
-    private static SourceResultElement GetDataElement(SelectionPath sourcePath, SourceResultElement data)
+    private static SourceResultElement GetDataElement(
+        ResolvedSelectionPath sourcePath,
+        SourceResultElement data)
     {
-        if (sourcePath.IsRoot)
+        var path = sourcePath.Path;
+
+        if (path.IsRoot)
         {
             return data;
         }
 
         var current = data;
 
-        for (var i = 0; i < sourcePath.Length; i++)
+        for (var i = 0; i < path.Length; i++)
         {
             if (current.ValueKind != JsonValueKind.Object)
             {
@@ -1825,7 +1852,7 @@ AddErrors_Next:
                 return current.ValueKind is JsonValueKind.Null ? current : default;
             }
 
-            var segment = sourcePath[i];
+            var segment = path[i];
 
             switch (segment.Kind)
             {
@@ -1840,9 +1867,10 @@ AddErrors_Next:
                 case SelectionPathSegmentKind.InlineFragment:
                     if (!current.TryGetProperty(IntrospectionFieldNames.TypeNameSpan, out var typeNameProperty)
                             || typeNameProperty.ValueKind != JsonValueKind.String
-                            || !typeNameProperty.TextEqualsHelper(
+                            || !MatchesFragmentTypeCondition(
+                                typeNameProperty,
                                 segment.Name,
-                                isPropertyName: false))
+                                sourcePath.GetPossibleTypes(i)))
                     {
                         return default;
                     }

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Results/FetchResultStore.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Execution/Results/FetchResultStore.cs
@@ -809,7 +809,20 @@ AddErrors_Next:
                 for (var j = 0; j < currentCount; j++)
                 {
                     var element = current[j];
-                    if (typeCondition.IsAssignableFrom(element.AssertSelectionSet().Type))
+                    var elementType = element.SelectionSet?.Type;
+
+                    if (elementType is null)
+                    {
+                        continue;
+                    }
+
+                    // A resolved condition is matched by type identity; an unresolved (name-only)
+                    // condition is matched by type-name equality, mirroring the source-side behavior.
+                    var matches = typeCondition is null
+                        ? string.Equals(elementType.Name, segment.Name, StringComparison.Ordinal)
+                        : typeCondition.IsAssignableFrom(elementType);
+
+                    if (matches)
                     {
                         AddToBuffer(ref next, ref nextCount, element);
                     }

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Planning/OperationPlanner.BuildExecutionTree.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Planning/OperationPlanner.BuildExecutionTree.cs
@@ -455,7 +455,7 @@ public sealed partial class OperationPlanner
     private static void BuildExecutionNodes(
         ImmutableList<PlanStep> planSteps,
         ExecutionPlanBuildContext ctx,
-        ISchemaDefinition schema,
+        FusionSchemaDefinition schema,
         bool hasVariables,
         CancellationToken cancellationToken)
     {
@@ -513,7 +513,7 @@ public sealed partial class OperationPlanner
 
     private static OperationExecutionNode CreateOperationExecutionNode(
         OperationPlanStep operationStep,
-        ISchemaDefinition schema,
+        FusionSchemaDefinition schema,
         bool requiresUpload,
         List<string>? variableBuffer)
     {
@@ -576,7 +576,7 @@ public sealed partial class OperationPlanner
 
     private static EventStreamExecutionNode CreateEventStreamExecutionNode(
         OperationPlanStep operationStep,
-        ISchemaDefinition schema)
+        FusionSchemaDefinition schema)
     {
         var eventStreamPlan = operationStep.EventStreamPlan
             ?? throw new InvalidOperationException("The operation step does not carry event-stream metadata.");

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Planning/OperationPlanner.BuildExecutionTree.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Planning/OperationPlanner.BuildExecutionTree.cs
@@ -558,8 +558,8 @@ public sealed partial class OperationPlanner
             operationStep.Id,
             operationSource,
             operationStep.SchemaName,
-            operationStep.Target,
-            operationStep.Source,
+            ResolvedSelectionPath.Create(operationStep.Target, schema),
+            ResolvedSelectionPath.Create(operationStep.Source, schema),
             requirements,
             forwardedVariables,
             resultSelectionSet,
@@ -588,8 +588,8 @@ public sealed partial class OperationPlanner
         var node = new EventStreamExecutionNode(
             operationStep.Id,
             eventStreamPlan.FieldName,
-            operationStep.Target,
-            operationStep.Source,
+            ResolvedSelectionPath.Create(operationStep.Target, schema),
+            ResolvedSelectionPath.Create(operationStep.Source, schema),
             resultSelectionSet,
             eventStreamPlan.Source,
             eventStreamPlan.Message,
@@ -683,11 +683,11 @@ public sealed partial class OperationPlanner
 
                 var primary = group[0];
                 var (canonicalOp, canonicalRequirements) = CanonicalizeOperation(primary);
-                var targets = new SelectionPath[group.Count];
+                var targets = new ResolvedSelectionPath[group.Count];
 
                 for (var i = 0; i < group.Count; i++)
                 {
-                    targets[i] = group[i].Target;
+                    targets[i] = group[i].ResolvedTarget;
                 }
 
                 mergeResults[primary.Id] = new MergeResult(
@@ -990,7 +990,7 @@ public sealed partial class OperationPlanner
             merge.CanonicalOp,
             primary.SchemaName,
             merge.Targets,
-            primary.Source,
+            primary.ResolvedSource,
             merge.CanonicalRequirements,
             primary.ForwardedVariables.ToArray(),
             primary.ResultSelectionSet,
@@ -1011,8 +1011,8 @@ public sealed partial class OperationPlanner
             member.Id,
             member.Operation,
             member.SchemaName,
-            member.Target,
-            member.Source,
+            member.ResolvedTarget,
+            member.ResolvedSource,
             member.Requirements.ToArray(),
             member.ForwardedVariables.ToArray(),
             member.ResultSelectionSet,
@@ -2008,7 +2008,7 @@ public sealed partial class OperationPlanner
     }
 
     private readonly record struct MergeResult(
-        SelectionPath[] Targets,
+        ResolvedSelectionPath[] Targets,
         OperationSourceText CanonicalOp,
         OperationRequirement[] CanonicalRequirements,
         OperationExecutionNode Primary);

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Text/Json/CompositeResultDocument.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Text/Json/CompositeResultDocument.cs
@@ -53,6 +53,11 @@ public sealed partial class CompositeResultDocument : IDisposable
     {
         var row = _metaDb.Get(cursor);
 
+        if (row.TokenType is ElementTokenType.Reference)
+        {
+            row = _metaDb.Get(new Cursor(row.Location));
+        }
+
         if (row.OperationReferenceType is not OperationReferenceType.SelectionSet)
         {
             return null;

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Text/Json/CompositeResultDocument.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Text/Json/CompositeResultDocument.cs
@@ -51,12 +51,7 @@ public sealed partial class CompositeResultDocument : IDisposable
 
     internal SelectionSet? GetSelectionSet(Cursor cursor)
     {
-        var row = _metaDb.Get(cursor);
-
-        if (row.TokenType is ElementTokenType.Reference)
-        {
-            row = _metaDb.Get(new Cursor(row.Location));
-        }
+        var row = _metaDb.GetValue(ref cursor);
 
         if (row.OperationReferenceType is not OperationReferenceType.SelectionSet)
         {

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/AbstractTypeTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/AbstractTypeTests.cs
@@ -1274,6 +1274,103 @@ public class AbstractTypeTests : FusionTestBase
         await MatchSnapshotAsync(gateway, request, result);
     }
 
+    [Fact]
+    public async Task Nested_Interface_Fragment_With_Field_Resolved_From_Other_Schema()
+    {
+        // arrange
+        using var serverA = CreateSourceSchema(
+            "A",
+            """
+            type Query {
+              orders: [OrderBase!]!
+            }
+
+            interface OrderBase {
+              name: String!
+            }
+
+            interface MultiOrderBase implements OrderBase {
+              name: String!
+              items: [OrderItem!]!
+            }
+
+            type OrderA implements MultiOrderBase & OrderBase {
+              name: String!
+              items: [OrderItem!]!
+            }
+
+            type OrderB implements MultiOrderBase & OrderBase {
+              name: String!
+              items: [OrderItem!]!
+            }
+
+            type OrderItem {
+              product: Product!
+            }
+
+            type Product @key(fields: "id") {
+              id: ID!
+            }
+            """);
+
+        using var serverB = CreateSourceSchema(
+            "B",
+            """
+            type Query {
+              productById(id: ID!): Product @lookup
+            }
+
+            type Product @key(fields: "id") {
+              id: ID!
+              name: String!
+              description: String!
+            }
+            """);
+
+        using var gateway = await CreateCompositeSchemaAsync(
+        [
+            ("A", serverA),
+            ("B", serverB)
+        ]);
+
+        // act
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        var request = new OperationRequest(
+            """
+            query {
+              orders {
+                ...OrderBaseFragment
+              }
+            }
+
+            fragment OrderBaseFragment on OrderBase {
+              __typename
+              name
+              ...MultiOrderBaseFragment
+            }
+
+            fragment MultiOrderBaseFragment on MultiOrderBase {
+              __typename
+              items {
+                product {
+                  id
+                  name
+                  description
+                }
+              }
+            }
+            """);
+
+        using var result = await client.PostAsync(
+            request,
+            new Uri("http://localhost:5000/graphql"),
+            TestContext.Current.CancellationToken);
+
+        // assert
+        await MatchSnapshotAsync(gateway, request, result);
+    }
+
     public static class SourceSchema1
     {
         public class Query

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/AbstractTypeTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/AbstractTypeTests.cs
@@ -1371,6 +1371,197 @@ public class AbstractTypeTests : FusionTestBase
         await MatchSnapshotAsync(gateway, request, result);
     }
 
+    [Fact]
+    public async Task Three_Level_Interface_Fragment_With_Field_Resolved_From_Other_Schema()
+    {
+        // arrange
+        using var serverA = CreateSourceSchema(
+            "A",
+            """
+            type Query {
+              orders: [OrderBase!]!
+            }
+
+            interface OrderBase {
+              name: String!
+            }
+
+            interface MultiOrderBase implements OrderBase {
+              name: String!
+              items: [OrderItem!]!
+            }
+
+            interface DetailedOrderBase implements MultiOrderBase & OrderBase {
+              name: String!
+              items: [OrderItem!]!
+              priority: Int!
+            }
+
+            type OrderA implements DetailedOrderBase & MultiOrderBase & OrderBase {
+              name: String!
+              items: [OrderItem!]!
+              priority: Int!
+            }
+
+            type OrderB implements DetailedOrderBase & MultiOrderBase & OrderBase {
+              name: String!
+              items: [OrderItem!]!
+              priority: Int!
+            }
+
+            type OrderItem {
+              product: Product!
+            }
+
+            type Product @key(fields: "id") {
+              id: ID!
+            }
+            """);
+
+        using var serverB = CreateSourceSchema(
+            "B",
+            """
+            type Query {
+              productById(id: ID!): Product @lookup
+            }
+
+            type Product @key(fields: "id") {
+              id: ID!
+              name: String!
+              description: String!
+            }
+            """);
+
+        using var gateway = await CreateCompositeSchemaAsync(
+        [
+            ("A", serverA),
+            ("B", serverB)
+        ]);
+
+        // act
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        var request = new OperationRequest(
+            """
+            query {
+              orders {
+                ...OrderBaseFragment
+              }
+            }
+
+            fragment OrderBaseFragment on OrderBase {
+              __typename
+              name
+              ...MultiOrderBaseFragment
+            }
+
+            fragment MultiOrderBaseFragment on MultiOrderBase {
+              __typename
+              items {
+                product {
+                  id
+                  name
+                  description
+                }
+              }
+              ...DetailedOrderBaseFragment
+            }
+
+            fragment DetailedOrderBaseFragment on DetailedOrderBase {
+              __typename
+              priority
+            }
+            """);
+
+        using var result = await client.PostAsync(
+            request,
+            new Uri("http://localhost:5000/graphql"),
+            TestContext.Current.CancellationToken);
+
+        // assert
+        await MatchSnapshotAsync(gateway, request, result);
+    }
+
+    [Fact]
+    public async Task Union_Member_Fragment_With_Field_Resolved_From_Other_Schema()
+    {
+        // arrange
+        using var serverA = CreateSourceSchema(
+            "A",
+            """
+            type Query {
+              feed: [FeedItem!]!
+            }
+
+            union FeedItem = Article | Photo
+
+            type Article @key(fields: "id") {
+              id: ID!
+            }
+
+            type Photo @key(fields: "id") {
+              id: ID!
+            }
+            """);
+
+        using var serverB = CreateSourceSchema(
+            "B",
+            """
+            type Query {
+              articleById(id: ID!): Article @lookup
+              photoById(id: ID!): Photo @lookup
+            }
+
+            type Article @key(fields: "id") {
+              id: ID!
+              headline: String!
+            }
+
+            type Photo @key(fields: "id") {
+              id: ID!
+              caption: String!
+            }
+            """);
+
+        using var gateway = await CreateCompositeSchemaAsync(
+        [
+            ("A", serverA),
+            ("B", serverB)
+        ]);
+
+        // act
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        var request = new OperationRequest(
+            """
+            query {
+              feed {
+                __typename
+                ...ArticleFragment
+                ...PhotoFragment
+              }
+            }
+
+            fragment ArticleFragment on Article {
+              id
+              headline
+            }
+
+            fragment PhotoFragment on Photo {
+              id
+              caption
+            }
+            """);
+
+        using var result = await client.PostAsync(
+            request,
+            new Uri("http://localhost:5000/graphql"),
+            TestContext.Current.CancellationToken);
+
+        // assert
+        await MatchSnapshotAsync(gateway, request, result);
+    }
+
     public static class SourceSchema1
     {
         public class Query

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/AbstractTypeTests.Nested_Interface_Fragment_With_Field_Resolved_From_Other_Schema.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/AbstractTypeTests.Nested_Interface_Fragment_With_Field_Resolved_From_Other_Schema.yaml
@@ -1,0 +1,440 @@
+title: Nested_Interface_Fragment_With_Field_Resolved_From_Other_Schema
+request:
+  document: |
+    {
+      orders {
+        ...OrderBaseFragment
+      }
+    }
+
+    fragment OrderBaseFragment on OrderBase {
+      __typename
+      name
+      ...MultiOrderBaseFragment
+    }
+
+    fragment MultiOrderBaseFragment on MultiOrderBase {
+      __typename
+      items {
+        product {
+          id
+          name
+          description
+        }
+      }
+    }
+response:
+  body: |
+    {
+      "data": {
+        "orders": [
+          {
+            "__typename": "OrderA",
+            "name": "OrderA: T3JkZXJBOjE=",
+            "items": [
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxOQ==",
+                  "name": "Product: UHJvZHVjdDoxOQ==",
+                  "description": "Product: UHJvZHVjdDoxOQ=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoyMA==",
+                  "name": "Product: UHJvZHVjdDoyMA==",
+                  "description": "Product: UHJvZHVjdDoyMA=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoyMQ==",
+                  "name": "Product: UHJvZHVjdDoyMQ==",
+                  "description": "Product: UHJvZHVjdDoyMQ=="
+                }
+              }
+            ]
+          },
+          {
+            "__typename": "OrderB",
+            "name": "OrderB: T3JkZXJCOjI=",
+            "items": [
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxNg==",
+                  "name": "Product: UHJvZHVjdDoxNg==",
+                  "description": "Product: UHJvZHVjdDoxNg=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxNw==",
+                  "name": "Product: UHJvZHVjdDoxNw==",
+                  "description": "Product: UHJvZHVjdDoxNw=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxOA==",
+                  "name": "Product: UHJvZHVjdDoxOA==",
+                  "description": "Product: UHJvZHVjdDoxOA=="
+                }
+              }
+            ]
+          },
+          {
+            "__typename": "OrderA",
+            "name": "OrderA: T3JkZXJBOjM=",
+            "items": [
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxMw==",
+                  "name": "Product: UHJvZHVjdDoxMw==",
+                  "description": "Product: UHJvZHVjdDoxMw=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxNA==",
+                  "name": "Product: UHJvZHVjdDoxNA==",
+                  "description": "Product: UHJvZHVjdDoxNA=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxNQ==",
+                  "name": "Product: UHJvZHVjdDoxNQ==",
+                  "description": "Product: UHJvZHVjdDoxNQ=="
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+sourceSchemas:
+  - name: A
+    schema: |
+      schema {
+        query: Query
+      }
+
+      type Query {
+        orders: [OrderBase!]!
+      }
+
+      type OrderA implements MultiOrderBase & OrderBase {
+        name: String!
+        items: [OrderItem!]!
+      }
+
+      type OrderB implements MultiOrderBase & OrderBase {
+        name: String!
+        items: [OrderItem!]!
+      }
+
+      type OrderItem {
+        product: Product!
+      }
+
+      type Product @key(fields: "id") {
+        id: ID!
+      }
+
+      interface MultiOrderBase implements OrderBase {
+        name: String!
+        items: [OrderItem!]!
+      }
+
+      interface OrderBase {
+        name: String!
+      }
+    interactions:
+      - request:
+          accept: application/graphql-response+json; charset=utf-8, application/json; charset=utf-8, application/jsonl; charset=utf-8, text/event-stream; charset=utf-8
+          document: |
+            query Op_643d0a26_1 {
+              orders {
+                __typename
+                name
+                ... on MultiOrderBase {
+                  __typename
+                  items {
+                    product {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+        response:
+          results:
+            - |
+              {
+                "data": {
+                  "orders": [
+                    {
+                      "__typename": "OrderA",
+                      "name": "OrderA: T3JkZXJBOjE=",
+                      "items": [
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxOQ=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoyMA=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoyMQ=="
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "__typename": "OrderB",
+                      "name": "OrderB: T3JkZXJCOjI=",
+                      "items": [
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxNg=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxNw=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxOA=="
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "__typename": "OrderA",
+                      "name": "OrderA: T3JkZXJBOjM=",
+                      "items": [
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxMw=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxNA=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxNQ=="
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+  - name: B
+    schema: |
+      schema {
+        query: Query
+      }
+
+      type Query {
+        productById(id: ID!): Product @lookup
+      }
+
+      type Product @key(fields: "id") {
+        id: ID!
+        name: String!
+        description: String!
+      }
+    interactions:
+      - request:
+          accept: application/jsonl; charset=utf-8, text/event-stream; charset=utf-8, application/graphql-response+json; charset=utf-8, application/json; charset=utf-8
+          document: |
+            query Op_643d0a26_2($__fusion_1_id: ID!) {
+              productById(id: $__fusion_1_id) {
+                name
+                description
+              }
+            }
+          variables: |
+            [
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxOQ=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoyMA=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoyMQ=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxNg=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxNw=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxOA=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxMw=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxNA=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxNQ=="
+              }
+            ]
+        response:
+          contentType: application/jsonl; charset=utf-8
+          results:
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxOQ==",
+                    "description": "Product: UHJvZHVjdDoxOQ=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoyMA==",
+                    "description": "Product: UHJvZHVjdDoyMA=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoyMQ==",
+                    "description": "Product: UHJvZHVjdDoyMQ=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxNg==",
+                    "description": "Product: UHJvZHVjdDoxNg=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxNw==",
+                    "description": "Product: UHJvZHVjdDoxNw=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxOA==",
+                    "description": "Product: UHJvZHVjdDoxOA=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxMw==",
+                    "description": "Product: UHJvZHVjdDoxMw=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxNA==",
+                    "description": "Product: UHJvZHVjdDoxNA=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxNQ==",
+                    "description": "Product: UHJvZHVjdDoxNQ=="
+                  }
+                }
+              }
+operationPlan:
+  operation:
+    - document: |
+        {
+          orders {
+            __typename
+            name
+            ... on MultiOrderBase {
+              __typename
+              items {
+                product {
+                  id
+                  id @fusion__requirement
+                  name
+                  description
+                }
+              }
+            }
+          }
+        }
+      hash: 643d0a264895d8609f51438a3530f442
+      searchSpace: 1
+      expandedNodes: 2
+  nodes:
+    - id: 1
+      type: Operation
+      schema: A
+      operation: |
+        query Op_643d0a26_1 {
+          orders {
+            __typename
+            name
+            ... on MultiOrderBase {
+              __typename
+              items {
+                product {
+                  id
+                }
+              }
+            }
+          }
+        }
+    - id: 2
+      type: Operation
+      schema: B
+      operation: |
+        query Op_643d0a26_2($__fusion_1_id: ID!) {
+          productById(id: $__fusion_1_id) {
+            name
+            description
+          }
+        }
+      source: $.productById
+      target: $.orders<MultiOrderBase>.items.product
+      requirements:
+        - name: __fusion_1_id
+          selectionMap: >-
+            id
+      dependencies:
+        - id: 1

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/AbstractTypeTests.Three_Level_Interface_Fragment_With_Field_Resolved_From_Other_Schema.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/AbstractTypeTests.Three_Level_Interface_Fragment_With_Field_Resolved_From_Other_Schema.yaml
@@ -1,0 +1,472 @@
+title: Three_Level_Interface_Fragment_With_Field_Resolved_From_Other_Schema
+request:
+  document: |
+    {
+      orders {
+        ...OrderBaseFragment
+      }
+    }
+
+    fragment OrderBaseFragment on OrderBase {
+      __typename
+      name
+      ...MultiOrderBaseFragment
+    }
+
+    fragment MultiOrderBaseFragment on MultiOrderBase {
+      __typename
+      items {
+        product {
+          id
+          name
+          description
+        }
+      }
+      ...DetailedOrderBaseFragment
+    }
+
+    fragment DetailedOrderBaseFragment on DetailedOrderBase {
+      __typename
+      priority
+    }
+response:
+  body: |
+    {
+      "data": {
+        "orders": [
+          {
+            "__typename": "OrderA",
+            "name": "OrderA: T3JkZXJBOjE=",
+            "items": [
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxOQ==",
+                  "name": "Product: UHJvZHVjdDoxOQ==",
+                  "description": "Product: UHJvZHVjdDoxOQ=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoyMA==",
+                  "name": "Product: UHJvZHVjdDoyMA==",
+                  "description": "Product: UHJvZHVjdDoyMA=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoyMQ==",
+                  "name": "Product: UHJvZHVjdDoyMQ==",
+                  "description": "Product: UHJvZHVjdDoyMQ=="
+                }
+              }
+            ],
+            "priority": 123
+          },
+          {
+            "__typename": "OrderB",
+            "name": "OrderB: T3JkZXJCOjI=",
+            "items": [
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxNg==",
+                  "name": "Product: UHJvZHVjdDoxNg==",
+                  "description": "Product: UHJvZHVjdDoxNg=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxNw==",
+                  "name": "Product: UHJvZHVjdDoxNw==",
+                  "description": "Product: UHJvZHVjdDoxNw=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxOA==",
+                  "name": "Product: UHJvZHVjdDoxOA==",
+                  "description": "Product: UHJvZHVjdDoxOA=="
+                }
+              }
+            ],
+            "priority": 123
+          },
+          {
+            "__typename": "OrderA",
+            "name": "OrderA: T3JkZXJBOjM=",
+            "items": [
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxMw==",
+                  "name": "Product: UHJvZHVjdDoxMw==",
+                  "description": "Product: UHJvZHVjdDoxMw=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxNA==",
+                  "name": "Product: UHJvZHVjdDoxNA==",
+                  "description": "Product: UHJvZHVjdDoxNA=="
+                }
+              },
+              {
+                "product": {
+                  "id": "UHJvZHVjdDoxNQ==",
+                  "name": "Product: UHJvZHVjdDoxNQ==",
+                  "description": "Product: UHJvZHVjdDoxNQ=="
+                }
+              }
+            ],
+            "priority": 123
+          }
+        ]
+      }
+    }
+sourceSchemas:
+  - name: A
+    schema: |
+      schema {
+        query: Query
+      }
+
+      type Query {
+        orders: [OrderBase!]!
+      }
+
+      type OrderA implements DetailedOrderBase & MultiOrderBase & OrderBase {
+        name: String!
+        items: [OrderItem!]!
+        priority: Int!
+      }
+
+      type OrderB implements DetailedOrderBase & MultiOrderBase & OrderBase {
+        name: String!
+        items: [OrderItem!]!
+        priority: Int!
+      }
+
+      type OrderItem {
+        product: Product!
+      }
+
+      type Product @key(fields: "id") {
+        id: ID!
+      }
+
+      interface DetailedOrderBase implements MultiOrderBase & OrderBase {
+        name: String!
+        items: [OrderItem!]!
+        priority: Int!
+      }
+
+      interface MultiOrderBase implements OrderBase {
+        name: String!
+        items: [OrderItem!]!
+      }
+
+      interface OrderBase {
+        name: String!
+      }
+    interactions:
+      - request:
+          accept: application/graphql-response+json; charset=utf-8, application/json; charset=utf-8, application/jsonl; charset=utf-8, text/event-stream; charset=utf-8
+          document: |
+            query Op_895cfa47_1 {
+              orders {
+                __typename
+                name
+                ... on MultiOrderBase {
+                  __typename
+                  items {
+                    product {
+                      id
+                    }
+                  }
+                  ... on DetailedOrderBase {
+                    __typename
+                    priority
+                  }
+                }
+              }
+            }
+        response:
+          results:
+            - |
+              {
+                "data": {
+                  "orders": [
+                    {
+                      "__typename": "OrderA",
+                      "name": "OrderA: T3JkZXJBOjE=",
+                      "items": [
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxOQ=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoyMA=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoyMQ=="
+                          }
+                        }
+                      ],
+                      "priority": 123
+                    },
+                    {
+                      "__typename": "OrderB",
+                      "name": "OrderB: T3JkZXJCOjI=",
+                      "items": [
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxNg=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxNw=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxOA=="
+                          }
+                        }
+                      ],
+                      "priority": 123
+                    },
+                    {
+                      "__typename": "OrderA",
+                      "name": "OrderA: T3JkZXJBOjM=",
+                      "items": [
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxMw=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxNA=="
+                          }
+                        },
+                        {
+                          "product": {
+                            "id": "UHJvZHVjdDoxNQ=="
+                          }
+                        }
+                      ],
+                      "priority": 123
+                    }
+                  ]
+                }
+              }
+  - name: B
+    schema: |
+      schema {
+        query: Query
+      }
+
+      type Query {
+        productById(id: ID!): Product @lookup
+      }
+
+      type Product @key(fields: "id") {
+        id: ID!
+        name: String!
+        description: String!
+      }
+    interactions:
+      - request:
+          accept: application/jsonl; charset=utf-8, text/event-stream; charset=utf-8, application/graphql-response+json; charset=utf-8, application/json; charset=utf-8
+          document: |
+            query Op_895cfa47_2($__fusion_1_id: ID!) {
+              productById(id: $__fusion_1_id) {
+                name
+                description
+              }
+            }
+          variables: |
+            [
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxOQ=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoyMA=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoyMQ=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxNg=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxNw=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxOA=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxMw=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxNA=="
+              },
+              {
+                "__fusion_1_id": "UHJvZHVjdDoxNQ=="
+              }
+            ]
+        response:
+          contentType: application/jsonl; charset=utf-8
+          results:
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxOQ==",
+                    "description": "Product: UHJvZHVjdDoxOQ=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoyMA==",
+                    "description": "Product: UHJvZHVjdDoyMA=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoyMQ==",
+                    "description": "Product: UHJvZHVjdDoyMQ=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxNg==",
+                    "description": "Product: UHJvZHVjdDoxNg=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxNw==",
+                    "description": "Product: UHJvZHVjdDoxNw=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxOA==",
+                    "description": "Product: UHJvZHVjdDoxOA=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxMw==",
+                    "description": "Product: UHJvZHVjdDoxMw=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxNA==",
+                    "description": "Product: UHJvZHVjdDoxNA=="
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "productById": {
+                    "name": "Product: UHJvZHVjdDoxNQ==",
+                    "description": "Product: UHJvZHVjdDoxNQ=="
+                  }
+                }
+              }
+operationPlan:
+  operation:
+    - document: |
+        {
+          orders {
+            __typename
+            name
+            ... on MultiOrderBase {
+              __typename
+              items {
+                product {
+                  id
+                  id @fusion__requirement
+                  name
+                  description
+                }
+              }
+              ... on DetailedOrderBase {
+                __typename
+                priority
+              }
+            }
+          }
+        }
+      hash: 895cfa47e0b605e01b35aa424eb99183
+      searchSpace: 1
+      expandedNodes: 2
+  nodes:
+    - id: 1
+      type: Operation
+      schema: A
+      operation: |
+        query Op_895cfa47_1 {
+          orders {
+            __typename
+            name
+            ... on MultiOrderBase {
+              __typename
+              items {
+                product {
+                  id
+                }
+              }
+              ... on DetailedOrderBase {
+                __typename
+                priority
+              }
+            }
+          }
+        }
+    - id: 2
+      type: Operation
+      schema: B
+      operation: |
+        query Op_895cfa47_2($__fusion_1_id: ID!) {
+          productById(id: $__fusion_1_id) {
+            name
+            description
+          }
+        }
+      source: $.productById
+      target: $.orders<MultiOrderBase>.items.product
+      requirements:
+        - name: __fusion_1_id
+          selectionMap: >-
+            id
+      dependencies:
+        - id: 1

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/AbstractTypeTests.Union_Member_Fragment_With_Field_Resolved_From_Other_Schema.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/AbstractTypeTests.Union_Member_Fragment_With_Field_Resolved_From_Other_Schema.yaml
@@ -1,0 +1,249 @@
+title: Union_Member_Fragment_With_Field_Resolved_From_Other_Schema
+request:
+  document: |
+    {
+      feed {
+        __typename
+        ...ArticleFragment
+        ...PhotoFragment
+      }
+    }
+
+    fragment ArticleFragment on Article {
+      id
+      headline
+    }
+
+    fragment PhotoFragment on Photo {
+      id
+      caption
+    }
+response:
+  body: |
+    {
+      "data": {
+        "feed": [
+          {
+            "__typename": "Article",
+            "id": "QXJ0aWNsZTox",
+            "headline": "Article: QXJ0aWNsZTox"
+          },
+          {
+            "__typename": "Photo",
+            "id": "UGhvdG86Mg==",
+            "caption": "Photo: UGhvdG86Mg=="
+          },
+          {
+            "__typename": "Article",
+            "id": "QXJ0aWNsZToz",
+            "headline": "Article: QXJ0aWNsZToz"
+          }
+        ]
+      }
+    }
+sourceSchemas:
+  - name: A
+    schema: |
+      schema {
+        query: Query
+      }
+
+      type Query {
+        feed: [FeedItem!]!
+      }
+
+      type Article @key(fields: "id") {
+        id: ID!
+      }
+
+      type Photo @key(fields: "id") {
+        id: ID!
+      }
+
+      union FeedItem = Article | Photo
+    interactions:
+      - request:
+          accept: application/graphql-response+json; charset=utf-8, application/json; charset=utf-8, application/jsonl; charset=utf-8, text/event-stream; charset=utf-8
+          document: |
+            query Op_f8edc1f1_1 {
+              feed {
+                __typename
+                ... on Article {
+                  id
+                }
+                ... on Photo {
+                  id
+                }
+              }
+            }
+        response:
+          results:
+            - |
+              {
+                "data": {
+                  "feed": [
+                    {
+                      "__typename": "Article",
+                      "id": "QXJ0aWNsZTox"
+                    },
+                    {
+                      "__typename": "Photo",
+                      "id": "UGhvdG86Mg=="
+                    },
+                    {
+                      "__typename": "Article",
+                      "id": "QXJ0aWNsZToz"
+                    }
+                  ]
+                }
+              }
+  - name: B
+    schema: |
+      schema {
+        query: Query
+      }
+
+      type Query {
+        articleById(id: ID!): Article @lookup
+        photoById(id: ID!): Photo @lookup
+      }
+
+      type Article @key(fields: "id") {
+        id: ID!
+        headline: String!
+      }
+
+      type Photo @key(fields: "id") {
+        id: ID!
+        caption: String!
+      }
+    interactions:
+      - request:
+          accept: application/jsonl; charset=utf-8, text/event-stream; charset=utf-8, application/graphql-response+json; charset=utf-8, application/json; charset=utf-8
+          kind: OperationBatch
+          items:
+            - document: |
+                query Op_f8edc1f1_2($__fusion_1_id: ID!) {
+                  photoById(id: $__fusion_1_id) {
+                    caption
+                  }
+                }
+              variables: |
+                {
+                  "__fusion_1_id": "UGhvdG86Mg=="
+                }
+            - document: |
+                query Op_f8edc1f1_3($__fusion_2_id: ID!) {
+                  articleById(id: $__fusion_2_id) {
+                    headline
+                  }
+                }
+              variables: |
+                [
+                  {
+                    "__fusion_2_id": "QXJ0aWNsZTox"
+                  },
+                  {
+                    "__fusion_2_id": "QXJ0aWNsZToz"
+                  }
+                ]
+        response:
+          contentType: application/jsonl; charset=utf-8
+          results:
+            - |
+              {
+                "data": {
+                  "articleById": {
+                    "headline": "Article: QXJ0aWNsZTox"
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "articleById": {
+                    "headline": "Article: QXJ0aWNsZToz"
+                  }
+                }
+              }
+            - |
+              {
+                "data": {
+                  "photoById": {
+                    "caption": "Photo: UGhvdG86Mg=="
+                  }
+                }
+              }
+operationPlan:
+  operation:
+    - document: |
+        {
+          feed {
+            __typename
+            ... on Article {
+              id
+              id @fusion__requirement
+              headline
+            }
+            ... on Photo {
+              id
+              id @fusion__requirement
+              caption
+            }
+          }
+        }
+      hash: f8edc1f1dbfa7ef2b434256c881f4c35
+      searchSpace: 1
+      expandedNodes: 2
+  nodes:
+    - id: 1
+      type: Operation
+      schema: A
+      operation: |
+        query Op_f8edc1f1_1 {
+          feed {
+            __typename
+            ... on Article {
+              id
+            }
+            ... on Photo {
+              id
+            }
+          }
+        }
+    - id: 2
+      type: Operation
+      schema: B
+      operation: |
+        query Op_f8edc1f1_2($__fusion_1_id: ID!) {
+          photoById(id: $__fusion_1_id) {
+            caption
+          }
+        }
+      source: $.photoById
+      target: $.feed<Photo>
+      batchingGroupId: 2
+      requirements:
+        - name: __fusion_1_id
+          selectionMap: >-
+            id
+      dependencies:
+        - id: 1
+    - id: 3
+      type: Operation
+      schema: B
+      operation: |
+        query Op_f8edc1f1_3($__fusion_2_id: ID!) {
+          articleById(id: $__fusion_2_id) {
+            headline
+          }
+        }
+      source: $.articleById
+      target: $.feed<Article>
+      batchingGroupId: 2
+      requirements:
+        - name: __fusion_2_id
+          selectionMap: >-
+            id
+      dependencies:
+        - id: 1

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Nodes/ResolvedSelectionPathTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Nodes/ResolvedSelectionPathTests.cs
@@ -1,0 +1,79 @@
+using HotChocolate.Execution;
+
+namespace HotChocolate.Fusion.Execution.Nodes;
+
+public sealed class ResolvedSelectionPathTests : FusionTestBase
+{
+    [Fact]
+    public void Create_Should_ResolveTypeConditionAndPossibleTypes_When_ConditionIsKnownAbstractType()
+    {
+        // arrange
+        var schema = ComposeSchema(
+            """
+            # name: A
+            type Query {
+              orders: [OrderBase!]!
+            }
+
+            interface OrderBase {
+              name: String!
+            }
+
+            interface MultiOrderBase implements OrderBase {
+              name: String!
+              items: [OrderItem!]!
+            }
+
+            type OrderA implements MultiOrderBase & OrderBase {
+              name: String!
+              items: [OrderItem!]!
+            }
+
+            type OrderB implements MultiOrderBase & OrderBase {
+              name: String!
+              items: [OrderItem!]!
+            }
+
+            type OrderItem {
+              product: String!
+            }
+            """);
+
+        var path = SelectionPath.Root
+            .AppendField("orders")
+            .AppendFragment("MultiOrderBase");
+
+        // act
+        var resolved = ResolvedSelectionPath.Create(path, schema);
+
+        // assert
+        Assert.Equal("MultiOrderBase", resolved.GetTypeCondition(1)?.Name);
+        Assert.Equal(["OrderA", "OrderB"], resolved.GetPossibleTypes(1).Select(t => t.Name));
+    }
+
+    [Fact]
+    public void Create_Should_FallBackToNameMatching_When_TypeConditionIsUnknown()
+    {
+        // arrange
+        // A path referencing a type the schema cannot resolve, as can happen when a cached plan
+        // outlives a schema change.
+        var schema = ComposeSchema(
+            """
+            # name: A
+            type Query {
+              field: String
+            }
+            """);
+
+        var path = SelectionPath.Root
+            .AppendField("field")
+            .AppendFragment("RemovedType");
+
+        // act
+        var resolved = ResolvedSelectionPath.Create(path, schema);
+
+        // assert
+        Assert.Null(resolved.GetTypeCondition(1));
+        Assert.True(resolved.GetPossibleTypes(1).IsEmpty);
+    }
+}

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/OperationPlanContextRoutingTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/OperationPlanContextRoutingTests.cs
@@ -30,7 +30,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var result = context.CreateVariableValueSets(
-            SelectionPath.Root,
+            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
             forwardedVariables: [],
             requirements: [Requirement("__fusion_1_id")]);
 
@@ -48,7 +48,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var result = context.CreateVariableValueSets(
-            SelectionPath.Root,
+            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
             forwardedVariables: [],
             requirements: [Requirement("__fusion_2_other")]);
 
@@ -67,7 +67,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
         // act
         var exception = Assert.Throws<InvalidOperationException>(
             () => context.CreateVariableValueSets(
-                SelectionPath.Root,
+                ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
                 forwardedVariables: [],
                 requirements:
                 [
@@ -129,7 +129,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var first = context.CreateVariableValueSets(
-            SelectionPath.Root,
+            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
             forwardedVariables: [],
             requirements:
             [
@@ -137,7 +137,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
                 Requirement("__fusion_2_sku")
             ]);
         var second = context.CreateVariableValueSets(
-            SelectionPath.Root,
+            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
             forwardedVariables: [],
             requirements:
             [
@@ -173,7 +173,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var result = context.CreateVariableValueSets(
-            SelectionPath.Root,
+            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
             forwardedVariables: ["limit"],
             requirements: [Requirement("__fusion_1_id")]);
 
@@ -199,7 +199,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var result = context.CreateVariableValueSets(
-            SelectionPath.Root,
+            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
             forwardedVariables: [],
             requirements: [Requirement("__fusion_1_id")]);
 
@@ -222,7 +222,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
         // act
         var exception = Assert.Throws<InvalidOperationException>(
             () => context.CreateVariableValueSets(
-                selectionSets: [SelectionPath.Root],
+                selectionSets: [ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema)],
                 forwardedVariables: [],
                 requiredData:
                 [

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/OperationPlanContextRoutingTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/OperationPlanContextRoutingTests.cs
@@ -7,6 +7,7 @@ using HotChocolate.Fusion.Execution.Results;
 using HotChocolate.Fusion.Language;
 using HotChocolate.Fusion.Text.Json;
 using HotChocolate.Fusion.Transport.Http;
+using HotChocolate.Fusion.Types;
 using HotChocolate.Language;
 using HotChocolate.Types;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,7 +31,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var result = context.CreateVariableValueSets(
-            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
+            ResolvedSelectionPath.Create(SelectionPath.Root, (FusionSchemaDefinition)context.Schema),
             forwardedVariables: [],
             requirements: [Requirement("__fusion_1_id")]);
 
@@ -48,7 +49,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var result = context.CreateVariableValueSets(
-            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
+            ResolvedSelectionPath.Create(SelectionPath.Root, (FusionSchemaDefinition)context.Schema),
             forwardedVariables: [],
             requirements: [Requirement("__fusion_2_other")]);
 
@@ -67,7 +68,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
         // act
         var exception = Assert.Throws<InvalidOperationException>(
             () => context.CreateVariableValueSets(
-                ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
+                ResolvedSelectionPath.Create(SelectionPath.Root, (FusionSchemaDefinition)context.Schema),
                 forwardedVariables: [],
                 requirements:
                 [
@@ -129,7 +130,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var first = context.CreateVariableValueSets(
-            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
+            ResolvedSelectionPath.Create(SelectionPath.Root, (FusionSchemaDefinition)context.Schema),
             forwardedVariables: [],
             requirements:
             [
@@ -137,7 +138,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
                 Requirement("__fusion_2_sku")
             ]);
         var second = context.CreateVariableValueSets(
-            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
+            ResolvedSelectionPath.Create(SelectionPath.Root, (FusionSchemaDefinition)context.Schema),
             forwardedVariables: [],
             requirements:
             [
@@ -173,7 +174,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var result = context.CreateVariableValueSets(
-            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
+            ResolvedSelectionPath.Create(SelectionPath.Root, (FusionSchemaDefinition)context.Schema),
             forwardedVariables: ["limit"],
             requirements: [Requirement("__fusion_1_id")]);
 
@@ -199,7 +200,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
 
         // act
         var result = context.CreateVariableValueSets(
-            ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema),
+            ResolvedSelectionPath.Create(SelectionPath.Root, (FusionSchemaDefinition)context.Schema),
             forwardedVariables: [],
             requirements: [Requirement("__fusion_1_id")]);
 
@@ -222,7 +223,7 @@ public sealed class OperationPlanContextRoutingTests : FusionTestBase
         // act
         var exception = Assert.Throws<InvalidOperationException>(
             () => context.CreateVariableValueSets(
-                selectionSets: [ResolvedSelectionPath.Create(SelectionPath.Root, context.Schema)],
+                selectionSets: [ResolvedSelectionPath.Create(SelectionPath.Root, (FusionSchemaDefinition)context.Schema)],
                 forwardedVariables: [],
                 requiredData:
                 [

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Results/FetchResultStoreTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Results/FetchResultStoreTests.cs
@@ -60,7 +60,7 @@ public sealed class FetchResultStoreTests : FusionTestBase
         // act
         var exception = Assert.Throws<ArgumentOutOfRangeException>(
             () => store.AddPartialResults(
-                SelectionPath.Root,
+                ResolvedSelectionPath.Create(SelectionPath.Root, schema),
                 results,
                 node.ResultSelectionSet,
                 containsErrors));


### PR DESCRIPTION
**TODO: Needs discussion with Michael**

Fixes https://github.com/ChilliCream/graphql-platform/issues/10045

## Problem

Operation plan nodes address result data through `SelectionPath` values like `$.orders<MultiOrderBase>.items.product`. The `FetchResultStore` matched inline-fragment segments against the runtime `__typename` of result elements by plain string equality. For abstract type conditions (interfaces and unions) this never matches, since the runtime type name is always a concrete object type (`OrderA`, not `MultiOrderBase`). As a result, dependent nodes (e.g. an entity lookup on another source schema) were silently skipped and their fields resolved to `null`. Queries using fragments on concrete types worked, which is why the bug only surfaced with nested interface fragments.

## Design considerations

A few approaches were evaluated and rejected before landing on the final design:

- **Resolving possible types in the store at execution time** works, but puts schema lookups on the result-merge hot path for every request, even though the information is invariant per plan.
- **Expanding abstract conditions into concrete type names inside the plan** (e.g. `<MultiOrderBase|OrderA|OrderB>`) removes the runtime resolution, but explodes plan size for wide interfaces (a `Node`-like interface with hundreds of implementors), churns the plan format, and breaks the planner's document walks that match path segments against the original type-condition names.
- **Addressing elements by selection-set id instead of paths** looked attractive, but execution selection-set ids are assigned lazily per encountered runtime type, so a plan cannot carry a stable id set without a much larger refactor.

The key observation enabling the final design: the merge already resolves every composite object's `__typename` and stamps the element with a selection set specialized to its runtime type, so composite elements already carry resolved type identity.

## Solution

A new internal `ResolvedSelectionPath` pairs a `SelectionPath` with the resolved type condition (and, for abstract conditions, the schema's cached possible types) of each inline-fragment segment. It is created once per plan, at plan build and at cached-plan rehydration, both of which already have the schema. The serialized plan format is unchanged.

- **Target-side matching** (`CollectTargetElements`) checks `typeCondition.IsAssignableFrom(element.SelectionSet.Type)`: a frozen-set lookup per element, no `__typename` read, no strings, no schema access, O(1) regardless of implementor count.
- **Source-side matching** (`GetDataElement`) operates on raw source JSON without type identity, so it compares `__typename` against the segment name and the precomputed possible types carried by the node (a reference to the schema's existing per-type cache, nothing per-plan).

Edge cases hardened along the way:

- Unresolvable type conditions (e.g. a type removed after a plan was cached, previously tolerated by the opaque string comparison) degrade to name-only matching instead of failing plan construction.
- `@inaccessible` type conditions resolve via the inaccessible-inclusive type lookup, so they get full type-identity matching.
- Elements without selection-set metadata are skipped as non-matches instead of throwing.
- The deferred-plan requirement anchor is resolved once per plan and memoized instead of per incremental delivery.
- `CompositeResultDocument.GetSelectionSet` now chases `Reference` tokens like the other element accessors.