### PR TITLE
Download deprecated directive definitions and arguments

### DIFF
--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/CapabilityInspector.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/CapabilityInspector.cs
@@ -118,6 +118,9 @@ internal sealed class CapabilityInspector
                         },
                         {
                             "name": "isRepeatable"      # <--- and we are looking for this!
+                        },
+                        {
+                            "name": "isDeprecated"      # <--- and for this!
                         }
                     ]
                 }
@@ -145,6 +148,7 @@ internal sealed class CapabilityInspector
         {
             var locations = false;
             var isRepeatable = false;
+            var isDeprecated = false;
 
             foreach (var field in fields.EnumerateArray())
             {
@@ -168,7 +172,13 @@ internal sealed class CapabilityInspector
                     _features.HasRepeatableDirectives = true;
                 }
 
-                if (locations && isRepeatable)
+                if (fieldNameString.EqualsOrdinal("isDeprecated"))
+                {
+                    isDeprecated = true;
+                    _features.HasDirectiveDeprecation = true;
+                }
+
+                if (locations && isRepeatable && isDeprecated)
                 {
                     return;
                 }

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionFormatter.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionFormatter.cs
@@ -267,7 +267,9 @@ internal static class IntrospectionFormatter
             CreateDescription(directive.Description),
             directive.IsRepeatable ?? false,
             CreateInputValues(directive.Args),
-            [],
+            CreateDeprecatedDirective(
+                directive.IsDeprecated,
+                directive.DeprecationReason),
             locations
         );
     }

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryBuilder.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryBuilder.cs
@@ -57,10 +57,7 @@ internal static class IntrospectionQueryBuilder
 
         selections.Add(CreateTypesField());
 
-        selections.Add(
-            CreateDirectivesField(
-                features.HasDirectiveLocations,
-                features.HasRepeatableDirectives));
+        selections.Add(CreateDirectivesField(features));
 
         return new DocumentNode(
             new IDefinitionNode[]
@@ -103,28 +100,16 @@ internal static class IntrospectionQueryBuilder
                         Array.Empty<DirectiveNode>())
                 }));
 
-    private static FieldNode CreateDirectivesField(bool hasLocationsField, bool hasRepeatableDirective)
+    private static FieldNode CreateDirectivesField(ServerCapabilities features)
     {
         var selections = new List<ISelectionNode>
         {
             new FieldNode("name"),
             new FieldNode("description"),
-            new FieldNode(
-                new NameNode("args"),
-                null,
-                Array.Empty<DirectiveNode>(),
-                Array.Empty<ArgumentNode>(),
-                new SelectionSetNode(
-                    new ISelectionNode[]
-                    {
-                        new FragmentSpreadNode(
-                            null,
-                            new NameNode("InputValue"),
-                            Array.Empty<DirectiveNode>())
-                    }))
+            CreateArgsField(features.HasArgumentDeprecation)
         };
 
-        if (hasLocationsField)
+        if (features.HasDirectiveLocations)
         {
             selections.Add(new FieldNode("locations"));
         }
@@ -135,16 +120,24 @@ internal static class IntrospectionQueryBuilder
             selections.Add(new FieldNode("onField"));
         }
 
-        if (hasRepeatableDirective)
+        if (features.HasRepeatableDirectives)
         {
             selections.Add(new FieldNode("isRepeatable"));
+        }
+
+        if (features.HasDirectiveDeprecation)
+        {
+            selections.Add(new FieldNode("isDeprecated"));
+            selections.Add(new FieldNode("deprecationReason"));
         }
 
         return new FieldNode(
             new NameNode("directives"),
             null,
             Array.Empty<DirectiveNode>(),
-            Array.Empty<ArgumentNode>(),
+            features.HasDirectiveDeprecation
+                ? [new ArgumentNode("includeDeprecated", true)]
+                : Array.Empty<ArgumentNode>(),
             new SelectionSetNode(selections));
     }
 

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/Models/Directive.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/Models/Directive.cs
@@ -9,6 +9,8 @@ internal class Directive
     public ICollection<InputField> Args { get; set; }
     public ICollection<string> Locations { get; set; }
     public bool? IsRepeatable { get; set; }
+    public bool IsDeprecated { get; set; }
+    public string DeprecationReason { get; set; }
     public bool OnOperation { get; set; }
     public bool OnFragment { get; set; }
     public bool OnField { get; set; }

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/ServerCapabilities.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/ServerCapabilities.cs
@@ -37,6 +37,11 @@ public class ServerCapabilities
     public bool HasArgumentDeprecation { get; internal set; }
 
     /// <summary>
