### PR TITLE
Remove inverted nullable-state annotation on `IDeprecationProvider`

### DIFF
--- a/src/HotChocolate/Core/src/Types.Abstractions/Types/Provider/IDeprecationProvider.cs
+++ b/src/HotChocolate/Core/src/Types.Abstractions/Types/Provider/IDeprecationProvider.cs
@@ -1,6 +1,3 @@
-
-using System.Diagnostics.CodeAnalysis;
-
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 // ReSharper disable once CheckNamespace
 namespace HotChocolate.Types;
@@ -14,11 +11,11 @@ public interface IDeprecationProvider : ITypeSystemMember
     /// <summary>
     /// Defines if this <see cref="ITypeSystemMember"/> is deprecated.
     /// </summary>
-    [MemberNotNullWhen(false, nameof(DeprecationReason))]
     bool IsDeprecated { get; }
 
     /// <summary>
-    /// Gets the deprecation reason of this <see cref="ITypeSystemMember"/>.
+    /// Gets the deprecation reason of this <see cref="ITypeSystemMember"/>,
+    /// or <c>null</c> if no reason was provided.
     /// </summary>
     string? DeprecationReason { get; }
 }


### PR DESCRIPTION
## Summary

- `IDeprecationProvider.IsDeprecated` was annotated `[MemberNotNullWhen(false, nameof(DeprecationReason))]`, telling the compiler that `DeprecationReason` is non-null when a member is **not** deprecated. That suppressed nullable diagnostics in precisely the branch where the value is always null, so dereferencing `DeprecationReason` inside an `if (!IsDeprecated)` branch compiled clean and could throw at runtime.
- The annotation is removed rather than inverted. `IsDeprecated` and `DeprecationReason` are independently settable on the Mutable definitions and independently supplied to the Fusion definition constructors, so a member that is deprecated without a reason is a state the API supports. Asserting the opposite would be a promise the type system does not keep, and one the compiler never verifies for interface members.
- Annotation-only: no runtime behavior change, and callers that already null-check are unaffected.

## Test plan

- `dotnet build src/All.slnx` is clean across Core, Mutable, and Fusion.
- The repo escalates nullable diagnostics to errors via `WarningsAsErrors=nullable`, so any site that depended on the removed annotation would surface as a `CS8602` build error. None did, confirming no reads of `DeprecationReason` were relying on the false non-null guarantee.
- No test accompanies the change: it affects compile-time nullable flow analysis only, and there is no runtime behavior that differs before and after for a test to assert.
