### PR TITLE
Reduce abstract schema validation overhead and allocations

### DIFF
--- a/src/HotChocolate/Core/src/Types.Validation/Events/Contracts/IValidationEventHandler.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Events/Contracts/IValidationEventHandler.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Events.Contracts;
 /// Represents a handler for a schema validation event.
 /// </summary>
 /// <typeparam name="TEvent">The type of event to handle.</typeparam>
-public interface IValidationEventHandler<in TEvent> where TEvent : IValidationEvent
+public interface IValidationEventHandler<TEvent> where TEvent : IValidationEvent
 {
     /// <summary>
     /// Handles the specified schema validation event.

--- a/src/HotChocolate/Core/src/Types.Validation/Events/ValidationEvents.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Events/ValidationEvents.cs
@@ -7,12 +7,12 @@ namespace HotChocolate.Events;
 /// <summary>
 /// Represents an event that is triggered when an argument is encountered during schema validation.
 /// </summary>
-public sealed record ArgumentEvent(IInputValueDefinition Argument) : IValidationEvent;
+public readonly record struct ArgumentEvent(IInputValueDefinition Argument) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when a complex type is encountered during schema validation.
 /// </summary>
-public sealed record ComplexTypeEvent(IComplexTypeDefinition ComplexType) : IValidationEvent;
+public readonly record struct ComplexTypeEvent(IComplexTypeDefinition ComplexType) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered for each node of a default value literal
@@ -22,7 +22,7 @@ public sealed record ComplexTypeEvent(IComplexTypeDefinition ComplexType) : IVal
 /// <param name="Type">The type expected at the current position.</param>
 /// <param name="Path">The path from the default value root to the current node (input field names and list indices).</param>
 /// <param name="Root">The argument or input field that declares the default value.</param>
-public sealed record DefaultValueNodeEvent(
+public readonly record struct DefaultValueNodeEvent(
     IValueNode Value,
     IType Type,
     IReadOnlyList<object> Path,
@@ -31,7 +31,7 @@ public sealed record DefaultValueNodeEvent(
 /// <summary>
 /// Represents an event that is triggered when a directive argument assignment is encountered during schema validation.
 /// </summary>
-public sealed record DirectiveArgumentAssignmentEvent(
+public readonly record struct DirectiveArgumentAssignmentEvent(
     ArgumentAssignment Assignment,
     IInputValueDefinition Argument,
     IDirective Directive,
@@ -40,76 +40,76 @@ public sealed record DirectiveArgumentAssignmentEvent(
 /// <summary>
 /// Represents an event that is triggered when a directive definition is encountered during schema validation.
 /// </summary>
-public sealed record DirectiveDefinitionEvent(IDirectiveDefinition DirectiveDefinition) : IValidationEvent;
+public readonly record struct DirectiveDefinitionEvent(IDirectiveDefinition DirectiveDefinition) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when a directive is encountered during schema validation.
 /// </summary>
-public sealed record DirectiveEvent(
+public readonly record struct DirectiveEvent(
     IDirective Directive,
     ITypeSystemMember Member) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an Enum type is encountered during schema validation.
 /// </summary>
-public sealed record EnumTypeEvent(IEnumTypeDefinition EnumType) : IValidationEvent;
+public readonly record struct EnumTypeEvent(IEnumTypeDefinition EnumType) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an enum value is encountered during schema validation.
 /// </summary>
-public sealed record EnumValueEvent(IEnumValue EnumValue) : IValidationEvent;
+public readonly record struct EnumValueEvent(IEnumValue EnumValue) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when a field is encountered during schema validation.
 /// </summary>
-public sealed record FieldEvent(IFieldDefinition Field) : IValidationEvent;
+public readonly record struct FieldEvent(IFieldDefinition Field) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an Input Object field is encountered during schema validation.
 /// </summary>
-public sealed record InputFieldEvent(IInputValueDefinition InputField) : IValidationEvent;
+public readonly record struct InputFieldEvent(IInputValueDefinition InputField) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an Input Object type is encountered during schema validation.
 /// </summary>
-public sealed record InputObjectTypeEvent(IInputObjectTypeDefinition InputObjectType) : IValidationEvent;
+public readonly record struct InputObjectTypeEvent(IInputObjectTypeDefinition InputObjectType) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when multiple Input Object types are encountered during schema validation.
 /// </summary>
-public sealed record InputObjectTypesEvent(IEnumerable<IInputObjectTypeDefinition> InputObjectTypes) : IValidationEvent;
+public readonly record struct InputObjectTypesEvent(IEnumerable<IInputObjectTypeDefinition> InputObjectTypes) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an input value is encountered during schema validation.
 /// </summary>
-public sealed record InputValueEvent(IInputValueDefinition InputValue) : IValidationEvent;
+public readonly record struct InputValueEvent(IInputValueDefinition InputValue) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an Interface type is encountered during schema validation.
 /// </summary>
-public sealed record InterfaceTypeEvent(IInterfaceTypeDefinition InterfaceType) : IValidationEvent;
+public readonly record struct InterfaceTypeEvent(IInterfaceTypeDefinition InterfaceType) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when a named member is encountered during schema validation.
 /// </summary>
-public sealed record NamedMemberEvent(INameProvider NamedMember) : IValidationEvent;
+public readonly record struct NamedMemberEvent(INameProvider NamedMember) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an Object type is encountered during schema validation.
 /// </summary>
-public sealed record ObjectTypeEvent(IObjectTypeDefinition ObjectType) : IValidationEvent;
+public readonly record struct ObjectTypeEvent(IObjectTypeDefinition ObjectType) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an output field is encountered during schema validation.
 /// </summary>
-public sealed record OutputFieldEvent(IOutputFieldDefinition OutputField) : IValidationEvent;
+public readonly record struct OutputFieldEvent(IOutputFieldDefinition OutputField) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when a type is encountered during schema validation.
 /// </summary>
-public sealed record TypeEvent(ITypeDefinition Type) : IValidationEvent;
+public readonly record struct TypeEvent(ITypeDefinition Type) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when a Union type is encountered during schema validation.
 /// </summary>
-public sealed record UnionTypeEvent(IUnionTypeDefinition UnionType) : IValidationEvent;
+public readonly record struct UnionTypeEvent(IUnionTypeDefinition UnionType) : IValidationEvent;

--- a/src/HotChocolate/Core/src/Types.Validation/Rules/ValidImplementationsRule.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Rules/ValidImplementationsRule.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using HotChocolate.Events;
 using HotChocolate.Events.Contracts;
 using HotChocolate.Logging;
@@ -38,13 +39,13 @@ public sealed class ValidImplementationsRule : IValidationEventHandler<ComplexTy
     private static bool IsValidImplementation(
         IComplexTypeDefinition type,
         IInterfaceTypeDefinition implementedType,
-        out List<LogEntry> logEntries)
+        [NotNullWhen(false)] out List<LogEntry>? logEntries)
     {
-        logEntries = [];
+        logEntries = null;
 
         if (!IsFullyImplementingInterface(type, implementedType))
         {
-            logEntries.Add(NotTransitivelyImplemented(type, implementedType));
+            (logEntries ??= []).Add(NotTransitivelyImplemented(type, implementedType));
         }
 
         foreach (var implementedField in implementedType.Fields)
@@ -53,17 +54,17 @@ public sealed class ValidImplementationsRule : IValidationEventHandler<ComplexTy
             {
                 if (!ValidateArguments(field, implementedField, out var argumentErrors))
                 {
-                    logEntries.AddRange(argumentErrors);
+                    (logEntries ??= []).AddRange(argumentErrors);
                 }
 
                 if (!IsValidImplementationFieldType(field.Type, implementedField.Type))
                 {
-                    logEntries.Add(InvalidFieldType(type, field, implementedField));
+                    (logEntries ??= []).Add(InvalidFieldType(type, field, implementedField));
                 }
 
                 if (field.IsDeprecated && !implementedField.IsDeprecated)
                 {
-                    logEntries.Add(InvalidFieldDeprecation(
+                    (logEntries ??= []).Add(InvalidFieldDeprecation(
                         implementedType.Name,
                         implementedField,
                         type,
@@ -72,11 +73,11 @@ public sealed class ValidImplementationsRule : IValidationEventHandler<ComplexTy
             }
             else
             {
-                logEntries.Add(FieldNotImplemented(type, implementedField));
+                (logEntries ??= []).Add(FieldNotImplemented(type, implementedField));
             }
         }
 
-        return logEntries.Count == 0;
+        return logEntries is null;
     }
 
     private static bool IsFullyImplementingInterface(
@@ -97,18 +98,17 @@ public sealed class ValidImplementationsRule : IValidationEventHandler<ComplexTy
     private static bool ValidateArguments(
         IOutputFieldDefinition field,
         IOutputFieldDefinition implementedField,
-        out List<LogEntry> logEntries)
+        [NotNullWhen(false)] out List<LogEntry>? logEntries)
     {
-        logEntries = [];
-        var implArgs = implementedField.Arguments.ToDictionary(t => t.Name);
+        logEntries = null;
 
         foreach (var argument in field.Arguments)
         {
-            if (implArgs.Remove(argument.Name, out var implementedArgument))
+            if (implementedField.Arguments.TryGetField(argument.Name, out var implementedArgument))
             {
                 if (!argument.Type.IsStructurallyEqual(implementedArgument.Type))
                 {
-                    logEntries.Add(
+                    (logEntries ??= []).Add(
                         InvalidArgumentType(
                             field,
                             implementedField,
@@ -118,7 +118,7 @@ public sealed class ValidImplementationsRule : IValidationEventHandler<ComplexTy
             }
             else if (argument.Type.IsNonNullType())
             {
-                logEntries.Add(
+                (logEntries ??= []).Add(
                     AdditionalArgumentNotNullable(
                         field,
                         implementedField,
@@ -126,16 +126,19 @@ public sealed class ValidImplementationsRule : IValidationEventHandler<ComplexTy
             }
         }
 
-        foreach (var missingArgument in implArgs.Values)
+        foreach (var implementedArgument in implementedField.Arguments)
         {
-            logEntries.Add(
-                ArgumentNotImplemented(
-                    field,
-                    implementedField,
-                    missingArgument));
+            if (!field.Arguments.ContainsName(implementedArgument.Name))
+            {
+                (logEntries ??= []).Add(
+                    ArgumentNotImplemented(
+                        field,
+                        implementedField,
+                        implementedArgument));
+            }
         }
 
-        return logEntries.Count == 0;
+        return logEntries is null;
     }
 
     // https://spec.graphql.org/September2025/#IsValidImplementationFieldType()

--- a/src/HotChocolate/Core/src/Types.Validation/Rules/ValidNameRule.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Rules/ValidNameRule.cs
@@ -28,7 +28,7 @@ public sealed class ValidNameRule : IValidationEventHandler<NamedMemberEvent>
                 is ITypeDefinition { IsIntrospectionType: true }
                 or IFieldDefinition { IsIntrospectionField: true };
 
-        if (!isIntrospectionMember && namedMember.Name.StartsWith("__"))
+        if (!isIntrospectionMember && namedMember.Name.StartsWith("__", StringComparison.Ordinal))
         {
             context.Log.Write(InvalidMemberName(namedMember));
         }

--- a/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
@@ -14,7 +14,8 @@ public sealed class SchemaValidator
 {
     private static int s_eventTypeCount;
 
-    private readonly HashSet<object> _rules;
+    // Handlers are dispatched in the order the rules were added, so this must preserve order.
+    private readonly List<object> _rules;
     private object?[] _handlers = [];
 
     /// <summary>
@@ -33,7 +34,7 @@ public sealed class SchemaValidator
     /// <param name="rules">The rules to use for validation.</param>
     public SchemaValidator(IEnumerable<object> rules)
     {
-        _rules = rules.ToHashSet();
+        _rules = [.. rules.Distinct()];
     }
 
     /// <summary>

--- a/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
@@ -12,7 +12,10 @@ namespace HotChocolate;
 /// </summary>
 public sealed class SchemaValidator
 {
+    private static int s_eventTypeCount;
+
     private readonly HashSet<object> _rules;
+    private object?[] _handlers = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SchemaValidator"/> class with the default
@@ -38,6 +41,8 @@ public sealed class SchemaValidator
     /// </summary>
     public void AddDefaultRules()
     {
+        _handlers = [];
+
         _rules.Add(new DirectiveDefinitionIncludesLocationRule());
         _rules.Add(new DirectiveDefinitionNoSelfReferenceRule());
         _rules.Add(new DirectiveIsDefinedRule());
@@ -276,12 +281,42 @@ public sealed class SchemaValidator
     private void PublishEvent<TEvent>(TEvent @event, ValidationContext context)
         where TEvent : IValidationEvent
     {
-        foreach (var rule in _rules)
+        foreach (var handler in GetHandlers<TEvent>())
         {
-            if (rule is IValidationEventHandler<TEvent> handler)
-            {
-                handler.Handle(@event, context);
-            }
+            handler.Handle(@event, context);
         }
+    }
+
+    /// <summary>
+    /// Gets the handlers that are subscribed to <typeparamref name="TEvent"/>. The handlers are
+    /// resolved once per event type and per validator, in the order in which the rules were added.
+    /// </summary>
+    private IValidationEventHandler<TEvent>[] GetHandlers<TEvent>()
+        where TEvent : IValidationEvent
+    {
+        var slot = EventSlot<TEvent>.Index;
+        var slots = _handlers;
+
+        if (slot >= slots.Length)
+        {
+            Array.Resize(ref slots, Math.Max(slot + 1, s_eventTypeCount));
+            _handlers = slots;
+        }
+
+        if (slots[slot] is IValidationEventHandler<TEvent>[] handlers)
+        {
+            return handlers;
+        }
+
+        handlers = _rules.OfType<IValidationEventHandler<TEvent>>().ToArray();
+        slots[slot] = handlers;
+
+        return handlers;
+    }
+
+    private static class EventSlot<TEvent>
+        where TEvent : IValidationEvent
+    {
+        public static readonly int Index = Interlocked.Increment(ref s_eventTypeCount) - 1;
     }
 }


### PR DESCRIPTION
## Summary

- `SchemaValidator` resolves the handler set for each event type once per validator, instead of type-testing every rule against every published event. Validating the GitHub public schema publishes 49,899 events, so the old linear scan performed roughly 898,000 interface type tests per validation.
- Validation events are now `readonly record struct`, so publishing an event no longer allocates. This requires `IValidationEventHandler<TEvent>` to drop its `in` variance, which value types cannot satisfy. Both changes are breaking for anyone implementing custom rules outside this repository.
- `ValidNameRule` compares the `__` prefix ordinally rather than culture-sensitively, and `ValidImplementationsRule` builds its log-entry lists only when it has something to report and resolves implemented arguments by name instead of building a dictionary per field.
- Against the GitHub public schema (1,813 types), validation goes from 4,013 μs and 2,109 KB to 1,347 μs and 520 KB, which is below the schema-build validator's 736 KB.

## Test plan

- `dotnet test src/HotChocolate/Core/test/Types.Validation.Tests` — 129 passing
- `dotnet test src/HotChocolate/Fusion/test/Fusion.Composition.Tests` — 712 passing, exercising the mutable-schema consumer
- BenchmarkDotNet comparison against the GitHub public schema, with per-rule and rule-count ablation runs to attribute each change
