### PR TITLE
Bump .NET 11 SDK and packages to preview 6

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -142,7 +142,7 @@ jobs:
             echo "Installing .NET..."
             curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
             chmod +x dotnet-install.sh
-            ./dotnet-install.sh --version 11.0.100-preview.5.26302.115 --install-dir $HOME/.dotnet
+            ./dotnet-install.sh --version 11.0.100-preview.6.26359.118 --install-dir $HOME/.dotnet
             rm dotnet-install.sh
             echo "$HOME/.dotnet" >> $GITHUB_PATH
             export PATH="$HOME/.dotnet:$PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
             8.x
             9.x
             10.x
-            11.0.100-preview.5.26302.115
+            11.0.100-preview.6.26359.118
 
       - name: Run Build
         id: run-build
@@ -289,7 +289,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
-          dotnet-version: 11.0.100-preview.5.26302.115
+          dotnet-version: 11.0.100-preview.6.26359.118
 
       - name: Download all coverage artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,7 @@ jobs:
             8.x
             9.x
             10.x
-            11.0.100-preview.5.26302.115
+            11.0.100-preview.6.26359.118
 
       - name: Run Build
         id: run-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
             8.x
             9.x
             10.x
-            11.0.100-preview.5.26302.115
+            11.0.100-preview.6.26359.118
 
       - name: 🖍️ Stamp template PackageReference versions
         shell: bash
@@ -262,7 +262,7 @@ jobs:
       - name: 🛠 Install .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
