### PR TITLE
Fix npm publish resolving release tarball as a GitHub spec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,7 +528,7 @@ jobs:
               echo "Skipping ${name}@${version} (already published)"
               return 0
             fi
-            npm publish "$tarball" \
+            npm publish "./$tarball" \
               --access public \
               --registry="$REGISTRY" \
               --tag "$PRIMARY_BAND"


### PR DESCRIPTION
## Summary

- `publish-npm` passed each tarball to `npm publish` as a bare `tarballs/<name>.tgz` path. npm reads a slashed argument without a leading `./` as the GitHub `owner/repo` shorthand, so it ran `git ls-remote ssh://git@github.com/tarballs/<name>.tgz` and failed with `Permission denied (publickey)` instead of publishing the local tarball. This broke the `16.6.0-p.1` release after the NuGet packages and Nitro operations had already published.
- Prefix the argument with `./` so npm resolves it as a local file.

## Test plan

- `yaml` parse of the workflow and a structural check of the publish phase (gating, ordering, idempotency) pass.
- Full validation requires a live `16.*` release tag (side-effecting) and was not run.
