### PR TITLE
Update ChilliCream.ModelContextProtocol.AspNetCore to 1.4.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.8" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.dotMemory" Version="0.15.8" />
-    <PackageVersion Include="ChilliCream.ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <PackageVersion Include="ChilliCream.ModelContextProtocol.AspNetCore" Version="1.4.1" />
     <PackageVersion Include="ChilliCream.Nitro.App" Version="$(NitroVersion)" />
     <PackageVersion Include="Confluent.Kafka" Version="2.14.2" />
     <PackageVersion Include="DiffPlex" Version="1.9.0" />


### PR DESCRIPTION
## Summary
- Bump `ChilliCream.ModelContextProtocol.AspNetCore` from 1.4.0 to 1.4.1 in central package management.

## Test plan
- `dotnet test src/HotChocolate/Adapters/test/Adapters.Mcp.Tests` — 948 passed, 0 failed, 0 skipped across net8.0 / net9.0 / net10.0 / net11.0 (covers both the Core and Fusion MCP adapters).
