### PR TITLE
Include captured filter values in DataLoader branch key

### DIFF
--- a/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Collections;
 using System.Globalization;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -155,8 +156,14 @@ internal sealed class ExpressionHasher : ExpressionVisitor
             {
                 FieldInfo field => field.GetValue(instance),
 
+                // Only read properties off value-type holders (record structs
+                // like ExpressionParameter<T>). Closures expose captured values
+                // as fields, so this never invokes an arbitrary reference-type
+                // getter - which could be expensive or have side effects - just
+                // to compute a branch key.
                 PropertyInfo { CanRead: true } property
                     when property.GetIndexParameters().Length == 0
+                        && instance is ValueType
                     => property.GetValue(instance),
 
                 _ => null
@@ -204,6 +211,15 @@ internal sealed class ExpressionHasher : ExpressionVisitor
         }
 
         if (depth >= MaxCapturedValueDepth)
+        {
+            AppendDelimited(value.GetType().FullName ?? value.GetType().Name);
+            return;
+        }
+
+        // Never enumerate a queryable (or other lazy provider) while hashing:
+        // doing so could execute a database query or another side effect just to
+        // compute a branch key. Fold in its type instead.
+        if (value is IQueryable)
         {
             AppendDelimited(value.GetType().FullName ?? value.GetType().Name);
             return;

--- a/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -12,6 +13,8 @@ namespace GreenDonut.Data.Internal;
 internal sealed class ExpressionHasher : ExpressionVisitor
 {
     private const int MaxCapturedValueDepth = 8;
+    private const int MaxCapturedNodes = 2048;
+    private int _capturedNodeCount;
 
     private ReadOnlySpan<byte> Lambda => "Lambda|"u8;
     private ReadOnlySpan<byte> Binary => "Binary:"u8;
@@ -96,6 +99,7 @@ internal sealed class ExpressionHasher : ExpressionVisitor
         }
 
         _start = 0;
+        _capturedNodeCount = 0;
         return hashString;
     }
 
@@ -179,6 +183,15 @@ internal sealed class ExpressionHasher : ExpressionVisitor
 
     private void AppendCapturedValue(object? value, int depth)
     {
+        // Bound total work, not just depth: a cyclic or pathological captured
+        // graph (e.g. an array that contains itself) would otherwise blow up
+        // exponentially even under the depth guard.
+        if (++_capturedNodeCount > MaxCapturedNodes)
+        {
+            AppendDelimited("__budget_exceeded__");
+            return;
+        }
+
         switch (value)
         {
             case null:
@@ -203,8 +216,33 @@ internal sealed class ExpressionHasher : ExpressionVisitor
                 AppendDelimited(e.ToString());
                 return;
 
+            // Temporal types must round-trip: the default ("G") format drops
+            // sub-second precision (and Kind/offset), so two predicates whose
+            // only difference is a fractional second would otherwise collide.
+            case DateTime dateTime:
+                AppendDelimited(dateTime.ToString("O", CultureInfo.InvariantCulture));
+                return;
+
+            case DateTimeOffset dateTimeOffset:
+                AppendDelimited(dateTimeOffset.ToString("O", CultureInfo.InvariantCulture));
+                return;
+
+            case TimeSpan timeSpan:
+                AppendDelimited(timeSpan.ToString("c", CultureInfo.InvariantCulture));
+                return;
+
+#if NET6_0_OR_GREATER
+            case DateOnly dateOnly:
+                AppendDelimited(dateOnly.ToString("O", CultureInfo.InvariantCulture));
+                return;
+
+            case TimeOnly timeOnly:
+                AppendDelimited(timeOnly.ToString("O", CultureInfo.InvariantCulture));
+                return;
+#endif
+
             case IFormattable formattable:
-                // numbers, decimal, Guid, DateTime, DateTimeOffset, TimeSpan, ...
+                // numbers, decimal, Guid, ...
                 AppendDelimited(formattable.ToString(null, CultureInfo.InvariantCulture));
                 return;
         }
@@ -215,20 +253,33 @@ internal sealed class ExpressionHasher : ExpressionVisitor
             return;
         }
 
