### PR TITLE
Disable fail-fast for the action repository update matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -742,6 +742,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [compute-release-context, publish-release]
     strategy:
+      fail-fast: false
       matrix:
         repo:
           - nitro-client-publish


### PR DESCRIPTION
## Summary

- The `🔄 Update GitHub Actions` job fans out over 16 `nitro-*` action repositories, dispatching each repository's `release.yaml` and watching it to completion. The matrix declared no `fail-fast`, so it ran with the default `true`: one failing leg cancelled every sibling still in flight, leaving those repositories un-bumped for a reason unrelated to them. [Release v16.6.0-p.9](https://github.com/ChilliCream/graphql-platform/actions/runs/30630235219) lost five updates that way, to a transient GitHub API connect timeout in a sixth.
- `fail-fast: false` lets each repository's update stand or fall on its own, so a follow-up re-dispatch is scoped to the legs that actually failed.

## Test plan

- Parsed the workflow and confirmed the `update-github-actions` strategy resolves to `fail-fast: false` across all 16 matrix entries.
- Runtime behavior is only observable on the next release run; the Nitro CLI build matrix at the top of the file is unchanged.
