### PR TITLE
[Website] Format federated event streams blog post with prettier

### DIFF
--- a/website/content/blog/2026-07-06-federated-event-streams.md
+++ b/website/content/blog/2026-07-06-federated-event-streams.md
@@ -2,7 +2,15 @@
 date: "2026-07-06"
 title: "Introducing Federated Event Streams for Fusion 16.4"
 description: "Federated Event Streams add broker-backed, resumable GraphQL subscriptions to Fusion 16.4, with stateless gateway scaling and client-owned resume cursors."
-tags: ["fusion", "graphql", "federation", "subscriptions", "event-streams", "dotnet"]
+tags:
+  [
+    "fusion",
+    "graphql",
+    "federation",
+    "subscriptions",
+    "event-streams",
+    "dotnet",
+  ]
 category: "Release"
 featuredImage: "header.png"
 author: Michael Staib


### PR DESCRIPTION
## Summary

- Reformat the federated event streams blog post with Prettier (the 3.8.3 version CI's `format:check` runs), wrapping the long `tags` frontmatter array so `yarn format:check` passes.