+    /// Gets a value that defines if the GraphQL server supports directive definition deprecation.
+    /// </summary>
+    public bool HasDirectiveDeprecation { get; internal set; }
+
+    /// <summary>
     /// Gets a value that defines if the GraphQL server supports schema descriptions.
     /// </summary>
     public bool HasSchemaDescription { get; internal set; }

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionClientTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionClientTests.cs
@@ -146,7 +146,7 @@ public class IntrospectionClientTests(TestServerFactory serverFactory) : ServerT
         Assert.Equal("Something went wrong", exception.Message);
     }
 
-    public class ObsoleteDirectiveType : DirectiveType
+    private sealed class ObsoleteDirectiveType : DirectiveType
     {
         protected override void Configure(IDirectiveTypeDescriptor descriptor)
         {

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionClientTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionClientTests.cs
@@ -1,5 +1,9 @@
 using System.Net;
 using HotChocolate.AspNetCore.Tests.Utilities;
+using HotChocolate.Language;
+using HotChocolate.Language.Utilities;
+using HotChocolate.Types;
+using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable AccessToDisposedClosure
 
@@ -19,13 +23,19 @@ public class IntrospectionClientTests(TestServerFactory serverFactory) : ServerT
         var features = await IntrospectionClient.InspectServerAsync(client, TestContext.Current.CancellationToken);
 
         // assert
-        Assert.True(features.HasArgumentDeprecation);
-        Assert.True(features.HasDirectiveLocations);
-        Assert.True(features.HasSubscriptionSupport);
-        Assert.True(features.HasSchemaDescription);
-        Assert.True(features.HasRepeatableDirectives);
-        Assert.True(features.HasDeferSupport);
-        Assert.True(features.HasStreamSupport);
+        features.MatchInlineSnapshot(
+            """
+            {
+              "HasDirectiveLocations": true,
+              "HasRepeatableDirectives": true,
+              "HasSubscriptionSupport": true,
+              "HasDeferSupport": true,
+              "HasStreamSupport": true,
+              "HasArgumentDeprecation": true,
+              "HasDirectiveDeprecation": true,
+              "HasSchemaDescription": true
+            }
+            """);
     }
 
     [Fact]
@@ -52,6 +62,32 @@ public class IntrospectionClientTests(TestServerFactory serverFactory) : ServerT
 
         // assert
         schema.ToString(true).MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task IntrospectServer_With_DeprecatedDirective()
+    {
+        // arrange
+        var server = CreateStarWarsServer(
+            configureServices: services => services
+                .AddGraphQL()
+                .AddDirectiveType<ObsoleteDirectiveType>());
+        var client = server.CreateClient();
+        client.BaseAddress = new Uri("http://localhost:5000/graphql");
+
+        // act
+        var schema = await IntrospectionClient.IntrospectServerAsync(client, TestContext.Current.CancellationToken);
+
+        // assert
+        var directive = Assert.Single(
+            schema.Definitions.OfType<DirectiveDefinitionNode>(),
+            t => t.Name.Value.Equals("obsolete", StringComparison.Ordinal));
+        directive.Print(indented: true).MatchInlineSnapshot(
+            """
+            directive @obsolete(
+              obsoleteArg: String @deprecated(reason: "Argument no longer supported.")
+            ) @deprecated(reason: "Directive no longer supported.") on FIELD
+            """);
     }
 
     [Fact]
@@ -108,6 +144,22 @@ public class IntrospectionClientTests(TestServerFactory serverFactory) : ServerT
         // assert
         var exception = await Assert.ThrowsAsync<Exception>(Error);
         Assert.Equal("Something went wrong", exception.Message);
+    }
+
+    public class ObsoleteDirectiveType : DirectiveType
+    {
+        protected override void Configure(IDirectiveTypeDescriptor descriptor)
+        {
+            descriptor
+                .Name("obsolete")
+                .Location(Types.DirectiveLocation.Field)
+                .Deprecated("Directive no longer supported.");
+
+            descriptor
+                .Argument("obsoleteArg")
+                .Type<StringType>()
+                .Deprecated("Argument no longer supported.");
+        }
     }
 
     private class CustomHttpClientHandler(HttpStatusCode? httpStatusCode = null) : HttpClientHandler

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionFormatterTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionFormatterTests.cs
@@ -34,6 +34,36 @@ public class IntrospectionFormatterTests
     }
 
     [Fact]