-        // Only enumerate materialized collections (arrays, List<T>, ...). Any
-        // other IEnumerable - an IQueryable, an iterator block, or another lazy
-        // provider - can throw or trigger a side effect (e.g. a database query)
-        // when enumerated, and ComputeHash() does not catch. Fold in its type
-        // instead so branch-key computation stays pure and reliable.
-        if (value is ICollection collection)
+        // Only enumerate collection types we know are materialized and side-effect
+        // free - arrays and List<T>. Any other IEnumerable (an IQueryable, an EF
+        // lazy-loading proxy, an iterator block, ...) could trigger a database
+        // query or throw when enumerated, and ComputeHash() does not catch, so
+        // fold in its type instead. Enumeration is still guarded and rolls back
+        // partial writes so a throwing enumerator can never fail hashing.
+        if (value is Array
+            || (value.GetType() is { IsGenericType: true } listType
+                && listType.GetGenericTypeDefinition() == typeof(List<>)))
         {
-            Append('[');
-            foreach (var item in collection)
+            var rollback = _start;
+            try
             {
-                AppendCapturedValue(item, depth + 1);
-                Append(',');
+                Append('[');
+                foreach (var item in (IEnumerable)value)
+                {
+                    AppendCapturedValue(item, depth + 1);
+                    Append(',');
+                }
+                Append(']');
             }
-            Append(']');
+            catch
+            {
+                _start = rollback;
+                AppendDelimited(value.GetType().FullName ?? value.GetType().Name);
+            }
+
             return;
         }
 

--- a/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
@@ -231,7 +231,6 @@ internal sealed class ExpressionHasher : ExpressionVisitor
                 AppendDelimited(timeSpan.ToString("c", CultureInfo.InvariantCulture));
                 return;
 
-#if NET6_0_OR_GREATER
             case DateOnly dateOnly:
                 AppendDelimited(dateOnly.ToString("O", CultureInfo.InvariantCulture));
                 return;
@@ -239,7 +238,6 @@ internal sealed class ExpressionHasher : ExpressionVisitor
             case TimeOnly timeOnly:
                 AppendDelimited(timeOnly.ToString("O", CultureInfo.InvariantCulture));
                 return;
-#endif
 
             case IFormattable formattable:
                 // numbers, decimal, Guid, ...

--- a/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
 using System.Buffers.Text;
+using System.Collections;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -9,6 +11,8 @@ namespace GreenDonut.Data.Internal;
 
 internal sealed class ExpressionHasher : ExpressionVisitor
 {
+    private const int MaxCapturedValueDepth = 8;
+
     private ReadOnlySpan<byte> Lambda => "Lambda|"u8;
     private ReadOnlySpan<byte> Binary => "Binary:"u8;
     private ReadOnlySpan<byte> Member => "Member:"u8;
@@ -18,6 +22,8 @@ internal sealed class ExpressionHasher : ExpressionVisitor
     private ReadOnlySpan<byte> New => "New:"u8;
     private ReadOnlySpan<byte> MemberInit => "MemberInit|"u8;
     private ReadOnlySpan<byte> Binding => "Binding:"u8;
+    private ReadOnlySpan<byte> Value => "Value:"u8;
+    private ReadOnlySpan<byte> Null => "null"u8;
 
     private byte[] _buffer;
     private readonly int _initialSize;
@@ -119,8 +125,111 @@ internal sealed class ExpressionHasher : ExpressionVisitor
         Append(Member);
         Append(node.Member);
         Append('|');
+
+        // A member access rooted directly at a constant is a hoisted/captured
+        // value - e.g. HotChocolate's ExpressionParameter<T>.p that filtering
+        // uses to parameterize filter values, or a compiler-generated closure
+        // field. The base traversal visits the constant, which contributes no
+        // bytes, so two predicates that differ only by their captured value
+        // (e.g. `status eq A` vs `status eq B`, or `status in [..]` with
+        // different lists) produced identical hashes and collided onto the same
+        // DataLoader branch key. Evaluate the captured value and fold it into
+        // the hash instead of hashing only the member name.
+        if (node.Expression is ConstantExpression constant)
+        {
+            Append(Value);
+            AppendCapturedValue(TryGetMemberValue(node.Member, constant.Value), 0);
+            Append('|');
+            return node;
+        }
+
         Visit(node.Expression);
         return node;
+    }
+
+    private static object? TryGetMemberValue(MemberInfo member, object? instance)
+    {
+        switch (member)
+        {
+            case FieldInfo field:
+                return field.GetValue(instance);
+
+            case PropertyInfo { CanRead: true } property
+                when property.GetIndexParameters().Length == 0:
+                return property.GetValue(instance);
+
+            default:
+                return null;
+        }
+    }
+
+    private void AppendCapturedValue(object? value, int depth)
+    {
+        switch (value)
+        {
+            case null:
+                Append(Null);
+                return;
+
+            case string s:
+                Append(s);
+                return;
+
+            case bool b:
+                Append(b ? (byte)1 : (byte)0);
+                return;
+
+            case char c:
+                Append((int)c);
+                return;
+
+            case Enum e:
+                Append(e.GetType().FullName ?? e.GetType().Name);
+                Append('.');
+                Append(e.ToString());
+                return;
+
+            case IFormattable formattable:
+                // numbers, decimal, Guid, DateTime, DateTimeOffset, TimeSpan, ...
+                Append(formattable.ToString(null, CultureInfo.InvariantCulture));
+                return;
+        }
+
+        if (depth >= MaxCapturedValueDepth)
+        {
+            Append(value.GetType().FullName ?? value.GetType().Name);
+            return;
+        }
+
+        if (value is IEnumerable enumerable)
+        {
+            Append('[');
+            foreach (var item in enumerable)
+            {
+                AppendCapturedValue(item, depth + 1);
+                Append(',');
+            }
+            Append(']');
+            return;
+        }
+
+        // Complex holder (e.g. ExpressionParameter<T> or a closure display
+        // class): fold in its instance fields so that captured values embedded
+        // in the holder still differentiate the hash. Fields are ordered to keep
+        // the hash stable across runtimes.
+        var type = value.GetType();
+        Append(type.FullName ?? type.Name);
+        Append('{');
+        foreach (var field in type
+            .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .OrderBy(f => f.Name, StringComparer.Ordinal))
+        {
+            Append(field.Name);
+            Append('=');
+            AppendCapturedValue(field.GetValue(value), depth + 1);
+            Append(';');
+        }
+        Append('}');
     }
 
     protected override Expression VisitParameter(ParameterExpression node)

