### PR TITLE
Deflake prepared operation cache eviction test

### DIFF
--- a/src/HotChocolate/Core/test/Execution.Tests/PreparedOperationCacheTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/PreparedOperationCacheTests.cs
@@ -30,8 +30,8 @@ public class PreparedOperationCacheTests
     public async Task Operation_Cache_Should_Be_Scoped_To_Executor()
     {
         // arrange
-        var executorEvictedResetEvent = new ManualResetEventSlim(false);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var executorEvicted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         var manager = new ServiceCollection()
             .AddGraphQL()
@@ -43,19 +43,19 @@ public class PreparedOperationCacheTests
         {
             if (@event.Type == RequestExecutorEventType.Evicted)
             {
-                executorEvictedResetEvent.Set();
+                executorEvicted.TrySetResult();
             }
         }));
 
         // act
-        var firstExecutor = await manager.GetExecutorAsync(cancellationToken: cts.Token);
+        var firstExecutor = await manager.GetExecutorAsync(cancellationToken: cancellationToken);
         var firstOperationCache = firstExecutor.Schema.Services
             .GetRequiredService<IPreparedOperationCache>();
 
         manager.EvictExecutor();
-        executorEvictedResetEvent.Wait(cts.Token);
+        await executorEvicted.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
 
-        var secondExecutor = await manager.GetExecutorAsync(cancellationToken: cts.Token);
+        var secondExecutor = await manager.GetExecutorAsync(cancellationToken: cancellationToken);
         var secondOperationCache = secondExecutor.Schema.Services
             .GetRequiredService<IPreparedOperationCache>();
 


### PR DESCRIPTION
## Summary

- `Operation_Cache_Should_Be_Scoped_To_Executor` waited for the `Evicted` event by blocking the test thread on `ManualResetEventSlim.Wait` under a 5-second `CancellationTokenSource`. Eviction is asynchronous (a channel write that triggers a full schema rebuild and warmup), so on a loaded CI runner the wait exceeded its budget and the test failed with `OperationCanceledException`.
- The test now awaits a `TaskCompletionSource` (`RunContinuationsAsynchronously`), keeps no thread blocked while the rebuild runs, and takes its token from `TestContext.Current.CancellationToken`, matching the sibling test. A 30-second `WaitAsync` cap remains so a genuinely lost event surfaces as a timeout instead of a hang.

## Test plan

- `dotnet test src/HotChocolate/Core/test/Execution.Tests --filter-class '*PreparedOperationCacheTests*'`: 8/8 pass across net8.0, net9.0, net10.0, and net11.0.
