### PR TITLE
[Website] Document v16 extension resolver projection change

### DIFF
--- a/website/content/docs/hotchocolate/migrating/migrate-from-15-to-16.md
+++ b/website/content/docs/hotchocolate/migrating/migrate-from-15-to-16.md
@@ -1406,7 +1406,7 @@ The `CanHandle` signature also changed on the filtering, sorting, and projection
 
 A field whose resolver is defined on a different type than the entity being projected, most commonly a resolver class annotated with `[ExtendObjectType]`, is no longer added to the queryable projection by default.
 
-In version 15, the projection included the backing member of such a field even though a custom resolver produced the value, and opting out required an explicit `[IsProjected(false)]`. Version 16 treats a resolver defined on a separate type as a genuine custom resolver: its backing member is left out of the projection unless you opt in. Fields whose resolver member is declared on the entity's runtime type, on an interface the entity implements, or on a base type it extends are unaffected and continue to be projected.
+In v15, the projection included the backing member of such a field even though a custom resolver produced the value, and opting out required an explicit `[IsProjected(false)]`. v16 treats a resolver defined on a separate type as a genuine custom resolver: its backing member is left out of the projection unless you opt in. Fields whose resolver member is declared on the entity's runtime type, on an interface the entity implements, or on a base type it extends are unaffected and continue to be projected.
 
 The following resolver reads a member of its parent through `[ExtendObjectType]`:
 
@@ -1418,7 +1418,7 @@ public sealed class AuthorExtensions
 }
 ```
 
-In version 15, `Author.Name` was projected, so `displayName` returned the author's name. In version 16, `Name` is no longer projected, the resolver receives a default-valued `Author`, and `displayName` returns an empty string.
+In v15, `Author.Name` was projected, so `displayName` returned the author's name. In v16, `Name` is no longer projected, so the resolver receives an `Author` whose `Name` is unset (the CLR default, `null` for a string), and `displayName` no longer returns the real name.
 
 To keep the backing member in the projection, annotate the resolver with `[BindMember]` and name the member it reads:
 

--- a/website/content/docs/hotchocolate/migrating/migrate-from-15-to-16.md
+++ b/website/content/docs/hotchocolate/migrating/migrate-from-15-to-16.md
@@ -1402,6 +1402,39 @@ public class CustomFilteringConvention : FilterConvention
 
 The `CanHandle` signature also changed on the filtering, sorting, and projection handler interfaces. If you have overridden it, re-override against the new signature.
 
+## Extension type resolvers are no longer projected by default
+
+A field whose resolver is defined on a different type than the entity being projected, most commonly a resolver class annotated with `[ExtendObjectType]`, is no longer added to the queryable projection by default.
+
+In version 15, the projection included the backing member of such a field even though a custom resolver produced the value, and opting out required an explicit `[IsProjected(false)]`. Version 16 treats a resolver defined on a separate type as a genuine custom resolver: its backing member is left out of the projection unless you opt in. Fields whose resolver member is declared on the entity's runtime type, on an interface the entity implements, or on a base type it extends are unaffected and continue to be projected.
+
+The following resolver reads a member of its parent through `[ExtendObjectType]`:
+
+```csharp
+[ExtendObjectType(typeof(Author))]
+public sealed class AuthorExtensions
+{
+    public string DisplayName([Parent] Author author) => author.Name;
+}
+```
+
+In version 15, `Author.Name` was projected, so `displayName` returned the author's name. In version 16, `Name` is no longer projected, the resolver receives a default-valued `Author`, and `displayName` returns an empty string.
+
+To keep the backing member in the projection, annotate the resolver with `[BindMember]` and name the member it reads:
+
+```diff
+[ExtendObjectType(typeof(Author))]
+public sealed class AuthorExtensions
+{
++   [BindMember(nameof(Author.Name))]
+    public string DisplayName([Parent] Author author) => author.Name;
+}
+```
+
+`[IsProjected(true)]` re-enables projection as well.
+
+If the resolver does not read a member of the entity, because it calls a service, resolves a DataLoader, or returns a computed value, no member needs to be projected and no change is required.
+
 ## Transaction scope handlers removed
 
 `AddTransactionScopeHandler` and `AddDefaultTransactionScopeHandler` have been removed. The `ITransactionScopeHandler` abstraction wrapped an entire mutation operation in a single transaction and rolled back all root field results when any root field errored. This violates the GraphQL specification, which defines mutation root fields as independent: each field's result must be observable regardless of whether subsequent fields succeed or fail.


### PR DESCRIPTION
## Summary
- Adds an **"Extension type resolvers are no longer projected by default"** breaking-change section to the v15→v16 migration guide.
- Explains that in v16 a field resolved on a different type than the entity (an `[ExtendObjectType]` resolver) is no longer auto-projected, and describes the before/after behavior (v15 projected the backing member; v16 returns its default, e.g. an empty string).
- Shows the `[BindMember(nameof(...))]` opt-in as a diff, with `[IsProjected(true)]` noted as an alternative, and notes that resolvers reading no entity member (service, DataLoader, or computed value) need no change.