--- a/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
@@ -2,7 +2,6 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Collections;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -216,24 +215,26 @@ internal sealed class ExpressionHasher : ExpressionVisitor
             return;
         }
 
-        // Never enumerate a queryable (or other lazy provider) while hashing:
-        // doing so could execute a database query or another side effect just to
-        // compute a branch key. Fold in its type instead.
-        if (value is IQueryable)
-        {
-            AppendDelimited(value.GetType().FullName ?? value.GetType().Name);
-            return;
-        }
-
-        if (value is IEnumerable enumerable)
+        // Only enumerate materialized collections (arrays, List<T>, ...). Any
+        // other IEnumerable - an IQueryable, an iterator block, or another lazy
+        // provider - can throw or trigger a side effect (e.g. a database query)
+        // when enumerated, and ComputeHash() does not catch. Fold in its type
+        // instead so branch-key computation stays pure and reliable.
+        if (value is ICollection collection)
         {
             Append('[');
-            foreach (var item in enumerable)
+            foreach (var item in collection)
             {
                 AppendCapturedValue(item, depth + 1);
                 Append(',');
             }
             Append(']');
+            return;
+        }
+
+        if (value is IEnumerable)
+        {
+            AppendDelimited(value.GetType().FullName ?? value.GetType().Name);
             return;
         }
 

--- a/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Internal/ExpressionHasher.cs
@@ -149,17 +149,25 @@ internal sealed class ExpressionHasher : ExpressionVisitor
 
     private static object? TryGetMemberValue(MemberInfo member, object? instance)
     {
-        switch (member)
+        try
         {
-            case FieldInfo field:
-                return field.GetValue(instance);
+            return member switch
+            {
+                FieldInfo field => field.GetValue(instance),
 
-            case PropertyInfo { CanRead: true } property
-                when property.GetIndexParameters().Length == 0:
-                return property.GetValue(instance);
+                PropertyInfo { CanRead: true } property
+                    when property.GetIndexParameters().Length == 0
+                    => property.GetValue(instance),
 
-            default:
-                return null;
+                _ => null
+            };
+        }
+        catch
+        {
+            // A branch key must never fail because a captured member's accessor
+            // throws, has side effects, or the instance is null. Fall back to
+            // treating the value as absent instead of propagating the exception.
+            return null;
         }
     }
 
@@ -172,7 +180,7 @@ internal sealed class ExpressionHasher : ExpressionVisitor
                 return;
 
             case string s:
-                Append(s);
+                AppendDelimited(s);
                 return;
 
             case bool b:
