### PR TITLE
Add code-first `.Authorize` overloads matching the directive

### DIFF
--- a/src/HotChocolate/Core/src/Authorization/Extensions/AuthorizeObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Authorization/Extensions/AuthorizeObjectFieldDescriptorExtensions.cs
@@ -80,6 +80,62 @@ public static class AuthorizeObjectFieldDescriptorExtensions
     }
 
     /// <summary>
+    /// Adds authorization to a field.
+    /// </summary>
+    /// <param name="descriptor">The field descriptor.</param>
+    /// <param name="roles">The roles for which this field shall be accessible.</param>
+    /// <param name="apply">Defines when the authorization policy is invoked.</param>
+    /// <returns>
+    /// Returns the <see cref="IObjectFieldDescriptor"/> for configuration chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IObjectFieldDescriptor Authorize(
+        this IObjectFieldDescriptor descriptor,
+        IReadOnlyList<string> roles,
+        ApplyPolicy apply = ApplyPolicy.BeforeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (apply is ApplyPolicy.Validation)
+        {
+            descriptor.Extend().Context.ModifyAuthorizationFieldOptions(o => o with { AuthorizeAtRequestLevel = true });
+        }
+
+        return descriptor.Directive(new AuthorizeDirective(roles, apply));
+    }
+
+    /// <summary>
+    /// Adds authorization to a field.
+    /// </summary>
+    /// <param name="descriptor">The field descriptor.</param>
+    /// <param name="policy">The authorization policy name.</param>
+    /// <param name="roles">The roles for which this field shall be accessible.</param>
+    /// <param name="apply">Defines when the authorization policy is invoked.</param>
+    /// <returns>
+    /// Returns the <see cref="IObjectFieldDescriptor"/> for configuration chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IObjectFieldDescriptor Authorize(
+        this IObjectFieldDescriptor descriptor,
+        string policy,
+        IReadOnlyList<string> roles,
+        ApplyPolicy apply = ApplyPolicy.BeforeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (apply is ApplyPolicy.Validation)
+        {
+            descriptor.Extend().Context.ModifyAuthorizationFieldOptions(o => o with { AuthorizeAtRequestLevel = true });
+        }
+
+        return descriptor.Directive(new AuthorizeDirective(policy, roles, apply));
+    }
+
+    /// <summary>
     /// Allows anonymous access to this field.
     /// </summary>
     /// <param name="descriptor">

--- a/src/HotChocolate/Core/src/Authorization/Extensions/AuthorizeObjectTypeDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Authorization/Extensions/AuthorizeObjectTypeDescriptorExtensions.cs
@@ -53,7 +53,7 @@ public static class AuthorizeObjectTypeDescriptorExtensions
     /// Adds authorization to a type.
     /// </summary>
     /// <param name="descriptor">The type descriptor.</param>
-    /// <param name="roles">The roles for which this field shall be accessible.</param>
+    /// <param name="roles">The roles for which this type shall be accessible.</param>
     /// <returns>
     /// Returns the <see cref="IObjectTypeDescriptor"/> for configuration chaining.
     /// </returns>
@@ -73,9 +73,55 @@ public static class AuthorizeObjectTypeDescriptorExtensions
     /// Adds authorization to a type.
     /// </summary>
     /// <param name="descriptor">The type descriptor.</param>
+    /// <param name="roles">The roles for which this type shall be accessible.</param>
     /// <param name="apply">Defines when the authorization policy is invoked.</param>
     /// <returns>
     /// Returns the <see cref="IObjectTypeDescriptor"/> for configuration chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IObjectTypeDescriptor Authorize(
+        this IObjectTypeDescriptor descriptor,
+        IReadOnlyList<string> roles,
+        ApplyPolicy apply = ApplyPolicy.BeforeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        return descriptor.Directive(new AuthorizeDirective(roles, apply));
+    }
+
+    /// <summary>
+    /// Adds authorization to a type.
+    /// </summary>
+    /// <param name="descriptor">The type descriptor.</param>
+    /// <param name="policy">The authorization policy name.</param>
+    /// <param name="roles">The roles for which this type shall be accessible.</param>
+    /// <param name="apply">Defines when the authorization policy is invoked.</param>
+    /// <returns>
+    /// Returns the <see cref="IObjectTypeDescriptor"/> for configuration chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IObjectTypeDescriptor Authorize(
+        this IObjectTypeDescriptor descriptor,
+        string policy,
+        IReadOnlyList<string> roles,
+        ApplyPolicy apply = ApplyPolicy.BeforeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        return descriptor.Directive(new AuthorizeDirective(policy, roles, apply));
+    }
+
+    /// <summary>
+    /// Adds authorization to a type.
+    /// </summary>
+    /// <param name="descriptor">The type descriptor.</param>
+    /// <param name="apply">Defines when the authorization policy is invoked.</param>
+    /// <returns>
+    /// Returns the <see cref="IObjectTypeDescriptor{T}"/> for configuration chaining.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// The <paramref name="descriptor"/> is <c>null</c>.
@@ -96,7 +142,7 @@ public static class AuthorizeObjectTypeDescriptorExtensions
     /// <param name="policy">The authorization policy name.</param>
     /// <param name="apply">Defines when the authorization policy is invoked.</param>
     /// <returns>
