### PR TITLE
Fix projection crash on empty nested list sub-projection

### DIFF
--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionListHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionListHandler.cs
@@ -85,6 +85,11 @@ public class QueryableProjectionListHandler
         if (!queryableScope.HasAbstractTypes()
             && (queryableScope.Level.Count == 0 || queryableScope.Level.Peek().Count == 0))
         {
+            // No member is projected for this list, so the instance pushed in OnBeforeEnter
+            // is popped here to keep the instance stack aligned with the parent scope,
+            // mirroring the pop the non-empty path performs below via CreateSelection.
+            context.PopInstance();
+
             action = SelectionVisitor.Continue;
 
             return true;

--- a/src/HotChocolate/Data/test/Data.Projections.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.Tests/IntegrationTests.cs
@@ -172,8 +172,7 @@ public class IntegrationTests
             .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // act
-        // 'computed' is the only selection inside the list, so the list sub-projection is
-        // empty; the trailing sibling 'id' must still bind against the parent.
+        // 'computed' is the only selection inside the list.
         var result = await executor.ExecuteAsync(
             """
             {
@@ -188,6 +187,11 @@ public class IntegrationTests
             TestContext.Current.CancellationToken);
 
         // assert
+        // 'computed' has no backing column, so it contributes nothing to the projection.
+        // As the only selection on the element, it leaves the list sub-projection empty, so
+        // the list is not materialized and 'items' is empty. The trailing 'id' must still
+        // bind against the parent. Materializing the list so element resolvers run when no
+        // element column is selected is a separate change, not covered here.
         result.MatchInlineSnapshot(
             """
             {

--- a/src/HotChocolate/Data/test/Data.Projections.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.Tests/IntegrationTests.cs
@@ -160,6 +160,50 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task Projection_Should_NotThrow_When_OnlyNonProjectableExtensionFieldInNestedList()
+    {
+        // arrange
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<QueryWithNestedListExtension>()
+            .AddTypeExtension<ListItemExtensions>()
+            .AddProjections()
+            .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
+            .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // act
+        // 'computed' is the only selection inside the list, so the list sub-projection is
+        // empty; the trailing sibling 'id' must still bind against the parent.
+        var result = await executor.ExecuteAsync(
+            """
+            {
+                listParents {
+                    items {
+                        computed
+                    }
+                    id
+                }
+            }
+            """,
+            TestContext.Current.CancellationToken);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "listParents": [
+                  {
+                    "items": [],
+                    "id": 1
+                  }
+                ]
+              }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task Projection_Should_Project_ArrayLength_Expression_Fields()
     {
         // arrange
@@ -921,4 +965,39 @@ public class QueryWithNodeResolvers
 
     [NodeResolver]
     public Bar GetBarById(string id) => new() { IdOfBar = "A" };
+}
+
+public class QueryWithNestedListExtension
+{
+    [UseProjection]
+    public IQueryable<ListParent> ListParents
+        => new[]
+        {
+            new ListParent
+            {
+                Id = 1,
+                Items = [new ListItem { Id = 10, Value = "a" }, new ListItem { Id = 11, Value = "b" }]
+            }
+        }.AsQueryable();
+}
+
+public class ListParent
+{
+    public int Id { get; set; }
+
+    public List<ListItem> Items { get; set; } = [];
+}
+
+public class ListItem
+{
+    public int Id { get; set; }
+
+    public string Value { get; set; } = "";
+}
+
+[ExtendObjectType(typeof(ListItem))]
+public class ListItemExtensions
+{
+    // Resolver whose value does not come from a ListItem column, so it is not projected.
+    public string Computed() => "computed";
 }


### PR DESCRIPTION
## Summary
- Queryable projection threw `ArgumentException: Property '...' is not defined for type 'List<T>'` when a nested list's sub-projection was empty and a scalar sibling followed it. `QueryableProjectionListHandler.OnBeforeEnter` pushes an instance, but the empty-projection early-return in `TryHandleLeave` never popped it, so the trailing sibling bound against the leaked list instance.
- The empty-projection branch now pops that instance, keeping the instance stack aligned with the parent scope, mirroring the non-empty path. This is the crash reported in #10034.

## Test plan
- Added a projection integration test: a non-projectable extension field selected alone inside a nested list, followed by a sibling scalar; it now returns a well-formed result instead of throwing.
- `Data.Projections.Tests` passes (156 tests).