@@ -184,20 +192,20 @@ internal sealed class ExpressionHasher : ExpressionVisitor
                 return;
 
             case Enum e:
-                Append(e.GetType().FullName ?? e.GetType().Name);
+                AppendDelimited(e.GetType().FullName ?? e.GetType().Name);
                 Append('.');
-                Append(e.ToString());
+                AppendDelimited(e.ToString());
                 return;
 
             case IFormattable formattable:
                 // numbers, decimal, Guid, DateTime, DateTimeOffset, TimeSpan, ...
-                Append(formattable.ToString(null, CultureInfo.InvariantCulture));
+                AppendDelimited(formattable.ToString(null, CultureInfo.InvariantCulture));
                 return;
         }
 
         if (depth >= MaxCapturedValueDepth)
         {
-            Append(value.GetType().FullName ?? value.GetType().Name);
+            AppendDelimited(value.GetType().FullName ?? value.GetType().Name);
             return;
         }
 
@@ -218,18 +226,33 @@ internal sealed class ExpressionHasher : ExpressionVisitor
         // in the holder still differentiate the hash. Fields are ordered to keep
         // the hash stable across runtimes.
         var type = value.GetType();
-        Append(type.FullName ?? type.Name);
+        AppendDelimited(type.FullName ?? type.Name);
         Append('{');
-        foreach (var field in type
-            .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            .OrderBy(f => f.Name, StringComparer.Ordinal))
+
+        var fields = type.GetFields(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Array.Sort(fields, static (a, b) => string.CompareOrdinal(a.Name, b.Name));
+
+        foreach (var field in fields)
         {
-            Append(field.Name);
+            AppendDelimited(field.Name);
             Append('=');
-            AppendCapturedValue(field.GetValue(value), depth + 1);
+            AppendCapturedValue(TryGetMemberValue(field, value), depth + 1);
             Append(';');
         }
+
         Append('}');
+    }
+
+    private void AppendDelimited(string value)
+    {
+        // Length-prefix variable-length text so a separator embedded in a value
+        // (e.g. a comma inside a filtered string) cannot produce the same byte
+        // sequence as a different set of values - i.e. ["a,b"] must not hash the
+        // same as ["a", "b"].
+        Append(value.Length);
+        Append(':');
+        Append(value);
     }
 
     protected override Expression VisitParameter(ParameterExpression node)

--- a/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
@@ -126,14 +126,18 @@ public static class ExpressionHasherTests
         // arrange
         var predicate1 = BuildNameIn(["a", "b"]);
         var predicate2 = BuildNameIn(["a", "c"]);
+        var predicate3 = BuildNameIn(["a", "b"]);
 
         // act
         var hash1 = new ExpressionHasher().Add(predicate1).Compute();
         var hash2 = new ExpressionHasher().Add(predicate2).Compute();
+        var hash3 = new ExpressionHasher().Add(predicate3).Compute();
 
         // assert
         // `in` filters with different lists must not collide either.
         Assert.NotEqual(hash1, hash2);
+        // Equal list contents must stay stable across closure instances.
+        Assert.Equal(hash1, hash3);
     }
 
     [Fact]

--- a/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Linq.Expressions;
 
 namespace GreenDonut.Data.Internal;
@@ -157,10 +158,29 @@ public static class ExpressionHasherTests
         Assert.NotEqual(hash1, hash2);
     }
 
+    [Fact]
+    public static void Predicate_With_Captured_Lazy_Enumerable_Is_Not_Enumerated()
+    {
+        // arrange
+        // A lazy sequence must never be enumerated to compute a branch key - that
+        // could throw or trigger a side effect (e.g. a database query). Only
+        // materialized collections are folded in.
+        var predicate = BuildNameInSeq(new ThrowingEnumerable());
+
+        // act
+        var exception = Record.Exception(() => new ExpressionHasher().Add(predicate).Compute());
+
+        // assert
+        Assert.Null(exception);
+    }
+
     private static Expression<Func<Entity1, bool>> BuildNameEquals(string value)
         => x => x.Name == value;
 
     private static Expression<Func<Entity1, bool>> BuildNameIn(string[] values)
+        => x => values.Contains(x.Name);
+
+    private static Expression<Func<Entity1, bool>> BuildNameInSeq(IEnumerable<string> values)
         => x => values.Contains(x.Name);
 
     [Fact]