-    /// Returns the <see cref="IObjectTypeDescriptor"/> for configuration chaining.
+    /// Returns the <see cref="IObjectTypeDescriptor{T}"/> for configuration chaining.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// The <paramref name="descriptor"/> is <c>null</c>.
@@ -115,9 +161,9 @@ public static class AuthorizeObjectTypeDescriptorExtensions
     /// Adds authorization to a type.
     /// </summary>
     /// <param name="descriptor">The type descriptor.</param>
-    /// <param name="roles">The roles for which this field shall be accessible.</param>
+    /// <param name="roles">The roles for which this type shall be accessible.</param>
     /// <returns>
-    /// Returns the <see cref="IObjectTypeDescriptor"/> for configuration chaining.
+    /// Returns the <see cref="IObjectTypeDescriptor{T}"/> for configuration chaining.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// The <paramref name="descriptor"/> is <c>null</c>.
@@ -129,5 +175,51 @@ public static class AuthorizeObjectTypeDescriptorExtensions
         ArgumentNullException.ThrowIfNull(descriptor);
 
         return descriptor.Directive(new AuthorizeDirective(roles));
+    }
+
+    /// <summary>
+    /// Adds authorization to a type.
+    /// </summary>
+    /// <param name="descriptor">The type descriptor.</param>
+    /// <param name="roles">The roles for which this type shall be accessible.</param>
+    /// <param name="apply">Defines when the authorization policy is invoked.</param>
+    /// <returns>
+    /// Returns the <see cref="IObjectTypeDescriptor{T}"/> for configuration chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IObjectTypeDescriptor<T> Authorize<T>(
+        this IObjectTypeDescriptor<T> descriptor,
+        IReadOnlyList<string> roles,
+        ApplyPolicy apply = ApplyPolicy.BeforeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        return descriptor.Directive(new AuthorizeDirective(roles, apply));
+    }
+
+    /// <summary>
+    /// Adds authorization to a type.
+    /// </summary>
+    /// <param name="descriptor">The type descriptor.</param>
+    /// <param name="policy">The authorization policy name.</param>
+    /// <param name="roles">The roles for which this type shall be accessible.</param>
+    /// <param name="apply">Defines when the authorization policy is invoked.</param>
+    /// <returns>
+    /// Returns the <see cref="IObjectTypeDescriptor{T}"/> for configuration chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IObjectTypeDescriptor<T> Authorize<T>(
+        this IObjectTypeDescriptor<T> descriptor,
+        string policy,
+        IReadOnlyList<string> roles,
+        ApplyPolicy apply = ApplyPolicy.BeforeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        return descriptor.Directive(new AuthorizeDirective(policy, roles, apply));
     }
 }

--- a/src/HotChocolate/Core/test/Authorization.Tests/CodeFirstAuthorizationTests.cs
+++ b/src/HotChocolate/Core/test/Authorization.Tests/CodeFirstAuthorizationTests.cs
@@ -11,8 +11,8 @@ public class CodeFirstAuthorizationTests
     [Fact]
     public async Task Authorize_Field_Roles_Apply_And_Policy_Roles_Apply()
     {
-        // arrange & act
-        var schema = await new ServiceCollection()
+        // arrange
+        var builder = new ServiceCollection()
             .AddGraphQLServer()
             .AddAuthorizationCore()
             .AddQueryType(d =>
@@ -24,18 +24,73 @@ public class CodeFirstAuthorizationTests
                 d.Field("fieldPolicyRolesApply")
                     .Resolve("x")
                     .Authorize("READ", ["admin", "user"], ApplyPolicy.AfterResolver);
-            })
-            .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+            });
+
+        // act
+        var schema = await builder.BuildSchemaAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         schema.MatchSnapshot();
     }
 
     [Fact]