-          dotnet-version: 11.0.100-preview.5.26302.115
+          dotnet-version: 11.0.100-preview.6.26359.118
 
       - name: 📦 Publish binary
         shell: bash

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.5.26302.115",
+    "version": "11.0.100-preview.6.26359.118",
     "rollForward": "latestMinor"
   },
   "test": {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -89,35 +89,35 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Microsoft.AspNetCore.HeaderPropagation" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="11.0.0-preview.5" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="11.0.0-preview.5" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="11.0.0-preview.5" />
-    <PackageVersion Include="System.IO.Hashing" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="System.IO.Packaging" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="11.0.0-preview.5.26302.115" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.AspNetCore.HeaderPropagation" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="11.0.0-preview.6" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="11.0.0-preview.6" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="11.0.0-preview.6" />
+    <PackageVersion Include="System.IO.Hashing" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="System.IO.Packaging" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="11.0.0-preview.6.26359.118" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,10 +11,10 @@
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.10" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.10" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.10" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.10" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.dotMemory" Version="0.15.8" />
     <PackageVersion Include="ChilliCream.ModelContextProtocol.AspNetCore" Version="1.4.1" />

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Field_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Field_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Model_Names_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Model_Names_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Operation_Names_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Operation_Names_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Routes_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Duplicated_Routes_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_Fields_And_FragmentDocument_Reference_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_Fields_And_FragmentDocument_Reference_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_Fields_And_Local_Fragment_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_Fields_And_Local_Fragment_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_FragmentDocument_Reference_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_FragmentDocument_Reference_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_Local_Fragment_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_Local_Fragment_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_Local_Fragment_With_FragmentDocument_Reference_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.FragmentDocument_With_Local_Fragment_With_FragmentDocument_Reference_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.HotReload_Add_New_Document_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.HotReload_Add_New_Document_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.HotReload_Remove_Existing_Operation_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.HotReload_Remove_Existing_Operation_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.HotReload_Update_Existing_Document_Different_Route_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.HotReload_Update_Existing_Document_Different_Route_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.HotReload_Update_Existing_Document_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.HotReload_Update_Existing_Document_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Missing_Field_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Missing_Field_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Missing_Model_References_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.Missing_Model_References_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET11_0_Fusion.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OpenApi_Includes_Initial_Routes_NET11_0_Fusion.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Default_Value_For_Variable_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Default_Value_For_Variable_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Fields_And_FragmentDocument_Reference_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Fields_And_FragmentDocument_Reference_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Fields_And_Local_Fragment_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Fields_And_Local_Fragment_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_FragmentDocument_Reference_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_FragmentDocument_Reference_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_FragmentDocument_Reference_On_Nullable_Field_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_FragmentDocument_Reference_On_Nullable_Field_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_List_Of_Unions_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_List_Of_Unions_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_List_With_Nullable_And_NonNull_Items_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_List_With_Nullable_And_NonNull_Items_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Local_Fragment_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Local_Fragment_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Local_Fragment_With_FragmentDocument_Reference_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTestBase.OperationDocument_With_Local_Fragment_With_FragmentDocument_Reference_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.Indirect_Input_Type_Via_Mutation_Body_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.Indirect_Input_Type_Via_Mutation_Body_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.Indirect_Input_Type_With_Two_Sibling_Occurrences_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.Indirect_Input_Type_With_Two_Sibling_Occurrences_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.Indirect_Output_Type_Via_Query_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.Indirect_Output_Type_Via_Query_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.SelfRef_Input_Type_Via_Mutation_Body_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.SelfRef_Input_Type_Via_Mutation_Body_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.SelfRef_Output_Type_Via_Query_NET11_0.json
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/OpenApi/__snapshots__/OpenApiIntegrationTests.SelfRef_Output_Type_Via_Query_NET11_0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.2",
+  "openapi": "3.2.0",
   "info": {
     "title": "HotChocolate.Adapters.OpenApi.Tests | v1",
     "version": "1.0.0"

--- a/src/HotChocolate/Diagnostics/test/Diagnostics.Tests/ActivityTestHelper.cs
+++ b/src/HotChocolate/Diagnostics/test/Diagnostics.Tests/ActivityTestHelper.cs
@@ -17,6 +17,11 @@ public static partial class ActivityTestHelper
     // stable regardless of those JIT/coverage differences.
     [GeneratedRegex(@"\n--- End of stack trace from previous location ---", RegexOptions.CultureInvariant)]
     private static partial Regex StackTraceResumptionMarkerRegex();
+    // Runtime-async continuation frames (RuntimeAsyncTaskContinuation) appear in captured stack
+    // traces on runtimes that enable runtime async and are absent otherwise. Removing them keeps
+    // the snapshot stable across runtime versions.
+    [GeneratedRegex(@"\n\s+at System\.Runtime\.CompilerServices\.RuntimeAsyncTaskContinuation[^\n]*", RegexOptions.CultureInvariant)]
+    private static partial Regex StackTraceRuntimeAsyncFrameRegex();
 
     public static IDisposable CaptureActivities(out Capture activities)
     {
@@ -89,6 +94,8 @@ public static partial class ActivityTestHelper
                 });
 
                 scrubbedStackTrace = StackTraceResumptionMarkerRegex().Replace(scrubbedStackTrace, "");
+
+                scrubbedStackTrace = StackTraceRuntimeAsyncFrameRegex().Replace(scrubbedStackTrace, "");
 
                 yield return new KeyValuePair<string, object?>(
                     tag.Key,


### PR DESCRIPTION
## Summary

- Bump the .NET 11 SDK to `11.0.100-preview.6.26359.118` (`global.json` and the CI, coverage, release, and benchmarks workflows) and the net11.0 preview packages (ASP.NET Core, EF Core, Npgsql, Extensions, and System.*) to preview.6.
- Bump `Basic.Reference.Assemblies` to 1.8.10 so the analyzer tests compile against the preview.6 net11.0 reference assemblies.
- Refresh the net11.0 OpenAPI adapter snapshots for the OpenAPI 3.2.0 documents that `Microsoft.AspNetCore.OpenApi` preview.6 emits.
- Scrub the runtime-async continuation frames that preview.6 adds to captured stack traces, keeping the diagnostics activity snapshots stable across runtimes.

## Test plan

- `dotnet test src/HotChocolate/Data/test/Data.PostgreSQL.Tests --framework net11.0` — passed.
- `dotnet test src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests --framework net11.0` — passed.
- `dotnet test src/HotChocolate/Diagnostics/test/Diagnostics.Tests --framework net11.0` — passed.
- Analyzer suites (`Types.Analyzers.Tests`, `Types.Analyzers.Integration.Tests`, `Mocha.Analyzers.Tests`) on net11.0 — passed.