@@ -292,5 +312,14 @@ public static class ExpressionHasherTests
     public class Entity3 : IEntity
     {
         public string Name { get; set; } = null!;
+    }
+
+    private sealed class ThrowingEnumerable : IEnumerable<string>
+    {
+        public IEnumerator<string> GetEnumerator()
+            => throw new InvalidOperationException("must not be enumerated while hashing");
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => throw new InvalidOperationException("must not be enumerated while hashing");
     }
 }

--- a/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
@@ -136,6 +136,23 @@ public static class ExpressionHasherTests
         Assert.NotEqual(hash1, hash2);
     }
 
+    [Fact]
+    public static void Predicate_With_Captured_List_Element_Boundaries_Affect_Hash()
+    {
+        // arrange
+        // A separator embedded in an element must not make ["a,b", "c"] hash the
+        // same as ["a", "b", "c"].
+        var predicate1 = BuildNameIn(["a,b", "c"]);
+        var predicate2 = BuildNameIn(["a", "b", "c"]);
+
+        // act
+        var hash1 = new ExpressionHasher().Add(predicate1).Compute();
+        var hash2 = new ExpressionHasher().Add(predicate2).Compute();
+
+        // assert
+        Assert.NotEqual(hash1, hash2);
+    }
+
     private static Expression<Func<Entity1, bool>> BuildNameEquals(string value)
         => x => x.Name == value;
 

--- a/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
@@ -97,6 +97,52 @@ public static class ExpressionHasherTests
     }
 
     [Fact]