+    public async Task Authorize_Field_Roles_Validation_Authorizes_At_Request_Level()
+    {
+        // arrange
+        // both fields carry a roles-based validation policy;
+        // request-level enforcement must be triggered by the field configuration alone.
+        var handler = new AuthHandler(
+            resolver: (_, _) => AuthorizeResult.Allowed,
+            validation: (_, _) => AuthorizeResult.NotAllowed);
+
+        var executor = await new ServiceCollection()
+            .AddGraphQLServer()
+            .AddQueryType(d =>
+            {
+                d.Name("Query");
+                d.Field("rolesValidation")
+                    .Type<StringType>()
+                    .Resolve("x")
+                    .Authorize(["admin", "user"], ApplyPolicy.Validation);
+                d.Field("policyRolesValidation")
+                    .Type<StringType>()
+                    .Resolve("x")
+                    .Authorize("READ", ["admin", "user"], ApplyPolicy.Validation);
+            })
+            .AddAuthorizationHandler(_ => handler)
+            .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // act
+        var result = await executor.ExecuteAsync(
+            "{ rolesValidation policyRolesValidation }",
+            TestContext.Current.CancellationToken);
+
+        // assert
+        // request-level rejection: an error with no path, raised before resolvers run
+        Snapshot
+            .Create()
+            .Add(result)
+            .MatchInline(
+                """
+                {
+                  "errors": [
+                    {
+                      "message": "The current user is not authorized to access this resource.",
+                      "extensions": {
+                        "code": "AUTH_NOT_AUTHORIZED"
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    [Fact]
     public async Task Authorize_Type_Roles_Apply_And_Policy_Roles_Apply()
     {
-        // arrange & act
-        var schema = await new ServiceCollection()
+        // arrange
+        var builder = new ServiceCollection()
             .AddGraphQLServer()
             .AddAuthorizationCore()
             .AddQueryType(d =>
@@ -44,8 +99,11 @@ public class CodeFirstAuthorizationTests
                 d.Authorize(["type_reader", "type_writer"], ApplyPolicy.AfterResolver);
                 d.Authorize("READ", ["type_reader", "type_writer"], ApplyPolicy.AfterResolver);
                 d.Field("field").Resolve("x");
-            })
-            .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+            });
+
+        // act
+        var schema = await builder.BuildSchemaAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         schema.MatchSnapshot();
@@ -54,8 +112,8 @@ public class CodeFirstAuthorizationTests
     [Fact]
     public async Task Authorize_Type_Roles_Apply_And_Policy_Roles_Apply_Generic()
     {
-        // arrange & act
-        var schema = await new ServiceCollection()
+        // arrange
+        var builder = new ServiceCollection()
             .AddGraphQLServer()
             .AddAuthorizationCore()
             .AddQueryType(d =>
@@ -67,8 +125,11 @@ public class CodeFirstAuthorizationTests
                 d.Field("policyRolesApply")
                     .Type<PolicyRolesApplyType>()
                     .Resolve(new PolicyRolesApplyModel("b"));
-            })
-            .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+            });
+
+        // act
+        var schema = await builder.BuildSchemaAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         schema.MatchSnapshot();

--- a/src/HotChocolate/Core/test/Authorization.Tests/CodeFirstAuthorizationTests.cs
+++ b/src/HotChocolate/Core/test/Authorization.Tests/CodeFirstAuthorizationTests.cs
@@ -9,6 +9,72 @@ namespace HotChocolate.Authorization;
 public class CodeFirstAuthorizationTests
 {
     [Fact]
+    public async Task Authorize_Field_Roles_Apply_And_Policy_Roles_Apply()
+    {
+        // arrange & act
+        var schema = await new ServiceCollection()
+            .AddGraphQLServer()
+            .AddAuthorizationCore()
+            .AddQueryType(d =>
+            {
+                d.Name("Query");
+                d.Field("fieldRolesApply")
+                    .Resolve("x")
+                    .Authorize(["admin", "user"], ApplyPolicy.AfterResolver);
+                d.Field("fieldPolicyRolesApply")
+                    .Resolve("x")
+                    .Authorize("READ", ["admin", "user"], ApplyPolicy.AfterResolver);
+            })
+            .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task Authorize_Type_Roles_Apply_And_Policy_Roles_Apply()
+    {
+        // arrange & act
+        var schema = await new ServiceCollection()
+            .AddGraphQLServer()
+            .AddAuthorizationCore()
+            .AddQueryType(d =>
+            {
+                d.Name("Query");
+                d.Authorize(["type_reader", "type_writer"], ApplyPolicy.AfterResolver);
+                d.Authorize("READ", ["type_reader", "type_writer"], ApplyPolicy.AfterResolver);
+                d.Field("field").Resolve("x");
+            })
+            .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task Authorize_Type_Roles_Apply_And_Policy_Roles_Apply_Generic()
+    {
+        // arrange & act
+        var schema = await new ServiceCollection()
+            .AddGraphQLServer()
+            .AddAuthorizationCore()
+            .AddQueryType(d =>
+            {
+                d.Name("Query");
+                d.Field("rolesApply")
+                    .Type<RolesApplyType>()
+                    .Resolve(new RolesApplyModel("a"));
+                d.Field("policyRolesApply")
+                    .Type<PolicyRolesApplyType>()
+                    .Resolve(new PolicyRolesApplyModel("b"));
+            })
+            .BuildSchemaAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
+    [Fact]
     public async Task Authorize_Person_NoAccess()
     {
         // arrange
@@ -652,6 +718,26 @@ public class CodeFirstAuthorizationTests
             }
 
             return new(AuthorizeResult.Allowed);
+        }
+    }
+
+    private sealed record RolesApplyModel(string? Value);
+
+    private sealed record PolicyRolesApplyModel(string? Value);
+
+    private sealed class RolesApplyType : ObjectType<RolesApplyModel>
+    {
+        protected override void Configure(IObjectTypeDescriptor<RolesApplyModel> descriptor)
+        {
+            descriptor.Authorize(["reader", "writer"], ApplyPolicy.AfterResolver);
+        }
+    }
+
+    private sealed class PolicyRolesApplyType : ObjectType<PolicyRolesApplyModel>
+    {
+        protected override void Configure(IObjectTypeDescriptor<PolicyRolesApplyModel> descriptor)
+        {
+            descriptor.Authorize("READ", ["reader", "writer"], ApplyPolicy.AfterResolver);
         }
     }
 }

--- a/src/HotChocolate/Core/test/Authorization.Tests/__snapshots__/CodeFirstAuthorizationTests.Authorize_Field_Roles_Apply_And_Policy_Roles_Apply.graphql
+++ b/src/HotChocolate/Core/test/Authorization.Tests/__snapshots__/CodeFirstAuthorizationTests.Authorize_Field_Roles_Apply_And_Policy_Roles_Apply.graphql
@@ -1,0 +1,44 @@
+schema {
+  query: Query
+}
+
+type Query {
+  fieldRolesApply: String
+    @authorize(roles: ["admin", "user"], apply: AFTER_RESOLVER)
+    @cost(weight: "10")
+  fieldPolicyRolesApply: String
+    @authorize(policy: "READ", roles: ["admin", "user"], apply: AFTER_RESOLVER)
+    @cost(weight: "10")
+}
+
+"Defines when a policy shall be executed."
+enum ApplyPolicy {
+  "Before the resolver was executed."
+  BEFORE_RESOLVER
+  "After the resolver was executed."
+  AFTER_RESOLVER
+  "The policy is applied in the validation step before the execution."
+  VALIDATION
+}
+
+"The authorize directive."
+directive @authorize(
+  "The name of the authorization policy that determines access to the annotated resource."
+  policy: String
+  "Roles that are allowed to access the annotated resource."
+  roles: [String!]
+  "Defines when the authorize directive shall be applied. By default the authorize directive is applied before the resolver is executed."
+  apply: ApplyPolicy! = BEFORE_RESOLVER
+) repeatable on OBJECT | FIELD_DEFINITION
+
+"The purpose of the `cost` directive is to define a `weight` for GraphQL types, fields, and arguments. Static analysis can use these weights when calculating the overall cost of a query or response."
+directive @cost(
+  "The `weight` argument defines what value to add to the overall cost for every appearance, or possible appearance, of a type, field, argument, etc."
+  weight: String!
+) on
+  | SCALAR
+  | OBJECT
+  | FIELD_DEFINITION
+  | ARGUMENT_DEFINITION
+  | ENUM
+  | INPUT_FIELD_DEFINITION

--- a/src/HotChocolate/Core/test/Authorization.Tests/__snapshots__/CodeFirstAuthorizationTests.Authorize_Type_Roles_Apply_And_Policy_Roles_Apply.graphql
+++ b/src/HotChocolate/Core/test/Authorization.Tests/__snapshots__/CodeFirstAuthorizationTests.Authorize_Type_Roles_Apply_And_Policy_Roles_Apply.graphql
@@ -1,0 +1,45 @@
+schema {
+  query: Query
+}
+
+type Query
+  @authorize(roles: ["type_reader", "type_writer"], apply: AFTER_RESOLVER)
+  @authorize(
+    policy: "READ"
+    roles: ["type_reader", "type_writer"]
+    apply: AFTER_RESOLVER
+  ) {
+  field: String @cost(weight: "10")
+}
+
+"Defines when a policy shall be executed."
+enum ApplyPolicy {
+  "Before the resolver was executed."
+  BEFORE_RESOLVER
+  "After the resolver was executed."
+  AFTER_RESOLVER
+  "The policy is applied in the validation step before the execution."
+  VALIDATION
+}
+
+"The authorize directive."
+directive @authorize(
+  "The name of the authorization policy that determines access to the annotated resource."
+  policy: String
+  "Roles that are allowed to access the annotated resource."
+  roles: [String!]
+  "Defines when the authorize directive shall be applied. By default the authorize directive is applied before the resolver is executed."
+  apply: ApplyPolicy! = BEFORE_RESOLVER
+) repeatable on OBJECT | FIELD_DEFINITION
+
+"The purpose of the `cost` directive is to define a `weight` for GraphQL types, fields, and arguments. Static analysis can use these weights when calculating the overall cost of a query or response."
+directive @cost(
+  "The `weight` argument defines what value to add to the overall cost for every appearance, or possible appearance, of a type, field, argument, etc."
+  weight: String!
+) on
+  | SCALAR
+  | OBJECT
+  | FIELD_DEFINITION
+  | ARGUMENT_DEFINITION
+  | ENUM
+  | INPUT_FIELD_DEFINITION

--- a/src/HotChocolate/Core/test/Authorization.Tests/__snapshots__/CodeFirstAuthorizationTests.Authorize_Type_Roles_Apply_And_Policy_Roles_Apply_Generic.graphql
+++ b/src/HotChocolate/Core/test/Authorization.Tests/__snapshots__/CodeFirstAuthorizationTests.Authorize_Type_Roles_Apply_And_Policy_Roles_Apply_Generic.graphql
@@ -1,0 +1,50 @@
+schema {
+  query: Query
+}
+
+type Query {
+  rolesApply: RolesApplyModel @cost(weight: "10")
+  policyRolesApply: PolicyRolesApplyModel @cost(weight: "10")
+}
+
+type PolicyRolesApplyModel
+  @authorize(policy: "READ", roles: ["reader", "writer"], apply: AFTER_RESOLVER) {
+  value: String
+}
+
+type RolesApplyModel
+  @authorize(roles: ["reader", "writer"], apply: AFTER_RESOLVER) {
+  value: String
+}
+
+"Defines when a policy shall be executed."
+enum ApplyPolicy {
+  "Before the resolver was executed."
+  BEFORE_RESOLVER
+  "After the resolver was executed."
+  AFTER_RESOLVER
+  "The policy is applied in the validation step before the execution."
+  VALIDATION
+}
+
+"The authorize directive."
+directive @authorize(
+  "The name of the authorization policy that determines access to the annotated resource."
+  policy: String
+  "Roles that are allowed to access the annotated resource."
+  roles: [String!]
+  "Defines when the authorize directive shall be applied. By default the authorize directive is applied before the resolver is executed."
+  apply: ApplyPolicy! = BEFORE_RESOLVER
+) repeatable on OBJECT | FIELD_DEFINITION
+
+"The purpose of the `cost` directive is to define a `weight` for GraphQL types, fields, and arguments. Static analysis can use these weights when calculating the overall cost of a query or response."
+directive @cost(
+  "The `weight` argument defines what value to add to the overall cost for every appearance, or possible appearance, of a type, field, argument, etc."
+  weight: String!
+) on
+  | SCALAR
+  | OBJECT
+  | FIELD_DEFINITION
+  | ARGUMENT_DEFINITION
+  | ENUM
+  | INPUT_FIELD_DEFINITION


### PR DESCRIPTION
## Summary
- Adds code-first `.Authorize` overloads so the code-first API can express every combination the `@authorize` directive supports: `roles` + `apply`, and `policy` + `roles` + `apply` — for object fields and object types (both non-generic and generic `<T>`).
- The combined overloads take `IReadOnlyList<string> roles`, mirroring `AuthorizeDirective`'s constructors. The existing roles-only `params string[]` overload is unchanged, so a `params`/collection-expression call still binds to it — no ambiguity, no breaking change.
- Tidies the type-level overloads' XML docs: the roles `<param>` now says "type" (not "field"), and the generic overloads' `<returns>` cref points at `IObjectTypeDescriptor{T}`.

## Test plan
- New snapshot tests in `CodeFirstAuthorizationTests` cover the field, non-generic type, and generic type overloads, asserting the emitted `@authorize` renders `policy`, `roles`, and a non-default `apply`.
- Authorization test project green across net8.0/9.0/10.0/11.0.
