### PR TITLE
Validate directives on enum values and directive arguments

### DIFF
--- a/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
@@ -133,6 +133,8 @@ public sealed class SchemaValidator
                     {
                         PublishEvent(new EnumValueEvent(value), context);
                         PublishEvent(new NamedMemberEvent(value), context);
+
+                        PublishDirectiveEvents(value, context);
                     }
 
                     break;
@@ -170,6 +172,8 @@ public sealed class SchemaValidator
                 PublishEvent(new ArgumentEvent(argument), context);
                 PublishEvent(new InputValueEvent(argument), context);
                 PublishEvent(new NamedMemberEvent(argument), context);
+
+                PublishDirectiveEvents(argument, context);
             }
         }
     }

--- a/src/HotChocolate/Core/test/Types.Validation.Tests/Rules/DirectiveIsDefinedRuleTests.cs
+++ b/src/HotChocolate/Core/test/Types.Validation.Tests/Rules/DirectiveIsDefinedRuleTests.cs
@@ -36,6 +36,12 @@ public sealed class DirectiveIsDefinedRuleTests : RuleTestBase<DirectiveIsDefine
             type Object @example {
                 field(argument: Int @example): Int @example
             }
+
+            enum Enum {
+                VALUE @example
+            }
+
+            directive @other(argument: Int @example) on FIELD
             """,
             """
             {
@@ -64,6 +70,26 @@ public sealed class DirectiveIsDefinedRuleTests : RuleTestBase<DirectiveIsDefine
                 "severity": "Error",
                 "coordinate": "Object.field",
                 "member": "field",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Enum.VALUE' is not defined in the schema.",
+                "code": "HCV0026",
+                "severity": "Error",
+                "coordinate": "Enum.VALUE",
+                "member": "VALUE",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The directive '@example' on '@other(argument:)' is not defined in the schema.",
+                "code": "HCV0026",
+                "severity": "Error",
+                "coordinate": "@other(argument:)",
+                "member": "argument",
                 "extensions": {}
             }
             """);


### PR DESCRIPTION
## Summary

- `SchemaValidator` publishes directive events for every directives provider it walks, including enum values and directive definition arguments. Directives applied at the `ENUM_VALUE` and `ARGUMENT_DEFINITION` (on a directive definition) locations were previously skipped, so rules keyed on `DirectiveEvent` and `DirectiveArgumentAssignmentEvent` never saw them — an undefined directive there passed validation silently.

## Test plan

- Extended `DirectiveIsDefinedRuleTests.Validate_DirectiveIsUndefined_Fails` to cover a directive on an enum value and on a directive definition's argument alongside the existing object/field/argument cases.
- `HotChocolate.Types.Validation.Tests` (404 tests) and `HotChocolate.Fusion.Composition.Tests` (2848 tests, the only other `SchemaValidator` consumer) pass on all target frameworks.