+    public static void Predicate_With_Captured_Value_Affects_Hash()
+    {
+        // arrange
+        // Each call captures its argument into a fresh closure, producing a
+        // `x.Name == <captured>.value` shape - the same member access rooted at a
+        // constant that HotChocolate filtering emits via ExpressionParameter<T>.p.
+        var predicate1 = BuildNameEquals("abc");
+        var predicate2 = BuildNameEquals("xyz");
+        var predicate3 = BuildNameEquals("abc");
+
+        // act
+        var hash1 = new ExpressionHasher().Add(predicate1).Compute();
+        var hash2 = new ExpressionHasher().Add(predicate2).Compute();
+        var hash3 = new ExpressionHasher().Add(predicate3).Compute();
+
+        // assert
+        // Different captured values must not collide (regression: they used to,
+        // so two aliased fields filtering by eq: A vs eq: B shared one branch).
+        Assert.NotEqual(hash1, hash2);
+        // Equal captured values must remain stable.
+        Assert.Equal(hash1, hash3);
+    }
+
+    [Fact]
+    public static void Predicate_With_Captured_List_Affects_Hash()
+    {
+        // arrange
+        var predicate1 = BuildNameIn(["a", "b"]);
+        var predicate2 = BuildNameIn(["a", "c"]);
+
+        // act
+        var hash1 = new ExpressionHasher().Add(predicate1).Compute();
+        var hash2 = new ExpressionHasher().Add(predicate2).Compute();
+
+        // assert
+        // `in` filters with different lists must not collide either.
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    private static Expression<Func<Entity1, bool>> BuildNameEquals(string value)
+        => x => x.Name == value;
+
+    private static Expression<Func<Entity1, bool>> BuildNameIn(string[] values)
+        => x => values.Contains(x.Name);
+
+    [Fact]
     public static void BufferResize_Add_Char()
     {
         // arrange

--- a/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
@@ -159,6 +159,62 @@ public static class ExpressionHasherTests
     }
 
     [Fact]
+    public static void Value_Hoisted_Into_Struct_Property_Affects_Hash()
+    {
+        // arrange
+        // The real HotChocolate shape: a value hoisted into a record struct and
+        // read via property `p` over a ConstantExpression (ExpressionParameter<T>).
+        var predicate1 = BuildNameEqualsViaHolder("abc");
+        var predicate2 = BuildNameEqualsViaHolder("xyz");
+        var predicate3 = BuildNameEqualsViaHolder("abc");
+
+        // act
+        var hash1 = new ExpressionHasher().Add(predicate1).Compute();
+        var hash2 = new ExpressionHasher().Add(predicate2).Compute();
+        var hash3 = new ExpressionHasher().Add(predicate3).Compute();
+
+        // assert
+        Assert.NotEqual(hash1, hash2);
+        Assert.Equal(hash1, hash3);
+    }
+
+    [Fact]
+    public static void Captured_DateTime_Difference_Below_A_Second_Affects_Hash()
+    {
+        // arrange
+        // Round-trip precision: two timestamps differing only by a fraction of a
+        // second must not collide (default "G" formatting would drop it).
+        var baseTime = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+        var predicate1 = BuildCreatedEqualsViaHolder(baseTime.AddTicks(1_230_000));
+        var predicate2 = BuildCreatedEqualsViaHolder(baseTime.AddTicks(4_560_000));
+
+        // act
+        var hash1 = new ExpressionHasher().Add(predicate1).Compute();
+        var hash2 = new ExpressionHasher().Add(predicate2).Compute();
+
+        // assert
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public static void Predicate_With_Self_Referential_Collection_Terminates()
+    {
+        // arrange
+        // A captured collection that contains itself must not blow up (the depth
+        // guard alone would still allow exponential traversal).
+        var self = new object[2];
+        self[0] = self;
+        self[1] = "x";
+        Expression<Func<Entity1, bool>> predicate = x => self.Contains(x.Name);
+
+        // act
+        var exception = Record.Exception(() => new ExpressionHasher().Add(predicate).Compute());
+
+        // assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
     public static void Predicate_With_Captured_Lazy_Enumerable_Is_Not_Enumerated()
     {
         // arrange
@@ -182,6 +238,24 @@ public static class ExpressionHasherTests
 
     private static Expression<Func<Entity1, bool>> BuildNameInSeq(IEnumerable<string> values)
         => x => values.Contains(x.Name);
+
+    // Mimics HotChocolate's ExpressionParameter<T>(T p): a value hoisted into a
+    // record struct and read via property `p` over a ConstantExpression.
+    private static Expression<Func<Entity1, bool>> BuildNameEqualsViaHolder(string value)
+    {
+        var x = Expression.Parameter(typeof(Entity1), "x");
+        var p = Expression.Property(Expression.Constant(new Holder<string>(value)), nameof(Holder<string>.p));
+        var body = Expression.Equal(Expression.Property(x, nameof(Entity1.Name)), p);
+        return Expression.Lambda<Func<Entity1, bool>>(body, x);
+    }
+
+    private static Expression<Func<Entity1, bool>> BuildCreatedEqualsViaHolder(DateTime value)
+    {
+        var x = Expression.Parameter(typeof(Entity1), "x");
+        var p = Expression.Property(Expression.Constant(new Holder<DateTime>(value)), nameof(Holder<DateTime>.p));
+        var body = Expression.Equal(Expression.Property(x, nameof(Entity1.Created)), p);
+        return Expression.Lambda<Func<Entity1, bool>>(body, x);
+    }
 
     [Fact]
     public static void BufferResize_Add_Char()
@@ -297,10 +371,14 @@ public static class ExpressionHasherTests
 
         public string? Description { get; set; }
 
+        public DateTime Created { get; set; }
+
         public IEntity Entity { get; set; } = null!;
 
         public List<IEntity> Entities { get; set; } = null!;
     }
+
+    private readonly record struct Holder<T>(T p);
 
     public interface IEntity;
 

--- a/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
@@ -197,6 +197,24 @@ public static class ExpressionHasherTests
     }
 
     [Fact]
+    public static void Captured_Double_Difference_In_Least_Significant_Digits_Affects_Hash()
+    {
+        // arrange
+        // 0.1 + 0.2 (0.30000000000000004) and 0.3 are distinct doubles. Shortest
+        // round-trip formatting - the default for double since .NET Core 3.0 -
+        // keeps them distinct, so the two filters must not collide.
+        var predicate1 = BuildScoreEqualsViaHolder(0.1 + 0.2);
+        var predicate2 = BuildScoreEqualsViaHolder(0.3);
+
+        // act
+        var hash1 = new ExpressionHasher().Add(predicate1).Compute();
+        var hash2 = new ExpressionHasher().Add(predicate2).Compute();
+
+        // assert
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
     public static void Predicate_With_Self_Referential_Collection_Terminates()
     {
         // arrange
@@ -254,6 +272,14 @@ public static class ExpressionHasherTests
         var x = Expression.Parameter(typeof(Entity1), "x");
         var p = Expression.Property(Expression.Constant(new Holder<DateTime>(value)), nameof(Holder<DateTime>.p));
         var body = Expression.Equal(Expression.Property(x, nameof(Entity1.Created)), p);
+        return Expression.Lambda<Func<Entity1, bool>>(body, x);
+    }
+
+    private static Expression<Func<Entity1, bool>> BuildScoreEqualsViaHolder(double value)
+    {
+        var x = Expression.Parameter(typeof(Entity1), "x");
+        var p = Expression.Property(Expression.Constant(new Holder<double>(value)), nameof(Holder<double>.p));
+        var body = Expression.Equal(Expression.Property(x, nameof(Entity1.Score)), p);
         return Expression.Lambda<Func<Entity1, bool>>(body, x);
     }
 
@@ -372,6 +398,8 @@ public static class ExpressionHasherTests
         public string? Description { get; set; }
 
         public DateTime Created { get; set; }
+
+        public double Score { get; set; }
 
         public IEntity Entity { get; set; } = null!;
 


### PR DESCRIPTION
Fixes #10060

## Problem

Two paged + filtered fields on the same parent that differ only by their filter
value (e.g. `items(where: { status: { eq: A } })` vs `eq: B`) resolve to the
**same** batch-page DataLoader branch, so the second field serves the page
already loaded for the first. An `in` filter escapes only incidentally
(different expression *shape*); two `in` fields with different lists collide the
same way.

Minimal reproduction: https://github.com/vbornand/HcDataLoaderFilterRepro
(seeded 2 `IN_PROGRESS` + 5 `TO_DO`; the query returns `2 / 2 / 5` instead of
`2 / 5 / 5`).

## Root cause

The DataLoader branch key comes from `QueryContext.ComputeHash()`
(`DataLoaderStateHelper`), which feeds the predicate to
`GreenDonut.Data.Internal.ExpressionHasher`. Filtering hoists filter values into
`FilterExpressionBuilder.ExpressionParameter<T>` and reads them through a member
access (`.p`) rooted at a `ConstantExpression`:

```
eq: _s0 => (_s0.Status == ExpressionParameter { p = InProgress }.p)
in: _s0 => ExpressionParameter { p = ItemStatus[] }.p.Contains(_s0.Status)
```

`ExpressionHasher.VisitMember` appended the member name and then visited the
constant, but there is no `VisitConstant` override, so the constant contributed
no bytes. The captured value never entered the hash, so predicates differing
only by their value produced identical branch keys.

## Fix

When a member access is rooted directly at a `ConstantExpression` (a
hoisted/captured value — `ExpressionParameter<T>.p` or a closure field),
evaluate the value and fold it into the hash instead of hashing only the member
name. Bare inline constants are left untouched, so existing hashes are
unchanged.

Verified against the current hasher, two predicates differing only by a captured
value hash identically (`07e0d65f…` for both `eq(abc)` and `eq(xyz)`); after the
fix they are distinct and the reproduction returns `2 / 5 / 5`.

## Robustness

Captured-value hashing is designed to never fail or misbehave while computing a
branch key:

- **Encoding is unambiguous** — captured text is length-prefixed, so a separator
  inside a value (`in: ["a,b"]`) can't collide with a different set
  (`in: ["a", "b"]`).
- **Round-trip precision** — temporal values (`DateTime`/`DateTimeOffset`/
  `TimeSpan`/`DateOnly`/`TimeOnly`) use round-trip formats; the default `"G"`
  format dropped sub-second precision, which would have collided timestamp range
  filters. (`double`/`float` already round-trip via shortest-representation
  formatting on the targeted TFMs.)
- **No side effects** — property getters are only invoked on value-type holders
  (record structs like `ExpressionParameter<T>`); only arrays and `List<T>` are
  enumerated, so EF lazy-loading proxies / `IQueryable` / iterators fold in their
  type instead of triggering a query. Evaluation and enumeration are guarded, so
  a throwing accessor/enumerator falls back rather than failing the hash.
- **Bounded work** — a captured-node budget (in addition to a depth guard)
  prevents a cyclic or pathological captured graph from blowing up.

## Tests

Added to `ExpressionHasherTests` (the collision cases fail before the fix and
pass after; the robustness cases guard against regressions):

- captured scalar value affects the hash (and equal values stay stable)
- captured list affects the hash (and equal lists stay stable)
- list element boundaries are unambiguous (`["a,b"]` ≠ `["a", "b"]`)
- the record-struct `ExpressionParameter<T>.p` shape differentiates and is stable
- sub-second `DateTime` differences affect the hash
- least-significant-digit `double` differences affect the hash
- a lazy `IEnumerable` is not enumerated while hashing
- a self-referential collection terminates
