### PR TITLE
Enable Git long paths on Windows release checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,13 @@ jobs:
           apk add --no-cache bash clang lld build-base zlib-dev musl-dev \
             git curl icu-libs libstdc++ libgcc github-cli
 
+      # Enable Git long path support before checkout. Must be --system:
+      # actions/checkout overrides HOME (and thus global config) for its run,
+      # but honors system config.
+      - name: 🪟 Enable Git long paths (Windows)
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: 📦 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -127,9 +127,12 @@ kode
 Kydne
 LASTEXITCODE
 Leia
+libgcc
+libstdc
 LICEN*
 Linq
 Liquibase
+longpaths
 lscache
 Marek
 marocchino


### PR DESCRIPTION
## Summary

- The `build-nitro-cli` matrix job checks out the repo on `windows-2025`, where some Fusion snapshot paths exceed the Windows `MAX_PATH` limit and fail `actions/checkout` with `Filename too long`.
- Add a Windows-gated step that runs `git config --system core.longpaths true` before checkout. Uses `--system` because `actions/checkout` overrides `HOME` (and thus global config) for its run but honors system config.
- Add `libgcc`, `libstdc`, and `longpaths` to the spell-check dictionary.

## Test plan

- Verified by inspection: step is gated to Windows, ordered before the checkout step, and sets the config at system scope. Effective coverage is the next release run on the Windows legs (`win-x64`, `win-x86`).
