### PR TITLE
Clear known NuGet vulnerabilities in OpenAPI and Mediator

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.OpenApi.AspNetCore/HotChocolate.Adapters.OpenApi.AspNetCore.csproj
+++ b/src/HotChocolate/Adapters/src/Adapters.OpenApi.AspNetCore/HotChocolate.Adapters.OpenApi.AspNetCore.csproj
@@ -15,6 +15,11 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <!-- Dependency of Microsoft.AspNetCore.OpenApi. Pinned to secure version. -->
+    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.7.5" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Core\src\Types.Abstractions\HotChocolate.Types.Abstractions.csproj" />
     <ProjectReference Include="..\Adapters.OpenApi.Core\HotChocolate.Adapters.OpenApi.Core.csproj" />

--- a/src/Mocha/benchmarks/Mocha.Mediator.Benchmarks/Mocha.Mediator.Benchmarks.csproj
+++ b/src/Mocha/benchmarks/Mocha.Mediator.Benchmarks/Mocha.Mediator.Benchmarks.csproj
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="MediatR" VersionOverride="12.4.1" />
-    <PackageReference Include="Mediator.Abstractions" VersionOverride="3.0.1" />
-    <PackageReference Include="Mediator.SourceGenerator" VersionOverride="3.0.1" />
+    <PackageReference Include="Mediator.Abstractions" VersionOverride="3.0.2" />
+    <PackageReference Include="Mediator.SourceGenerator" VersionOverride="3.0.2" />
     <PackageReference Include="MassTransit" VersionOverride="8.5.8" />
     <PackageReference Include="Immediate.Handlers" VersionOverride="3.3.0" />
     <PackageReference Include="Mediator.Switch" VersionOverride="3.1.0" />


### PR DESCRIPTION
## Summary

- `Microsoft.OpenApi` 2.0.0 resolved transitively on net10.0 through `Microsoft.AspNetCore.OpenApi` 10.0.0, carrying [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (high, stack overflow on circular schema references). No `Microsoft.AspNetCore.OpenApi` 10.0.x raises its `Microsoft.OpenApi [2.0.0, )` floor, so a parent bump cannot clear it. Pinned to 2.7.5 with a net10.0-conditional `VersionOverride` in `HotChocolate.Adapters.OpenApi.AspNetCore`; that single pin lifts all six affected projects through the project-reference graph. The condition and the `VersionOverride` are both load-bearing: net9.0 resolves the unaffected 1.6.x line, net11.0 already resolves a patched 3.x, and the CPM scope declares `Microsoft.OpenApi` 1.6.14, which a bare reference would downgrade to.
- `Scriban` 6.2.0 reached `Mocha.Mediator.Benchmarks` through `Mediator.SourceGenerator` 3.0.1, carrying 14 advisories (1 critical, 9 high, 4 moderate). `Mediator` 3.0.2 declares no package dependencies at all, so bumping the coupled `Mediator.Abstractions` / `Mediator.SourceGenerator` pair removes `Scriban` from the graph.

`HotChocolate.Adapters.OpenApi.AspNetCore`'s published nuspec gains a direct `Microsoft.OpenApi >= 2.7.5` on its net10.0 dependency group. That is the intended mechanism for stopping consumers resolving the vulnerable version, but it is a change to what the package declares.

One caveat worth recording: `Mediator.SourceGenerator` 3.0.2 does not upgrade `Scriban` as a package, it ILMerges `Scriban` 7.0.0 into the analyzer assembly. That clears 11 of the 14 advisories including the critical one, but four survive as embedded code that `dotnet list package --vulnerable` can no longer see. All four are build-time only, in a benchmark project that never packs, driven by templates embedded in the generator.

## Test plan

- `dotnet restore src/All.slnx --force-evaluate` — clean across all 304 projects, no `NU1903`, `NU1605`, or `NU1608`
- `dotnet list src/All.slnx package --vulnerable --include-transitive` — zero vulnerable packages; the 36 projects outside `All.slnx` audited individually and also clean
- `dotnet build src/HotChocolate/Adapters/Adapters.slnx` — green
- `dotnet test HotChocolate.Adapters.OpenApi.Tests --framework net10.0` — 231 passed, 2 skipped, 0 failed
- `Mediator.SourceGenerator` 3.0.2 still emits its generated sources, confirming codegen works on the merged `Scriban`

`Mocha.Mediator.Benchmarks` does not compile, before or after this change — 22 pre-existing `RCS1163` errors in its own source, identical at 3.0.1 and 3.0.2. It is absent from every `.slnx`, so CI never builds it. Not addressed here.
