### PR TITLE
Fix the argument name in the `@deprecated` directive node

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Directives/DeprecatedDirective.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/DeprecatedDirective.cs
@@ -69,7 +69,7 @@ public sealed class DeprecatedDirective
 
         var arguments = reason is null
             ? Array.Empty<ArgumentNode>()
-            : [new ArgumentNode(DirectiveNames.Deprecated.Arguments.DefaultReason, reason)];
+            : [new ArgumentNode(DirectiveNames.Deprecated.Arguments.Reason, reason)];
 
         return new DirectiveNode(
             null,

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/DeprecatedDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/DeprecatedDirectiveTests.cs
@@ -1,0 +1,24 @@
+namespace HotChocolate.Types.Directives;
+
+public class DeprecatedDirectiveTests
+{
+    [Fact]
+    public void CreateNode_Should_NameTheReasonArgument_When_ReasonIsNotTheDefault()
+    {
+        // act
+        var node = DeprecatedDirective.CreateNode("Use `bar` instead.");
+
+        // assert
+        node.ToString().MatchInlineSnapshot("""@deprecated(reason: "Use `bar` instead.")""");
+    }
+
+    [Fact]
+    public void CreateNode_Should_OmitTheReasonArgument_When_ReasonIsTheDefault()
+    {
+        // act
+        var node = DeprecatedDirective.CreateNode("No longer supported.");
+
+        // assert
+        node.ToString().MatchInlineSnapshot("@deprecated");
+    }
+}


### PR DESCRIPTION
## Summary

- `DeprecatedDirective.CreateNode` passed the default-reason constant where the argument *name* belongs, so a custom reason rendered as `@deprecated("No longer supported.": "...")` rather than `@deprecated(reason: "...")`.
- The path is reached only through `DeprecatedDirective.ToString()`, so the effect was confined to diagnostic output. The schema printers construct the directive separately and were unaffected.

## Test plan

- `DeprecatedDirectiveTests` pins both branches of `CreateNode`: the named `reason` argument for a custom reason, and a bare `@deprecated` when the reason equals the default.
- Verified the first test fails against the previous code with the wrong argument name, and passes after the change (2/2 green).
- Searched the repository for the old rendering to confirm no snapshot depended on it.
