### PR TITLE
Add `appliedDirectives` to `__Directive` introspection

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
@@ -1,4 +1,5 @@
 #pragma warning disable IDE1006 // Naming Styles
+using System.Runtime.CompilerServices;
 using HotChocolate.Configuration;
 using HotChocolate.Language;
 using HotChocolate.Properties;
@@ -20,6 +21,7 @@ internal sealed class __Directive : ObjectType<DirectiveType>
         var nonNullBooleanType = Parse($"{ScalarNames.Boolean}!");
         var argumentListType = Parse($"[{nameof(__InputValue)}!]!");
         var locationListType = Parse($"[{nameof(__DirectiveLocation)}!]!");
+        var directiveListType = Parse($"[{nameof(__AppliedDirective)}!]!");
 
         var optInFeaturesEnabled = context.DescriptorContext.Options.EnableOptInFeatures;
 
@@ -79,6 +81,13 @@ internal sealed class __Directive : ObjectType<DirectiveType>
             }
         };
 
+        if (context.DescriptorContext.Options.EnableDirectiveIntrospection)
+        {
+            def.Fields.Add(new(Names.AppliedDirectives,
+                type: directiveListType,
+                pureResolver: Resolvers.AppliedDirectives));
+        }
+
         if (optInFeaturesEnabled)
         {
             def.Fields.Single(f => f.Name == Names.Args)
@@ -132,6 +141,12 @@ internal sealed class __Directive : ObjectType<DirectiveType>
                 : directive.Arguments.Where(t => !t.IsDeprecated);
         }
 
+        public static object AppliedDirectives(IResolverContext context) =>
+            ((IDirectivesProvider)context.Parent<DirectiveType>())
+                .Directives
+                .Where(t => Unsafe.As<DirectiveType>(t.Definition).IsPublic)
+                .Select(d => d.ToSyntaxNode());
+
         public static object RequiresOptIn(IResolverContext context) =>
             ((IDirectivesProvider)context.Parent<DirectiveType>())
                 .Directives
@@ -168,6 +183,7 @@ internal sealed class __Directive : ObjectType<DirectiveType>
         public const string DeprecationReason = "deprecationReason";
         public const string IncludeDeprecated = "includeDeprecated";
         public const string IncludeOptIn = "includeOptIn";
+        public const string AppliedDirectives = "appliedDirectives";
         public const string RequiresOptIn = "requiresOptIn";
         public const string Locations = "locations";
         public const string Args = "args";

--- a/src/HotChocolate/Core/test/Execution.Tests/IntrospectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/IntrospectionTests.cs
@@ -540,6 +540,52 @@ public class IntrospectionTests
         result.MatchSnapshot();
     }
 
+    [Fact]
+    public async Task AppliedDirectivesOnDirectiveDefinitionAreExposed()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __schema {
+                    directives {
+                        name
+                        appliedDirectives {
+                            name
+                            args {
+                                name
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddDocumentFromString(
+                """
+                type Query {
+                    field: String
+                }
+
+                directive @meta(name: String!) on DIRECTIVE_DEFINITION
+
+                directive @annotated @meta(name: "example") on FIELD
+                """)
+            .UseField(next => next)
+            .ModifyOptions(o => o.EnableDirectiveIntrospection = true)
+            .BuildRequestExecutorAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // act
+        var result = await executor.ExecuteAsync(query, TestContext.Current.CancellationToken);
+
+        // assert
+        // @annotated carries the applied @meta directive.
+        result.MatchSnapshot();
+    }
+
     private static Schema CreateSchema()
     {
         return SchemaBuilder.New()

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.AppliedDirectivesOnDirectiveDefinitionAreExposed.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.AppliedDirectivesOnDirectiveDefinitionAreExposed.snap
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "__schema": {
+      "directives": [
+        {
+          "name": "skip",
+          "appliedDirectives": []
+        },
+        {
+          "name": "include",
+          "appliedDirectives": []
+        },
+        {
+          "name": "deprecated",
+          "appliedDirectives": []
+        },
+        {
+          "name": "meta",
+          "appliedDirectives": []
+        },
+        {
+          "name": "annotated",
+          "appliedDirectives": [
+            {
+              "name": "meta",
+              "args": [
+                {
+                  "name": "name",
+                  "value": "\"example\""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.DirectiveIntrospection_AllDirectives_Internal.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.DirectiveIntrospection_AllDirectives_Internal.snap
@@ -24,6 +24,9 @@
             },
             {
               "appliedDirectives": []
+            },
+            {
+              "appliedDirectives": []
             }
           ]
         },

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.DirectiveIntrospection_AllDirectives_Public.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.DirectiveIntrospection_AllDirectives_Public.snap
@@ -24,6 +24,9 @@
             },
             {
               "appliedDirectives": []
+            },
+            {
+              "appliedDirectives": []
             }
           ]
         },

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.DirectiveIntrospection_AllDirectives_Public_When_DisableInternalDirectives_Is_True.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.DirectiveIntrospection_AllDirectives_Public_When_DisableInternalDirectives_Is_True.snap
@@ -24,6 +24,9 @@
             },
             {
               "appliedDirectives": []
+            },
+            {
+              "appliedDirectives": []
             }
           ]
         },

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.DirectiveIntrospection_SomeDirectives_Internal.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/IntrospectionTests.DirectiveIntrospection_SomeDirectives_Internal.snap
@@ -24,6 +24,9 @@
             },
             {
               "appliedDirectives": []
+            },
+            {
+              "appliedDirectives": []
             }
           ]
         },


### PR DESCRIPTION
## Summary
- Adds an `appliedDirectives: [__AppliedDirective!]!` field to the `__Directive` introspection type, gated behind the `EnableDirectiveIntrospection` schema option, so directives applied to a directive definition become introspectable.
- Mirrors the existing `appliedDirectives` implementations on `__Type`, `__Field`, and `__Schema`. Stays out of standard introspection because `__AppliedDirective` is a non-spec Hot Chocolate extension.

## Test plan
- New `IntrospectionTests.AppliedDirectivesOnDirectiveDefinitionAreExposed`: a directive definition carrying an applied directive round-trips through `__schema { directives { appliedDirectives { name args { name value } } } }`.
- Full `IntrospectionTests` suite green (net10.0); regenerated the four directive-introspection snapshots that enumerate every type's fields.
