### PR TITLE
Add missing net8.0/net9.0 snapshot for named-field parent requirement

### DIFF
--- a/src/HotChocolate/Data/test/Data.Tests/__snapshots__/ProjectableDataLoaderTests.Brand_Details_Requires_Brand_Name_With_Named_Field_NET8_0_NET9_0.md
+++ b/src/HotChocolate/Data/test/Data.Tests/__snapshots__/ProjectableDataLoaderTests.Brand_Details_Requires_Brand_Name_With_Named_Field_NET8_0_NET9_0.md
@@ -1,0 +1,22 @@
+# Brand_Details_Requires_Brand_Name_With_Named_Field
+
+## SQL
+
+```text
+-- @__keys_0={ '1' } (DbType = Object)
+SELECT b."Name", b."Id"
+FROM "Brands" AS b
+WHERE b."Id" = ANY (@__keys_0)
+```
+
+## Result
+
+```json
+{
+  "data": {
+    "brandById": {
+      "computedName": "Brand Name:Brand0"
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary

- `ProjectableDataLoaderTests.Brand_Details_Requires_Brand_Name_With_Named_Field` snapshots via `Snapshot.Create(Postfix([NET8_0, NET9_0]))`, so net8.0 and net9.0 resolve a `_NET8_0_NET9_0` file while net10.0 and net11.0 use the postfix-less one. Only the postfix-less file was committed, so the net8.0/net9.0 variant never existed.
- Adds it. CI builds with `--framework net11.0`, so this path was only reachable from a local multi-framework run — and there CookieCrumble creates a missing snapshot rather than failing, which is why it went unnoticed.

## Test plan

- `ProjectableDataLoaderTests` passes on net8.0 and net9.0 (23 passed, 1 skipped on each) against a PostgreSQL container, with the working tree clean afterwards — the committed snapshot is compared against, not regenerated.
