### PR TITLE
Fix frontend devcontainer workspace path for renamed checkouts

### DIFF
--- a/.devcontainer/frontend/devcontainer.json
+++ b/.devcontainer/frontend/devcontainer.json
@@ -19,7 +19,7 @@
       "onAutoForward": "silent"
     }
   },
-  "workspaceFolder": "/workspaces/graphql-platform/website",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/website",
   "postCreateCommand": "yarn install --immutable && yarn playwright install chromium",
   "containerEnv": {
     "NEXT_TELEMETRY_DISABLED": "1",


### PR DESCRIPTION
## Summary
- The frontend devcontainer hardcoded `workspaceFolder` to `/workspaces/graphql-platform/website`, which only resolves when the checkout directory is literally named `graphql-platform`. Worktrees and renamed clones mount at `/workspaces/<dir>` instead, so VS Code reported the workspace folder missing and `postCreateCommand` never ran in `website/`.
- Use `/workspaces/${localWorkspaceFolderBasename}/website` so the path tracks the actual mount for any checkout name.

## Test plan
- Open the frontend devcontainer from a checkout directory not named `graphql-platform` (e.g. a worktree); confirm it opens at `website/` and `postCreateCommand` (`yarn install`) runs.