+    public void DeserializeIntrospectionWithDeprecatedDirectives()
+    {
+        // arrange
+        var json = FileResource.Open("IntrospectionWithDeprecatedDirectives.json");
+        var result = JsonSerializer.Deserialize<IntrospectionResult>(json, SerializerOptions);
+
+        // act
+        var schema = IntrospectionFormatter.Format(result!);
+
+        // assert
+        schema.ToString(true).MatchInlineSnapshot(
+            """
+            schema {
+              query: Query
+            }
+
+            type Query {
+              field: String
+            }
+
+            "Built-in String"
+            scalar String
+
+            directive @obsolete(
+              obsoleteArg: String @deprecated(reason: "Argument no longer supported.")
+            ) @deprecated(reason: "Directive no longer supported.") on FIELD
+            """);
+    }
+
+    [Fact]
     public void DeserializeIntrospectionWithNullDeprecationReason()
     {
         // arrange

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionQueryBuilderTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionQueryBuilderTests.cs
@@ -36,6 +36,23 @@ public class IntrospectionQueryBuilderTests
     }
 
     [Fact]
+    public void Create_Query_With_DirectiveDeprecation()
+    {
+        // arrange
+        var options = new IntrospectionOptions();
+        var features = new ServerCapabilities
+        {
+            HasDirectiveDeprecation = true
+        };
+
+        // act
+        var document = IntrospectionQueryBuilder.Build(features, options);
+
+        //assert
+        document.Print().MatchSnapshot();
+    }
+
+    [Fact]
     public void Create_Query_With_DirectiveLocations()
     {
         // arrange

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__resources__/IntrospectionWithDeprecatedDirectives.json
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__resources__/IntrospectionWithDeprecatedDirectives.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [{
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [{
+              "name": "field",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "Built-in String",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": [{
+          "name": "obsolete",
+          "description": null,
+          "locations": ["FIELD"],
+          "args": [{
+              "name": "obsoleteArg",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": true,
+              "deprecationReason": "Argument no longer supported."
+            }
+          ],
+          "isRepeatable": false,
+          "isDeprecated": true,
+          "deprecationReason": "Directive no longer supported."
+        }
+      ]
+    }
+  }
+}

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__snapshots__/IntrospectionQueryBuilderTests.Create_Query_With_DirectiveDeprecation.snap
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__snapshots__/IntrospectionQueryBuilderTests.Create_Query_With_DirectiveDeprecation.snap
@@ -9,17 +9,17 @@ query IntrospectionQuery {
     types {
       ...FullType
     }
-    directives {
+    directives(includeDeprecated: true) {
       name
       description
-      args(includeDeprecated: true) {
+      args {
         ...InputValue
-        isDeprecated
-        deprecationReason
       }
       onOperation
       onFragment
       onField
+      isDeprecated
+      deprecationReason
     }
   }
 }
@@ -31,10 +31,8 @@ fragment FullType on __Type {
   fields(includeDeprecated: true) {
     name
     description
-    args(includeDeprecated: true) {
+    args {
       ...InputValue
-      isDeprecated
-      deprecationReason
     }
     type {
       ...TypeRef
@@ -42,10 +40,8 @@ fragment FullType on __Type {
     isDeprecated
     deprecationReason
   }
-  inputFields(includeDeprecated: true) {
+  inputFields {
     ...InputValue
-    isDeprecated
-    deprecationReason
   }
   interfaces {
     ...TypeRef


### PR DESCRIPTION
## Summary

- `IntrospectionClient` / `dotnet-graphql` silently dropped deprecated directive definitions and deprecated directive arguments from downloaded schemas: the server filters both out unless `includeDeprecated: true` is passed, and the client never passed it or selected `isDeprecated` / `deprecationReason` for directives. `@deprecated` was also never emitted on a directive definition.
- A new `ServerCapabilities.HasDirectiveDeprecation` flag, detected from `__Directive.isDeprecated` in the existing directive-type probe, gates `directives(includeDeprecated: true)` plus the deprecation selections, so servers without the field are queried exactly as before. Directive arguments ride on the existing `HasArgumentDeprecation`, matching how `__Type.inputFields` is already handled.
- `IntrospectionFormatter` now emits `@deprecated` on directive definitions, and the `Directive` model carries the deprecation state.

## Test plan

- Formatter test over a new introspection fixture with a deprecated directive definition and a deprecated directive argument, snapshotting the produced SDL.
- Round-trip against a Hot Chocolate server whose schema contains a deprecated directive with a deprecated argument; both `@deprecated` applications survive the download.
- Query-builder snapshot for the new capability, plus the default-capability snapshot proving no `includeDeprecated` and no `isDeprecated` are sent when the probe reports the field is absent.
